### PR TITLE
Add reaction module

### DIFF
--- a/src/main/java/com/openisle/controller/ReactionController.java
+++ b/src/main/java/com/openisle/controller/ReactionController.java
@@ -1,0 +1,61 @@
+package com.openisle.controller;
+
+import com.openisle.model.Reaction;
+import com.openisle.model.ReactionType;
+import com.openisle.service.ReactionService;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class ReactionController {
+    private final ReactionService reactionService;
+
+    @PostMapping("/posts/{postId}/reactions")
+    public ResponseEntity<ReactionDto> reactToPost(@PathVariable Long postId,
+                                                  @RequestBody ReactionRequest req,
+                                                  Authentication auth) {
+        Reaction reaction = reactionService.reactToPost(auth.getName(), postId, req.getType());
+        return ResponseEntity.ok(toDto(reaction));
+    }
+
+    @PostMapping("/comments/{commentId}/reactions")
+    public ResponseEntity<ReactionDto> reactToComment(@PathVariable Long commentId,
+                                                     @RequestBody ReactionRequest req,
+                                                     Authentication auth) {
+        Reaction reaction = reactionService.reactToComment(auth.getName(), commentId, req.getType());
+        return ResponseEntity.ok(toDto(reaction));
+    }
+
+    private ReactionDto toDto(Reaction reaction) {
+        ReactionDto dto = new ReactionDto();
+        dto.setId(reaction.getId());
+        dto.setType(reaction.getType());
+        dto.setUser(reaction.getUser().getUsername());
+        if (reaction.getPost() != null) {
+            dto.setPostId(reaction.getPost().getId());
+        }
+        if (reaction.getComment() != null) {
+            dto.setCommentId(reaction.getComment().getId());
+        }
+        return dto;
+    }
+
+    @Data
+    private static class ReactionRequest {
+        private ReactionType type;
+    }
+
+    @Data
+    private static class ReactionDto {
+        private Long id;
+        private ReactionType type;
+        private String user;
+        private Long postId;
+        private Long commentId;
+    }
+}

--- a/src/main/java/com/openisle/model/Reaction.java
+++ b/src/main/java/com/openisle/model/Reaction.java
@@ -1,0 +1,40 @@
+package com.openisle.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Reaction entity representing a user's reaction to a post or comment.
+ */
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@Table(name = "reactions",
+       uniqueConstraints = {
+           @UniqueConstraint(columnNames = {"user_id", "post_id"}),
+           @UniqueConstraint(columnNames = {"user_id", "comment_id"})
+       })
+public class Reaction {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ReactionType type;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
+}

--- a/src/main/java/com/openisle/model/ReactionType.java
+++ b/src/main/java/com/openisle/model/ReactionType.java
@@ -1,0 +1,11 @@
+package com.openisle.model;
+
+/**
+ * Enum of possible reaction types for posts and comments.
+ */
+public enum ReactionType {
+    LIKE,
+    DISLIKE,
+    RECOMMEND,
+    ANGRY
+}

--- a/src/main/java/com/openisle/repository/ReactionRepository.java
+++ b/src/main/java/com/openisle/repository/ReactionRepository.java
@@ -1,0 +1,14 @@
+package com.openisle.repository;
+
+import com.openisle.model.Comment;
+import com.openisle.model.Post;
+import com.openisle.model.Reaction;
+import com.openisle.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ReactionRepository extends JpaRepository<Reaction, Long> {
+    Optional<Reaction> findByUserAndPost(User user, Post post);
+    Optional<Reaction> findByUserAndComment(User user, Comment comment);
+}

--- a/src/main/java/com/openisle/service/ReactionService.java
+++ b/src/main/java/com/openisle/service/ReactionService.java
@@ -1,0 +1,49 @@
+package com.openisle.service;
+
+import com.openisle.model.Comment;
+import com.openisle.model.Post;
+import com.openisle.model.Reaction;
+import com.openisle.model.ReactionType;
+import com.openisle.model.User;
+import com.openisle.repository.CommentRepository;
+import com.openisle.repository.PostRepository;
+import com.openisle.repository.ReactionRepository;
+import com.openisle.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReactionService {
+    private final ReactionRepository reactionRepository;
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
+
+    public Reaction reactToPost(String username, Long postId, ReactionType type) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("Post not found"));
+        Reaction reaction = reactionRepository.findByUserAndPost(user, post)
+                .orElseGet(Reaction::new);
+        reaction.setUser(user);
+        reaction.setPost(post);
+        reaction.setType(type);
+        return reactionRepository.save(reaction);
+    }
+
+    public Reaction reactToComment(String username, Long commentId, ReactionType type) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("Comment not found"));
+        Reaction reaction = reactionRepository.findByUserAndComment(user, comment)
+                .orElseGet(Reaction::new);
+        reaction.setUser(user);
+        reaction.setComment(comment);
+        reaction.setPost(null);
+        reaction.setType(type);
+        return reactionRepository.save(reaction);
+    }
+}


### PR DESCRIPTION
## Summary
- add `Reaction` entity and `ReactionType` enum
- create repository, service and controller for reactions
- allow users to react (like/dislike/recommend/angry) on posts and comments

## Testing
- `apt-get update`
- `apt-get install -y maven`
- `mvn -q -DskipTests=false test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6862798c122c832bb14bf3737ef7e800