### PR TITLE
Update integration test passwords

### DIFF
--- a/src/test/java/com/openisle/integration/ComplexFlowIntegrationTest.java
+++ b/src/test/java/com/openisle/integration/ComplexFlowIntegrationTest.java
@@ -33,12 +33,12 @@ class ComplexFlowIntegrationTest {
         HttpHeaders h = new HttpHeaders();
         h.setContentType(MediaType.APPLICATION_JSON);
         rest.postForEntity("/api/auth/register", new HttpEntity<>(
-                Map.of("username", username, "email", email, "password", "pass"), h), Map.class);
+                Map.of("username", username, "email", email, "password", "pass123"), h), Map.class);
         User u = users.findByUsername(username).orElseThrow();
         rest.postForEntity("/api/auth/verify", new HttpEntity<>(
                 Map.of("username", username, "code", u.getVerificationCode()), h), Map.class);
         ResponseEntity<Map> resp = rest.postForEntity("/api/auth/login", new HttpEntity<>(
-                Map.of("username", username, "password", "pass"), h), Map.class);
+                Map.of("username", username, "password", "pass123"), h), Map.class);
         return (String) resp.getBody().get("token");
     }
 

--- a/src/test/java/com/openisle/integration/PublishModeIntegrationTest.java
+++ b/src/test/java/com/openisle/integration/PublishModeIntegrationTest.java
@@ -34,12 +34,12 @@ class PublishModeIntegrationTest {
         HttpHeaders h = new HttpHeaders();
         h.setContentType(MediaType.APPLICATION_JSON);
         rest.postForEntity("/api/auth/register", new HttpEntity<>(
-                Map.of("username", username, "email", email, "password", "pass"), h), Map.class);
+                Map.of("username", username, "email", email, "password", "pass123"), h), Map.class);
         User u = users.findByUsername(username).orElseThrow();
         rest.postForEntity("/api/auth/verify", new HttpEntity<>(
                 Map.of("username", username, "code", u.getVerificationCode()), h), Map.class);
         ResponseEntity<Map> resp = rest.postForEntity("/api/auth/login", new HttpEntity<>(
-                Map.of("username", username, "password", "pass"), h), Map.class);
+                Map.of("username", username, "password", "pass123"), h), Map.class);
         return (String) resp.getBody().get("token");
     }
 


### PR DESCRIPTION
## Summary
- adjust integration tests to use longer passwords now that password validator enforces minimum length

## Testing
- `mvn -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68637adc5220832ba68820c0cfdf70da