### PR TITLE
Fix search endpoint access

### DIFF
--- a/src/main/java/com/openisle/config/SecurityConfig.java
+++ b/src/main/java/com/openisle/config/SecurityConfig.java
@@ -69,6 +69,7 @@ public class SecurityConfig {
                     .requestMatchers(HttpMethod.GET, "/api/posts/**").permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/comments/**").permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/categories/**").permitAll()
+                    .requestMatchers(HttpMethod.GET, "/api/search/**").permitAll()
                     .requestMatchers(HttpMethod.POST, "/api/categories/**").hasAuthority("ADMIN")
                     .requestMatchers(HttpMethod.DELETE, "/api/categories/**").hasAuthority("ADMIN")
                     .requestMatchers("/api/admin/**").hasAuthority("ADMIN")
@@ -87,7 +88,8 @@ public class SecurityConfig {
                 String uri = request.getRequestURI();
 
                 boolean publicGet = "GET".equalsIgnoreCase(request.getMethod()) &&
-                        (uri.startsWith("/api/posts") || uri.startsWith("/api/comments") || uri.startsWith("/api/categories"));
+                        (uri.startsWith("/api/posts") || uri.startsWith("/api/comments") ||
+                         uri.startsWith("/api/categories") || uri.startsWith("/api/search"));
 
                 if (authHeader != null && authHeader.startsWith("Bearer ")) {
                     String token = authHeader.substring(7);


### PR DESCRIPTION
## Summary
- allow unauthenticated GET requests to `/api/search/**`
- include search endpoints in security filter public routes

## Testing
- `mvn test -Dtest=SearchIntegrationTest#globalSearchReturnsMixedResults` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6863e50e21f0832ba80af422be2aad14