### PR TITLE
Add endpoint to list reaction types

### DIFF
--- a/src/main/java/com/openisle/controller/ReactionController.java
+++ b/src/main/java/com/openisle/controller/ReactionController.java
@@ -15,6 +15,14 @@ import org.springframework.web.bind.annotation.*;
 public class ReactionController {
     private final ReactionService reactionService;
 
+    /**
+     * Get all available reaction types.
+     */
+    @GetMapping("/reaction-types")
+    public ReactionType[] listReactionTypes() {
+        return ReactionType.values();
+    }
+
     @PostMapping("/posts/{postId}/reactions")
     public ResponseEntity<ReactionDto> reactToPost(@PathVariable Long postId,
                                                   @RequestBody ReactionRequest req,

--- a/src/test/java/com/openisle/controller/ReactionControllerTest.java
+++ b/src/test/java/com/openisle/controller/ReactionControllerTest.java
@@ -17,6 +17,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.ArgumentMatchers.eq;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -69,5 +70,12 @@ class ReactionControllerTest {
                         .principal(new UsernamePasswordAuthenticationToken("u2", "p")))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.commentId").value(2));
+    }
+
+    @Test
+    void listReactionTypes() throws Exception {
+        mockMvc.perform(get("/api/reaction-types"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0]").value("LIKE"));
     }
 }


### PR DESCRIPTION
## Summary
- add `listReactionTypes` endpoint
- test listing available reaction types

## Testing
- `mvn -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686394986d5c832b9df827864b17f5a1