### PR TITLE
Fix duplicate posts in global search

### DIFF
--- a/src/test/java/com/openisle/service/SearchServiceTest.java
+++ b/src/test/java/com/openisle/service/SearchServiceTest.java
@@ -1,0 +1,47 @@
+package com.openisle.service;
+
+import com.openisle.model.Post;
+import com.openisle.model.PostStatus;
+import com.openisle.repository.CommentRepository;
+import com.openisle.repository.PostRepository;
+import com.openisle.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SearchServiceTest {
+
+    @Test
+    void globalSearchDeduplicatesPosts() {
+        UserRepository userRepo = Mockito.mock(UserRepository.class);
+        PostRepository postRepo = Mockito.mock(PostRepository.class);
+        CommentRepository commentRepo = Mockito.mock(CommentRepository.class);
+        SearchService service = new SearchService(userRepo, postRepo, commentRepo);
+
+        Post post1 = new Post();
+        post1.setId(1L);
+        post1.setTitle("hello");
+        Post post2 = new Post();
+        post2.setId(2L);
+        post2.setTitle("world");
+
+        Mockito.when(postRepo.findByTitleContainingIgnoreCaseOrContentContainingIgnoreCaseAndStatus(
+                Mockito.anyString(), Mockito.anyString(), Mockito.eq(PostStatus.PUBLISHED)))
+                .thenReturn(List.of(post1));
+        Mockito.when(postRepo.findByTitleContainingIgnoreCaseAndStatus(Mockito.anyString(), Mockito.eq(PostStatus.PUBLISHED)))
+                .thenReturn(List.of(post1, post2));
+        Mockito.when(commentRepo.findByContentContainingIgnoreCase(Mockito.anyString()))
+                .thenReturn(List.of());
+        Mockito.when(userRepo.findByUsernameContainingIgnoreCase(Mockito.anyString()))
+                .thenReturn(List.of());
+
+        List<SearchService.SearchResult> results = service.globalSearch("h");
+
+        assertEquals(2, results.size());
+        assertEquals(1L, results.get(0).id());
+        assertEquals(2L, results.get(1).id());
+    }
+}


### PR DESCRIPTION
## Summary
- de-duplicate post results in global search
- test SearchService for duplicate handling

## Testing
- `apt-get update -y`
- `apt-get install -y maven`
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6863e8318710832b90fd9e34db2e8e85