### PR TITLE
Add curl examples for testing APIs

### DIFF
--- a/src/main/java/com/openisle/controller/AdminController.java
+++ b/src/main/java/com/openisle/controller/AdminController.java
@@ -4,6 +4,11 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import java.util.Map;
 
+/*
+curl http://localhost:8080/api/admin/hello \
+    -H "Authorization: Bearer <token>"
+ */
+
 /**
  * Simple admin demo endpoint.
  */

--- a/src/main/java/com/openisle/controller/PostController.java
+++ b/src/main/java/com/openisle/controller/PostController.java
@@ -12,6 +12,19 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
+/*
+curl -X POST http://localhost:8080/api/posts \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer <token>" \
+    -d '{ "title": "First", "content": "Post" }'
+
+curl http://localhost:8080/api/posts \
+    -H "Authorization: Bearer <token>"
+
+curl http://localhost:8080/api/posts/1 \
+    -H "Authorization: Bearer <token>"
+ */
+
 @RestController
 @RequestMapping("/api/posts")
 @RequiredArgsConstructor


### PR DESCRIPTION
## Summary
- document curl commands above AdminController and PostController for easier API testing

## Testing
- `java -version`
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68626f438ae8832b99d197f8619745d8