### PR TITLE
Add comments and reactions to post detail

### DIFF
--- a/src/main/java/com/openisle/controller/PostController.java
+++ b/src/main/java/com/openisle/controller/PostController.java
@@ -1,7 +1,11 @@
 package com.openisle.controller;
 
+import com.openisle.model.Comment;
 import com.openisle.model.Post;
+import com.openisle.model.Reaction;
+import com.openisle.service.CommentService;
 import com.openisle.service.PostService;
+import com.openisle.service.ReactionService;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -30,6 +34,8 @@ curl http://localhost:8080/api/posts/1 \
 @RequiredArgsConstructor
 public class PostController {
     private final PostService postService;
+    private final CommentService commentService;
+    private final ReactionService reactionService;
 
     @PostMapping
     public ResponseEntity<PostDto> createPost(@RequestBody PostRequest req, Authentication auth) {
@@ -57,6 +63,58 @@ public class PostController {
         dto.setCreatedAt(post.getCreatedAt());
         dto.setAuthor(post.getAuthor().getUsername());
         dto.setViews(post.getViews());
+
+        List<ReactionDto> reactions = reactionService.getReactionsForPost(post.getId())
+                .stream()
+                .map(this::toReactionDto)
+                .collect(Collectors.toList());
+        dto.setReactions(reactions);
+
+        List<CommentDto> comments = commentService.getCommentsForPost(post.getId())
+                .stream()
+                .map(this::toCommentDtoWithReplies)
+                .collect(Collectors.toList());
+        dto.setComments(comments);
+
+        return dto;
+    }
+
+    private CommentDto toCommentDtoWithReplies(Comment comment) {
+        CommentDto dto = toCommentDto(comment);
+        List<CommentDto> replies = commentService.getReplies(comment.getId()).stream()
+                .map(this::toCommentDtoWithReplies)
+                .collect(Collectors.toList());
+        dto.setReplies(replies);
+
+        List<ReactionDto> reactions = reactionService.getReactionsForComment(comment.getId())
+                .stream()
+                .map(this::toReactionDto)
+                .collect(Collectors.toList());
+        dto.setReactions(reactions);
+
+        return dto;
+    }
+
+    private CommentDto toCommentDto(Comment comment) {
+        CommentDto dto = new CommentDto();
+        dto.setId(comment.getId());
+        dto.setContent(comment.getContent());
+        dto.setCreatedAt(comment.getCreatedAt());
+        dto.setAuthor(comment.getAuthor().getUsername());
+        return dto;
+    }
+
+    private ReactionDto toReactionDto(Reaction reaction) {
+        ReactionDto dto = new ReactionDto();
+        dto.setId(reaction.getId());
+        dto.setType(reaction.getType());
+        dto.setUser(reaction.getUser().getUsername());
+        if (reaction.getPost() != null) {
+            dto.setPostId(reaction.getPost().getId());
+        }
+        if (reaction.getComment() != null) {
+            dto.setCommentId(reaction.getComment().getId());
+        }
         return dto;
     }
 
@@ -74,5 +132,26 @@ public class PostController {
         private LocalDateTime createdAt;
         private String author;
         private long views;
+        private List<CommentDto> comments;
+        private List<ReactionDto> reactions;
+    }
+
+    @Data
+    private static class CommentDto {
+        private Long id;
+        private String content;
+        private LocalDateTime createdAt;
+        private String author;
+        private List<CommentDto> replies;
+        private List<ReactionDto> reactions;
+    }
+
+    @Data
+    private static class ReactionDto {
+        private Long id;
+        private com.openisle.model.ReactionType type;
+        private String user;
+        private Long postId;
+        private Long commentId;
     }
 }

--- a/src/main/java/com/openisle/repository/ReactionRepository.java
+++ b/src/main/java/com/openisle/repository/ReactionRepository.java
@@ -6,9 +6,12 @@ import com.openisle.model.Reaction;
 import com.openisle.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ReactionRepository extends JpaRepository<Reaction, Long> {
     Optional<Reaction> findByUserAndPost(User user, Post post);
     Optional<Reaction> findByUserAndComment(User user, Comment comment);
+    List<Reaction> findByPost(Post post);
+    List<Reaction> findByComment(Comment comment);
 }

--- a/src/main/java/com/openisle/service/ReactionService.java
+++ b/src/main/java/com/openisle/service/ReactionService.java
@@ -46,4 +46,16 @@ public class ReactionService {
         reaction.setType(type);
         return reactionRepository.save(reaction);
     }
+
+    public java.util.List<Reaction> getReactionsForPost(Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("Post not found"));
+        return reactionRepository.findByPost(post);
+    }
+
+    public java.util.List<Reaction> getReactionsForComment(Long commentId) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("Comment not found"));
+        return reactionRepository.findByComment(comment);
+    }
 }


### PR DESCRIPTION
## Summary
- expand PostController so a post's detailed info includes reactions and comments
- expose reaction list methods in ReactionService and ReactionRepository

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686284926030832ba4485bb276092a10