### PR TITLE
Fix AccessDeniedHandler usage in MVC tests

### DIFF
--- a/src/test/java/com/openisle/controller/AdminControllerTest.java
+++ b/src/test/java/com/openisle/controller/AdminControllerTest.java
@@ -7,7 +7,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.security.web.access.AccessDeniedHandler;
+import com.openisle.config.CustomAccessDeniedHandler;
 import com.openisle.config.SecurityConfig;
 import com.openisle.service.JwtService;
 import com.openisle.repository.UserRepository;
@@ -22,7 +22,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(AdminController.class)
 @AutoConfigureMockMvc
-@Import(SecurityConfig.class)
+@Import({SecurityConfig.class, CustomAccessDeniedHandler.class})
 class AdminControllerTest {
     @Autowired
     private MockMvc mockMvc;
@@ -31,8 +31,6 @@ class AdminControllerTest {
     private JwtService jwtService;
     @MockBean
     private UserRepository userRepository;
-    @MockBean
-    private AccessDeniedHandler customAccessDeniedHandler;
 
     @Test
     void adminHelloReturnsMessage() throws Exception {

--- a/src/test/java/com/openisle/controller/HelloControllerTest.java
+++ b/src/test/java/com/openisle/controller/HelloControllerTest.java
@@ -7,7 +7,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.security.web.access.AccessDeniedHandler;
+import com.openisle.config.CustomAccessDeniedHandler;
 import com.openisle.config.SecurityConfig;
 import com.openisle.service.JwtService;
 import com.openisle.repository.UserRepository;
@@ -22,7 +22,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(HelloController.class)
 @AutoConfigureMockMvc
-@Import(SecurityConfig.class)
+@Import({SecurityConfig.class, CustomAccessDeniedHandler.class})
 class HelloControllerTest {
     @Autowired
     private MockMvc mockMvc;
@@ -31,8 +31,6 @@ class HelloControllerTest {
     private JwtService jwtService;
     @MockBean
     private UserRepository userRepository;
-    @MockBean
-    private AccessDeniedHandler customAccessDeniedHandler;
 
     @Test
     void helloReturnsMessage() throws Exception {


### PR DESCRIPTION
## Summary
- make AdminControllerTest and HelloControllerTest import the real `CustomAccessDeniedHandler`
- remove mocked AccessDeniedHandler beans

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686286690c7c832b961bdb44f97601a8