### PR TITLE
Add article publish review mode

### DIFF
--- a/src/main/java/com/openisle/controller/AdminPostController.java
+++ b/src/main/java/com/openisle/controller/AdminPostController.java
@@ -1,0 +1,56 @@
+package com.openisle.controller;
+
+import com.openisle.model.Post;
+import com.openisle.service.PostService;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Endpoints for administrators to manage posts.
+ */
+@RestController
+@RequestMapping("/api/admin/posts")
+@RequiredArgsConstructor
+public class AdminPostController {
+    private final PostService postService;
+
+    @GetMapping("/pending")
+    public List<PostDto> pendingPosts() {
+        return postService.listPendingPosts().stream()
+                .map(this::toDto)
+                .collect(Collectors.toList());
+    }
+
+    @PostMapping("/{id}/approve")
+    public PostDto approve(@PathVariable Long id) {
+        return toDto(postService.approvePost(id));
+    }
+
+    private PostDto toDto(Post post) {
+        PostDto dto = new PostDto();
+        dto.setId(post.getId());
+        dto.setTitle(post.getTitle());
+        dto.setContent(post.getContent());
+        dto.setCreatedAt(post.getCreatedAt());
+        dto.setAuthor(post.getAuthor().getUsername());
+        dto.setCategory(post.getCategory().getName());
+        dto.setViews(post.getViews());
+        return dto;
+    }
+
+    @Data
+    private static class PostDto {
+        private Long id;
+        private String title;
+        private String content;
+        private LocalDateTime createdAt;
+        private String author;
+        private String category;
+        private long views;
+    }
+}

--- a/src/main/java/com/openisle/model/Post.java
+++ b/src/main/java/com/openisle/model/Post.java
@@ -5,8 +5,12 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+
 import java.time.LocalDateTime;
 
+/**
+ * Post entity representing an article posted by a user.
+ */
 @Entity
 @Getter
 @Setter
@@ -36,6 +40,10 @@ public class Post {
 
     @Column(nullable = false)
     private long views = 0;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PostStatus status = PostStatus.PUBLISHED;
 
     @PrePersist
     protected void onCreate() {

--- a/src/main/java/com/openisle/model/PostStatus.java
+++ b/src/main/java/com/openisle/model/PostStatus.java
@@ -1,0 +1,9 @@
+package com.openisle.model;
+
+/**
+ * Status of a post during its lifecycle.
+ */
+public enum PostStatus {
+    PUBLISHED,
+    PENDING
+}

--- a/src/main/java/com/openisle/model/PublishMode.java
+++ b/src/main/java/com/openisle/model/PublishMode.java
@@ -1,0 +1,9 @@
+package com.openisle.model;
+
+/**
+ * Application-wide article publish mode.
+ */
+public enum PublishMode {
+    DIRECT,
+    REVIEW
+}

--- a/src/main/java/com/openisle/repository/PostRepository.java
+++ b/src/main/java/com/openisle/repository/PostRepository.java
@@ -1,7 +1,11 @@
 package com.openisle.repository;
 
 import com.openisle.model.Post;
+import com.openisle.model.PostStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PostRepository extends JpaRepository<Post, Long> {
+    List<Post> findByStatus(PostStatus status);
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,3 +16,6 @@ app.upload.max-size=${UPLOAD_MAX_SIZE:5242880}
 
 app.jwt.secret=${JWT_SECRET:ChangeThisSecretKeyForJwt}
 app.jwt.expiration=${JWT_EXPIRATION:86400000}
+
+# Post publish mode: DIRECT or REVIEW
+app.post.publish-mode=${POST_PUBLISH_MODE:DIRECT}

--- a/src/test/java/com/openisle/integration/PublishModeIntegrationTest.java
+++ b/src/test/java/com/openisle/integration/PublishModeIntegrationTest.java
@@ -1,0 +1,86 @@
+package com.openisle.integration;
+
+import com.openisle.model.Role;
+import com.openisle.model.User;
+import com.openisle.repository.UserRepository;
+import com.openisle.service.EmailSender;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.*;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Integration tests for review publish mode. */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = "app.post.publish-mode=REVIEW")
+class PublishModeIntegrationTest {
+
+    @Autowired
+    private TestRestTemplate rest;
+
+    @Autowired
+    private UserRepository users;
+
+    @MockBean
+    private EmailSender emailService;
+
+    private String registerAndLogin(String username, String email) {
+        HttpHeaders h = new HttpHeaders();
+        h.setContentType(MediaType.APPLICATION_JSON);
+        rest.postForEntity("/api/auth/register", new HttpEntity<>(
+                Map.of("username", username, "email", email, "password", "pass"), h), Map.class);
+        User u = users.findByUsername(username).orElseThrow();
+        rest.postForEntity("/api/auth/verify", new HttpEntity<>(
+                Map.of("username", username, "code", u.getVerificationCode()), h), Map.class);
+        ResponseEntity<Map> resp = rest.postForEntity("/api/auth/login", new HttpEntity<>(
+                Map.of("username", username, "password", "pass"), h), Map.class);
+        return (String) resp.getBody().get("token");
+    }
+
+    private String registerAndLoginAsAdmin(String username, String email) {
+        String token = registerAndLogin(username, email);
+        User u = users.findByUsername(username).orElseThrow();
+        u.setRole(Role.ADMIN);
+        users.save(u);
+        return token;
+    }
+
+    private ResponseEntity<Map> postJson(String url, Map<?,?> body, String token) {
+        HttpHeaders h = new HttpHeaders();
+        h.setContentType(MediaType.APPLICATION_JSON);
+        if (token != null) h.setBearerAuth(token);
+        return rest.exchange(url, HttpMethod.POST, new HttpEntity<>(body, h), Map.class);
+    }
+
+    @Test
+    void postRequiresApproval() {
+        String userToken = registerAndLogin("eve", "e@example.com");
+        String adminToken = registerAndLoginAsAdmin("admin", "admin@example.com");
+
+        ResponseEntity<Map> catResp = postJson("/api/categories",
+                Map.of("name", "review"), adminToken);
+        Long catId = ((Number)catResp.getBody().get("id")).longValue();
+
+        ResponseEntity<Map> postResp = postJson("/api/posts",
+                Map.of("title", "Need", "content", "Review", "categoryId", catId), userToken);
+        Long postId = ((Number)postResp.getBody().get("id")).longValue();
+
+        List<?> list = rest.getForObject("/api/posts", List.class);
+        assertTrue(list.isEmpty(), "Post should not be listed before approval");
+
+        List<Map<String, Object>> pending = (List<Map<String, Object>>) rest.getForObject("/api/admin/posts/pending", List.class);
+        assertEquals(1, pending.size());
+        assertEquals(postId.intValue(), ((Number)pending.get(0).get("id")).intValue());
+
+        postJson("/api/admin/posts/" + postId + "/approve", Map.of(), adminToken);
+
+        List<?> listAfter = rest.getForObject("/api/posts", List.class);
+        assertEquals(1, listAfter.size(), "Post should appear after approval");
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -17,3 +17,6 @@ app.upload.max-size=1048576
 
 app.jwt.secret=TestSecret
 app.jwt.expiration=3600000
+
+# Default publish mode for tests
+app.post.publish-mode=DIRECT


### PR DESCRIPTION
## Summary
- support configurable publish mode and post status
- implement admin endpoints to approve posts
- keep default direct publish and add properties for mode
- test publish mode workflow

## Testing
- `mvn -q -DskipTests=false test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68636be3e350832b9e522baa8fcbe13e