### PR TITLE
Add post listing filters and pagination

### DIFF
--- a/src/main/java/com/openisle/controller/PostController.java
+++ b/src/main/java/com/openisle/controller/PostController.java
@@ -49,8 +49,16 @@ public class PostController {
     }
 
     @GetMapping
-    public List<PostDto> listPosts() {
-        return postService.listPosts().stream().map(this::toDto).collect(Collectors.toList());
+    public List<PostDto> listPosts(@RequestParam(value = "categoryId", required = false) Long categoryId,
+                                   @RequestParam(value = "categoryIds", required = false) List<Long> categoryIds,
+                                   @RequestParam(value = "page", required = false) Integer page,
+                                   @RequestParam(value = "pageSize", required = false) Integer pageSize) {
+        List<Long> ids = categoryIds;
+        if (categoryId != null) {
+            ids = java.util.List.of(categoryId);
+        }
+        return postService.listPostsByCategories(ids, page, pageSize)
+                .stream().map(this::toDto).collect(Collectors.toList());
     }
 
     private PostDto toDto(Post post) {

--- a/src/main/java/com/openisle/repository/PostRepository.java
+++ b/src/main/java/com/openisle/repository/PostRepository.java
@@ -3,6 +3,7 @@ package com.openisle.repository;
 import com.openisle.model.Post;
 import com.openisle.model.PostStatus;
 import com.openisle.model.User;
+import com.openisle.model.Category;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -10,5 +11,8 @@ import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findByStatus(PostStatus status);
+    List<Post> findByStatus(PostStatus status, Pageable pageable);
     List<Post> findByAuthorAndStatusOrderByCreatedAtDesc(User author, PostStatus status, Pageable pageable);
+    List<Post> findByCategoryInAndStatus(List<Category> categories, PostStatus status);
+    List<Post> findByCategoryInAndStatus(List<Category> categories, PostStatus status, Pageable pageable);
 }

--- a/src/main/java/com/openisle/service/PostService.java
+++ b/src/main/java/com/openisle/service/PostService.java
@@ -58,7 +58,29 @@ public class PostService {
     }
 
     public List<Post> listPosts() {
-        return postRepository.findByStatus(PostStatus.PUBLISHED);
+        return listPostsByCategories(null, null, null);
+    }
+
+    public List<Post> listPostsByCategories(java.util.List<Long> categoryIds,
+                                            Integer page,
+                                            Integer pageSize) {
+        Pageable pageable = null;
+        if (page != null && pageSize != null) {
+            pageable = PageRequest.of(page, pageSize);
+        }
+
+        if (categoryIds == null || categoryIds.isEmpty()) {
+            if (pageable != null) {
+                return postRepository.findByStatus(PostStatus.PUBLISHED, pageable);
+            }
+            return postRepository.findByStatus(PostStatus.PUBLISHED);
+        }
+
+        java.util.List<Category> categories = categoryRepository.findAllById(categoryIds);
+        if (pageable != null) {
+            return postRepository.findByCategoryInAndStatus(categories, PostStatus.PUBLISHED, pageable);
+        }
+        return postRepository.findByCategoryInAndStatus(categories, PostStatus.PUBLISHED);
     }
 
     public List<Post> getRecentPostsByUser(String username, int limit) {

--- a/src/test/java/com/openisle/controller/PostControllerTest.java
+++ b/src/test/java/com/openisle/controller/PostControllerTest.java
@@ -81,7 +81,8 @@ class PostControllerTest {
         post.setCreatedAt(LocalDateTime.now());
         post.setAuthor(user);
         post.setCategory(cat);
-        Mockito.when(postService.listPosts()).thenReturn(List.of(post));
+        Mockito.when(postService.listPostsByCategories(Mockito.isNull(), Mockito.isNull(), Mockito.isNull()))
+                .thenReturn(List.of(post));
 
         mockMvc.perform(get("/api/posts"))
                 .andExpect(status().isOk())


### PR DESCRIPTION
## Summary
- add ability to filter posts by category IDs and paginate results
- extend PostService and PostRepository to support category-based queries
- adjust PostController to expose the new query parameters
- update PostControllerTest

## Testing
- `mvn -q -DskipTests=false test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_686395064880832b8a618f0c72b8722f