### PR TITLE
Fix integration tests with valid passwords

### DIFF
--- a/src/test/java/com/openisle/integration/ComplexFlowIntegrationTest.java
+++ b/src/test/java/com/openisle/integration/ComplexFlowIntegrationTest.java
@@ -33,12 +33,12 @@ class ComplexFlowIntegrationTest {
         HttpHeaders h = new HttpHeaders();
         h.setContentType(MediaType.APPLICATION_JSON);
         rest.postForEntity("/api/auth/register", new HttpEntity<>(
-                Map.of("username", username, "email", email, "password", "pass"), h), Map.class);
+                Map.of("username", username, "email", email, "password", "password"), h), Map.class);
         User u = users.findByUsername(username).orElseThrow();
         rest.postForEntity("/api/auth/verify", new HttpEntity<>(
                 Map.of("username", username, "code", u.getVerificationCode()), h), Map.class);
         ResponseEntity<Map> resp = rest.postForEntity("/api/auth/login", new HttpEntity<>(
-                Map.of("username", username, "password", "pass"), h), Map.class);
+                Map.of("username", username, "password", "password"), h), Map.class);
         return (String) resp.getBody().get("token");
     }
 

--- a/src/test/java/com/openisle/integration/PublishModeIntegrationTest.java
+++ b/src/test/java/com/openisle/integration/PublishModeIntegrationTest.java
@@ -34,12 +34,12 @@ class PublishModeIntegrationTest {
         HttpHeaders h = new HttpHeaders();
         h.setContentType(MediaType.APPLICATION_JSON);
         rest.postForEntity("/api/auth/register", new HttpEntity<>(
-                Map.of("username", username, "email", email, "password", "pass"), h), Map.class);
+                Map.of("username", username, "email", email, "password", "password"), h), Map.class);
         User u = users.findByUsername(username).orElseThrow();
         rest.postForEntity("/api/auth/verify", new HttpEntity<>(
                 Map.of("username", username, "code", u.getVerificationCode()), h), Map.class);
         ResponseEntity<Map> resp = rest.postForEntity("/api/auth/login", new HttpEntity<>(
-                Map.of("username", username, "password", "pass"), h), Map.class);
+                Map.of("username", username, "password", "password"), h), Map.class);
         return (String) resp.getBody().get("token");
     }
 


### PR DESCRIPTION
## Summary
- update integration tests to use a longer password

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68637ae2c9e0832b8c7487c09a82b517