### PR TITLE
Add low strength password length check and tests

### DIFF
--- a/src/main/java/com/openisle/service/PasswordValidator.java
+++ b/src/main/java/com/openisle/service/PasswordValidator.java
@@ -24,7 +24,14 @@ public class PasswordValidator {
                 checkHigh(password);
                 break;
             default:
-                // LOW, nothing beyond non-empty
+                checkLow(password);
+                break;
+        }
+    }
+
+    private void checkLow(String password) {
+        if (password.length() < 6) {
+            throw new IllegalArgumentException("Password must be at least 6 characters long");
         }
     }
 

--- a/src/test/java/com/openisle/service/PasswordValidatorTest.java
+++ b/src/test/java/com/openisle/service/PasswordValidatorTest.java
@@ -1,0 +1,39 @@
+package com.openisle.service;
+
+import com.openisle.model.PasswordStrength;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PasswordValidatorTest {
+
+    @Test
+    void lowStrengthRequiresSixChars() {
+        PasswordValidator validator = new PasswordValidator(PasswordStrength.LOW);
+
+        assertThrows(IllegalArgumentException.class, () -> validator.validate("12345"));
+        assertDoesNotThrow(() -> validator.validate("123456"));
+    }
+
+    @Test
+    void mediumStrengthRules() {
+        PasswordValidator validator = new PasswordValidator(PasswordStrength.MEDIUM);
+
+        assertThrows(IllegalArgumentException.class, () -> validator.validate("abc123"));
+        assertThrows(IllegalArgumentException.class, () -> validator.validate("abcdefgh"));
+        assertThrows(IllegalArgumentException.class, () -> validator.validate("12345678"));
+        assertDoesNotThrow(() -> validator.validate("abcd1234"));
+    }
+
+    @Test
+    void highStrengthRules() {
+        PasswordValidator validator = new PasswordValidator(PasswordStrength.HIGH);
+
+        assertThrows(IllegalArgumentException.class, () -> validator.validate("Abc123$"));
+        assertThrows(IllegalArgumentException.class, () -> validator.validate("abcd1234$xyz"));
+        assertThrows(IllegalArgumentException.class, () -> validator.validate("ABCD1234$XYZ"));
+        assertThrows(IllegalArgumentException.class, () -> validator.validate("AbcdABCDabcd"));
+        assertThrows(IllegalArgumentException.class, () -> validator.validate("Abcd1234abcd"));
+        assertDoesNotThrow(() -> validator.validate("Abcd1234$xyz"));
+    }
+}


### PR DESCRIPTION
## Summary
- enforce minimum length of 6 characters even for LOW password strength
- add detailed unit tests for password validation at all strength levels

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686376756b38832b9d40fab3be76c13d