### PR TITLE
Add auth failure cases for hello and admin controllers

### DIFF
--- a/src/test/java/com/openisle/controller/AdminControllerTest.java
+++ b/src/test/java/com/openisle/controller/AdminControllerTest.java
@@ -4,22 +4,79 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import com.openisle.config.SecurityConfig;
+import com.openisle.service.JwtService;
+import com.openisle.repository.UserRepository;
+import com.openisle.model.Role;
+import com.openisle.model.User;
+import java.util.Optional;
+import org.mockito.Mockito;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(AdminController.class)
-@AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureMockMvc
+@Import(SecurityConfig.class)
 class AdminControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
+    @MockBean
+    private JwtService jwtService;
+    @MockBean
+    private UserRepository userRepository;
+    @MockBean
+    private AccessDeniedHandler customAccessDeniedHandler;
+
     @Test
     void adminHelloReturnsMessage() throws Exception {
-        mockMvc.perform(get("/api/admin/hello"))
+        Mockito.when(jwtService.validateAndGetSubject("adminToken")).thenReturn("admin");
+        User admin = new User();
+        admin.setUsername("admin");
+        admin.setPassword("p");
+        admin.setEmail("a@b.com");
+        admin.setRole(Role.ADMIN);
+        Mockito.when(userRepository.findByUsername("admin")).thenReturn(Optional.of(admin));
+
+        mockMvc.perform(get("/api/admin/hello").header("Authorization", "Bearer adminToken"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value("Hello, Admin User"));
+    }
+
+    @Test
+    void adminHelloMissingToken() throws Exception {
+        mockMvc.perform(get("/api/admin/hello"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error").value("Missing token"));
+    }
+
+    @Test
+    void adminHelloInvalidToken() throws Exception {
+        Mockito.when(jwtService.validateAndGetSubject("bad")).thenThrow(new RuntimeException());
+
+        mockMvc.perform(get("/api/admin/hello").header("Authorization", "Bearer bad"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error").value("Invalid or expired token"));
+    }
+
+    @Test
+    void adminHelloNotAdmin() throws Exception {
+        Mockito.when(jwtService.validateAndGetSubject("userToken")).thenReturn("user");
+        User user = new User();
+        user.setUsername("user");
+        user.setPassword("p");
+        user.setEmail("u@example.com");
+        user.setRole(Role.USER);
+        Mockito.when(userRepository.findByUsername("user")).thenReturn(Optional.of(user));
+
+        mockMvc.perform(get("/api/admin/hello").header("Authorization", "Bearer userToken"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error").value("Unauthorized"));
     }
 }

--- a/src/test/java/com/openisle/controller/HelloControllerTest.java
+++ b/src/test/java/com/openisle/controller/HelloControllerTest.java
@@ -4,22 +4,64 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import com.openisle.config.SecurityConfig;
+import com.openisle.service.JwtService;
+import com.openisle.repository.UserRepository;
+import com.openisle.model.Role;
+import com.openisle.model.User;
+import java.util.Optional;
+import org.mockito.Mockito;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(HelloController.class)
-@AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureMockMvc
+@Import(SecurityConfig.class)
 class HelloControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
+    @MockBean
+    private JwtService jwtService;
+    @MockBean
+    private UserRepository userRepository;
+    @MockBean
+    private AccessDeniedHandler customAccessDeniedHandler;
+
     @Test
     void helloReturnsMessage() throws Exception {
-        mockMvc.perform(get("/api/hello"))
+        Mockito.when(jwtService.validateAndGetSubject("token")).thenReturn("user");
+        User user = new User();
+        user.setUsername("user");
+        user.setPassword("p");
+        user.setEmail("u@example.com");
+        user.setRole(Role.USER);
+        Mockito.when(userRepository.findByUsername("user")).thenReturn(Optional.of(user));
+
+        mockMvc.perform(get("/api/hello").header("Authorization", "Bearer token"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value("Hello, Authenticated User"));
+    }
+
+    @Test
+    void helloMissingToken() throws Exception {
+        mockMvc.perform(get("/api/hello"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error").value("Missing token"));
+    }
+
+    @Test
+    void helloInvalidToken() throws Exception {
+        Mockito.when(jwtService.validateAndGetSubject("bad")).thenThrow(new RuntimeException());
+
+        mockMvc.perform(get("/api/hello").header("Authorization", "Bearer bad"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error").value("Invalid or expired token"));
     }
 }


### PR DESCRIPTION
## Summary
- enable security filters for HelloControllerTest and AdminControllerTest
- mock JWT and repository beans to exercise authentication logic
- add tests for missing token, invalid token and non-admin role

## Testing
- `mvn -q test` *(fails: Could not download spring-boot parent pom)*

------
https://chatgpt.com/codex/tasks/task_e_68628420a57c832bb391ddd49f64cce8