### PR TITLE
Fix captcha dependency in tests

### DIFF
--- a/src/test/java/com/openisle/controller/AuthControllerTest.java
+++ b/src/test/java/com/openisle/controller/AuthControllerTest.java
@@ -4,6 +4,7 @@ import com.openisle.model.User;
 import com.openisle.service.EmailSender;
 import com.openisle.service.JwtService;
 import com.openisle.service.UserService;
+import com.openisle.service.CaptchaService;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,6 +35,8 @@ class AuthControllerTest {
     private JwtService jwtService;
     @MockBean
     private EmailSender emailService;
+    @MockBean
+    private CaptchaService captchaService;
 
     @Test
     void registerSendsEmail() throws Exception {

--- a/src/test/java/com/openisle/controller/CommentControllerTest.java
+++ b/src/test/java/com/openisle/controller/CommentControllerTest.java
@@ -4,6 +4,7 @@ import com.openisle.model.Comment;
 import com.openisle.model.Post;
 import com.openisle.model.User;
 import com.openisle.service.CommentService;
+import com.openisle.service.CaptchaService;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,6 +31,8 @@ class CommentControllerTest {
 
     @MockBean
     private CommentService commentService;
+    @MockBean
+    private CaptchaService captchaService;
 
     private Comment createComment(Long id, String content, String authorName) {
         User user = new User();

--- a/src/test/java/com/openisle/controller/PostControllerTest.java
+++ b/src/test/java/com/openisle/controller/PostControllerTest.java
@@ -6,6 +6,7 @@ import com.openisle.model.Category;
 import com.openisle.service.PostService;
 import com.openisle.service.CommentService;
 import com.openisle.service.ReactionService;
+import com.openisle.service.CaptchaService;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,6 +38,8 @@ class PostControllerTest {
     private CommentService commentService;
     @MockBean
     private ReactionService reactionService;
+    @MockBean
+    private CaptchaService captchaService;
 
     @Test
     void createAndGetPost() throws Exception {

--- a/src/test/java/com/openisle/integration/ComplexFlowIntegrationTest.java
+++ b/src/test/java/com/openisle/integration/ComplexFlowIntegrationTest.java
@@ -35,8 +35,10 @@ class ComplexFlowIntegrationTest {
         rest.postForEntity("/api/auth/register", new HttpEntity<>(
                 Map.of("username", username, "email", email, "password", "pass123"), h), Map.class);
         User u = users.findByUsername(username).orElseThrow();
-        rest.postForEntity("/api/auth/verify", new HttpEntity<>(
-                Map.of("username", username, "code", u.getVerificationCode()), h), Map.class);
+        if (u.getVerificationCode() != null) {
+            rest.postForEntity("/api/auth/verify", new HttpEntity<>(
+                    Map.of("username", username, "code", u.getVerificationCode()), h), Map.class);
+        }
         ResponseEntity<Map> resp = rest.postForEntity("/api/auth/login", new HttpEntity<>(
                 Map.of("username", username, "password", "pass123"), h), Map.class);
         return (String) resp.getBody().get("token");

--- a/src/test/java/com/openisle/integration/SearchIntegrationTest.java
+++ b/src/test/java/com/openisle/integration/SearchIntegrationTest.java
@@ -31,8 +31,10 @@ class SearchIntegrationTest {
         rest.postForEntity("/api/auth/register", new HttpEntity<>(
                 Map.of("username", username, "email", email, "password", "pass123"), h), Map.class);
         User u = users.findByUsername(username).orElseThrow();
-        rest.postForEntity("/api/auth/verify", new HttpEntity<>(
-                Map.of("username", username, "code", u.getVerificationCode()), h), Map.class);
+        if (u.getVerificationCode() != null) {
+            rest.postForEntity("/api/auth/verify", new HttpEntity<>(
+                    Map.of("username", username, "code", u.getVerificationCode()), h), Map.class);
+        }
         ResponseEntity<Map> resp = rest.postForEntity("/api/auth/login", new HttpEntity<>(
                 Map.of("username", username, "password", "pass123"), h), Map.class);
         return (String) resp.getBody().get("token");


### PR DESCRIPTION
## Summary
- mock `CaptchaService` in controller tests
- avoid `NullPointerException` in integration tests when reusing users

## Testing
- `mvn test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6863b37ea830832bbef8de0956dd4bd1