### PR TITLE
Fix CosImageUploader test

### DIFF
--- a/src/test/java/com/openisle/service/CosImageUploaderTest.java
+++ b/src/test/java/com/openisle/service/CosImageUploaderTest.java
@@ -16,6 +16,6 @@ class CosImageUploaderTest {
         String url = uploader.upload("data".getBytes(), "img.png").join();
 
         verify(client).putObject(any(PutObjectRequest.class));
-        assertEquals("http://cos.example.com/img.png", url);
+        assertTrue(url.matches("http://cos.example.com/[a-f0-9]{32}\\.png"));
     }
 }


### PR DESCRIPTION
## Summary
- update CosImageUploaderTest to accept random filenames

## Testing
- `mvn test` *(fails: Non-resolvable parent POM due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_68636ea63230832b9dfb384598b479b3