### PR TITLE
Add aggregated user data endpoint

### DIFF
--- a/src/main/java/com/openisle/controller/UserController.java
+++ b/src/main/java/com/openisle/controller/UserController.java
@@ -86,6 +86,26 @@ public class UserController {
                 .collect(java.util.stream.Collectors.toList());
     }
 
+    @GetMapping("/{username}/all")
+    public ResponseEntity<UserAggregateDto> userAggregate(@PathVariable String username,
+                                                          @RequestParam(value = "postsLimit", required = false) Integer postsLimit,
+                                                          @RequestParam(value = "repliesLimit", required = false) Integer repliesLimit) {
+        User user = userService.findByUsername(username).orElseThrow();
+        int pLimit = postsLimit != null ? postsLimit : defaultPostsLimit;
+        int rLimit = repliesLimit != null ? repliesLimit : defaultRepliesLimit;
+        java.util.List<PostMetaDto> posts = postService.getRecentPostsByUser(username, pLimit).stream()
+                .map(this::toMetaDto)
+                .collect(java.util.stream.Collectors.toList());
+        java.util.List<CommentInfoDto> replies = commentService.getRecentCommentsByUser(username, rLimit).stream()
+                .map(this::toCommentInfoDto)
+                .collect(java.util.stream.Collectors.toList());
+        UserAggregateDto dto = new UserAggregateDto();
+        dto.setUser(toDto(user));
+        dto.setPosts(posts);
+        dto.setReplies(replies);
+        return ResponseEntity.ok(dto);
+    }
+
     private UserDto toDto(User user) {
         UserDto dto = new UserDto();
         dto.setId(user.getId());
@@ -137,5 +157,12 @@ public class UserController {
         private String content;
         private java.time.LocalDateTime createdAt;
         private Long postId;
+    }
+
+    @Data
+    private static class UserAggregateDto {
+        private UserDto user;
+        private java.util.List<PostMetaDto> posts;
+        private java.util.List<CommentInfoDto> replies;
     }
 }

--- a/src/test/java/com/openisle/controller/UserControllerTest.java
+++ b/src/test/java/com/openisle/controller/UserControllerTest.java
@@ -125,4 +125,36 @@ class UserControllerTest {
                 .andExpect(jsonPath("$[0].id").value(4));
     }
 
+    @Test
+    void aggregateUserData() throws Exception {
+        User user = new User();
+        user.setId(2L);
+        user.setUsername("bob");
+        user.setEmail("b@e.com");
+        com.openisle.model.Category cat = new com.openisle.model.Category();
+        cat.setName("tech");
+        com.openisle.model.Post post = new com.openisle.model.Post();
+        post.setId(3L);
+        post.setTitle("hello");
+        post.setCreatedAt(java.time.LocalDateTime.now());
+        post.setCategory(cat);
+        post.setAuthor(user);
+        com.openisle.model.Comment comment = new com.openisle.model.Comment();
+        comment.setId(4L);
+        comment.setContent("hi");
+        comment.setCreatedAt(java.time.LocalDateTime.now());
+        comment.setAuthor(user);
+        comment.setPost(post);
+
+        Mockito.when(userService.findByUsername("bob")).thenReturn(Optional.of(user));
+        Mockito.when(postService.getRecentPostsByUser("bob", 10)).thenReturn(java.util.List.of(post));
+        Mockito.when(commentService.getRecentCommentsByUser("bob", 50)).thenReturn(java.util.List.of(comment));
+
+        mockMvc.perform(get("/api/users/bob/all"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.user.id").value(2))
+                .andExpect(jsonPath("$.posts[0].id").value(3))
+                .andExpect(jsonPath("$.replies[0].id").value(4));
+    }
+
 }


### PR DESCRIPTION
## Summary
- add `/api/users/{username}/all` endpoint to fetch user info, posts and replies at once
- cover the new endpoint with a unit test

## Testing
- `mvn test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686395534568832b9c2c192bcccd2372