### PR TITLE
Fix admin post integration test auth

### DIFF
--- a/src/test/java/com/openisle/integration/PublishModeIntegrationTest.java
+++ b/src/test/java/com/openisle/integration/PublishModeIntegrationTest.java
@@ -58,6 +58,12 @@ class PublishModeIntegrationTest {
         return rest.exchange(url, HttpMethod.POST, new HttpEntity<>(body, h), Map.class);
     }
 
+    private <T> ResponseEntity<T> get(String url, Class<T> type, String token) {
+        HttpHeaders h = new HttpHeaders();
+        if (token != null) h.setBearerAuth(token);
+        return rest.exchange(url, HttpMethod.GET, new HttpEntity<>(h), type);
+    }
+
     @Test
     void postRequiresApproval() {
         String userToken = registerAndLogin("eve", "e@example.com");
@@ -74,7 +80,7 @@ class PublishModeIntegrationTest {
         List<?> list = rest.getForObject("/api/posts", List.class);
         assertTrue(list.isEmpty(), "Post should not be listed before approval");
 
-        List<Map<String, Object>> pending = (List<Map<String, Object>>) rest.getForObject("/api/admin/posts/pending", List.class);
+        List<Map<String, Object>> pending = get("/api/admin/posts/pending", List.class, adminToken).getBody();
         assertEquals(1, pending.size());
         assertEquals(postId.intValue(), ((Number)pending.get(0).get("id")).intValue());
 


### PR DESCRIPTION
## Summary
- use authenticated GET when retrieving pending posts

## Testing
- `mvn -q test -Dtest=com.openisle.integration.PublishModeIntegrationTest#postRequiresApproval` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68636e60bd60832b9c36a1ed2dcbf327