### PR TITLE
Add tag module with post associations

### DIFF
--- a/src/main/java/com/openisle/config/SecurityConfig.java
+++ b/src/main/java/com/openisle/config/SecurityConfig.java
@@ -69,9 +69,12 @@ public class SecurityConfig {
                     .requestMatchers(HttpMethod.GET, "/api/posts/**").permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/comments/**").permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/categories/**").permitAll()
+                    .requestMatchers(HttpMethod.GET, "/api/tags/**").permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/search/**").permitAll()
                     .requestMatchers(HttpMethod.POST, "/api/categories/**").hasAuthority("ADMIN")
+                    .requestMatchers(HttpMethod.POST, "/api/tags/**").hasAuthority("ADMIN")
                     .requestMatchers(HttpMethod.DELETE, "/api/categories/**").hasAuthority("ADMIN")
+                    .requestMatchers(HttpMethod.DELETE, "/api/tags/**").hasAuthority("ADMIN")
                     .requestMatchers("/api/admin/**").hasAuthority("ADMIN")
                     .anyRequest().authenticated()
             )
@@ -89,7 +92,8 @@ public class SecurityConfig {
 
                 boolean publicGet = "GET".equalsIgnoreCase(request.getMethod()) &&
                         (uri.startsWith("/api/posts") || uri.startsWith("/api/comments") ||
-                         uri.startsWith("/api/categories") || uri.startsWith("/api/search"));
+                         uri.startsWith("/api/categories") || uri.startsWith("/api/tags") ||
+                         uri.startsWith("/api/search"));
 
                 if (authHeader != null && authHeader.startsWith("Bearer ")) {
                     String token = authHeader.substring(7);

--- a/src/main/java/com/openisle/controller/PostController.java
+++ b/src/main/java/com/openisle/controller/PostController.java
@@ -38,7 +38,8 @@ public class PostController {
         if (captchaEnabled && postCaptchaEnabled && !captchaService.verify(req.getCaptcha())) {
             return ResponseEntity.badRequest().build();
         }
-        Post post = postService.createPost(auth.getName(), req.getCategoryId(), req.getTitle(), req.getContent());
+        Post post = postService.createPost(auth.getName(), req.getCategoryId(),
+                req.getTitle(), req.getContent(), req.getTagIds());
         return ResponseEntity.ok(toDto(post));
     }
 
@@ -69,6 +70,7 @@ public class PostController {
         dto.setCreatedAt(post.getCreatedAt());
         dto.setAuthor(post.getAuthor().getUsername());
         dto.setCategory(post.getCategory().getName());
+        dto.setTags(post.getTags().stream().map(com.openisle.model.Tag::getName).collect(Collectors.toList()));
         dto.setViews(post.getViews());
 
         List<ReactionDto> reactions = reactionService.getReactionsForPost(post.getId())
@@ -130,6 +132,7 @@ public class PostController {
         private Long categoryId;
         private String title;
         private String content;
+        private java.util.List<Long> tagIds;
         private String captcha;
     }
 
@@ -141,6 +144,7 @@ public class PostController {
         private LocalDateTime createdAt;
         private String author;
         private String category;
+        private java.util.List<String> tags;
         private long views;
         private List<CommentDto> comments;
         private List<ReactionDto> reactions;

--- a/src/main/java/com/openisle/controller/TagController.java
+++ b/src/main/java/com/openisle/controller/TagController.java
@@ -1,0 +1,58 @@
+package com.openisle.controller;
+
+import com.openisle.model.Tag;
+import com.openisle.service.TagService;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/tags")
+@RequiredArgsConstructor
+public class TagController {
+    private final TagService tagService;
+
+    @PostMapping
+    public TagDto create(@RequestBody TagRequest req) {
+        Tag tag = tagService.createTag(req.getName());
+        return toDto(tag);
+    }
+
+    @DeleteMapping("/{id}")
+    public void delete(@PathVariable Long id) {
+        tagService.deleteTag(id);
+    }
+
+    @GetMapping
+    public List<TagDto> list() {
+        return tagService.listTags().stream()
+                .map(this::toDto)
+                .collect(Collectors.toList());
+    }
+
+    @GetMapping("/{id}")
+    public TagDto get(@PathVariable Long id) {
+        return toDto(tagService.getTag(id));
+    }
+
+    private TagDto toDto(Tag tag) {
+        TagDto dto = new TagDto();
+        dto.setId(tag.getId());
+        dto.setName(tag.getName());
+        return dto;
+    }
+
+    @Data
+    private static class TagRequest {
+        private String name;
+    }
+
+    @Data
+    private static class TagDto {
+        private Long id;
+        private String name;
+    }
+}

--- a/src/main/java/com/openisle/model/Post.java
+++ b/src/main/java/com/openisle/model/Post.java
@@ -5,6 +5,11 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.util.HashSet;
+import java.util.Set;
+
+import com.openisle.model.Tag;
+
 
 import java.time.LocalDateTime;
 
@@ -37,6 +42,12 @@ public class Post {
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id")
     private Category category;
+
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(name = "post_tags",
+            joinColumns = @JoinColumn(name = "post_id"),
+            inverseJoinColumns = @JoinColumn(name = "tag_id"))
+    private java.util.Set<Tag> tags = new java.util.HashSet<>();
 
     @Column(nullable = false)
     private long views = 0;

--- a/src/main/java/com/openisle/model/Tag.java
+++ b/src/main/java/com/openisle/model/Tag.java
@@ -1,0 +1,20 @@
+package com.openisle.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@Table(name = "tags")
+public class Tag {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String name;
+}

--- a/src/main/java/com/openisle/repository/TagRepository.java
+++ b/src/main/java/com/openisle/repository/TagRepository.java
@@ -1,0 +1,7 @@
+package com.openisle.repository;
+
+import com.openisle.model.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TagRepository extends JpaRepository<Tag, Long> {
+}

--- a/src/main/java/com/openisle/service/TagService.java
+++ b/src/main/java/com/openisle/service/TagService.java
@@ -1,0 +1,33 @@
+package com.openisle.service;
+
+import com.openisle.model.Tag;
+import com.openisle.repository.TagRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TagService {
+    private final TagRepository tagRepository;
+
+    public Tag createTag(String name) {
+        Tag tag = new Tag();
+        tag.setName(name);
+        return tagRepository.save(tag);
+    }
+
+    public void deleteTag(Long id) {
+        tagRepository.deleteById(id);
+    }
+
+    public Tag getTag(Long id) {
+        return tagRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Tag not found"));
+    }
+
+    public List<Tag> listTags() {
+        return tagRepository.findAll();
+    }
+}

--- a/src/test/java/com/openisle/controller/PostControllerTest.java
+++ b/src/test/java/com/openisle/controller/PostControllerTest.java
@@ -3,6 +3,7 @@ package com.openisle.controller;
 import com.openisle.model.Post;
 import com.openisle.model.User;
 import com.openisle.model.Category;
+import com.openisle.model.Tag;
 import com.openisle.service.PostService;
 import com.openisle.service.CommentService;
 import com.openisle.service.ReactionService;
@@ -48,6 +49,9 @@ class PostControllerTest {
         Category cat = new Category();
         cat.setId(1L);
         cat.setName("tech");
+        Tag tag = new Tag();
+        tag.setId(1L);
+        tag.setName("java");
         Post post = new Post();
         post.setId(1L);
         post.setTitle("t");
@@ -55,12 +59,13 @@ class PostControllerTest {
         post.setCreatedAt(LocalDateTime.now());
         post.setAuthor(user);
         post.setCategory(cat);
-        Mockito.when(postService.createPost(eq("alice"), eq(1L), eq("t"), eq("c"))).thenReturn(post);
+        post.setTags(java.util.Set.of(tag));
+        Mockito.when(postService.createPost(eq("alice"), eq(1L), eq("t"), eq("c"), eq(java.util.List.of(1L)))).thenReturn(post);
         Mockito.when(postService.getPost(1L)).thenReturn(post);
 
         mockMvc.perform(post("/api/posts")
                         .contentType("application/json")
-                        .content("{\"title\":\"t\",\"content\":\"c\",\"categoryId\":1}")
+                        .content("{\"title\":\"t\",\"content\":\"c\",\"categoryId\":1,\"tagIds\":[1]}")
                         .principal(new UsernamePasswordAuthenticationToken("alice", "p")))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.title").value("t"));
@@ -77,6 +82,9 @@ class PostControllerTest {
         Category cat = new Category();
         cat.setId(1L);
         cat.setName("tech");
+        Tag tag = new Tag();
+        tag.setId(1L);
+        tag.setName("java");
         Post post = new Post();
         post.setId(2L);
         post.setTitle("hello");
@@ -84,6 +92,7 @@ class PostControllerTest {
         post.setCreatedAt(LocalDateTime.now());
         post.setAuthor(user);
         post.setCategory(cat);
+        post.setTags(java.util.Set.of(tag));
         Mockito.when(postService.listPostsByCategories(Mockito.isNull(), Mockito.isNull(), Mockito.isNull()))
                 .thenReturn(List.of(post));
 

--- a/src/test/java/com/openisle/controller/TagControllerTest.java
+++ b/src/test/java/com/openisle/controller/TagControllerTest.java
@@ -1,0 +1,59 @@
+package com.openisle.controller;
+
+import com.openisle.model.Tag;
+import com.openisle.service.TagService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(TagController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class TagControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private TagService tagService;
+
+    @Test
+    void createAndGetTag() throws Exception {
+        Tag t = new Tag();
+        t.setId(1L);
+        t.setName("java");
+        Mockito.when(tagService.createTag(eq("java"))).thenReturn(t);
+        Mockito.when(tagService.getTag(1L)).thenReturn(t);
+
+        mockMvc.perform(post("/api/tags")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"java\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("java"));
+
+        mockMvc.perform(get("/api/tags/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1));
+    }
+
+    @Test
+    void listTags() throws Exception {
+        Tag t = new Tag();
+        t.setId(2L);
+        t.setName("spring");
+        Mockito.when(tagService.listTags()).thenReturn(List.of(t));
+
+        mockMvc.perform(get("/api/tags"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].name").value("spring"));
+    }
+}

--- a/src/test/java/com/openisle/integration/ComplexFlowIntegrationTest.java
+++ b/src/test/java/com/openisle/integration/ComplexFlowIntegrationTest.java
@@ -69,8 +69,13 @@ class ComplexFlowIntegrationTest {
                 Map.of("name", "general"), adminToken);
         Long catId = ((Number)catResp.getBody().get("id")).longValue();
 
+        ResponseEntity<Map> tagResp = postJson("/api/tags",
+                Map.of("name", "java"), adminToken);
+        Long tagId = ((Number)tagResp.getBody().get("id")).longValue();
+
         ResponseEntity<Map> postResp = postJson("/api/posts",
-                Map.of("title", "Hello", "content", "World", "categoryId", catId), t1);
+                Map.of("title", "Hello", "content", "World", "categoryId", catId,
+                        "tagIds", List.of(tagId)), t1);
         Long postId = ((Number)postResp.getBody().get("id")).longValue();
 
         ResponseEntity<Map> c1Resp = postJson("/api/posts/" + postId + "/comments",
@@ -122,8 +127,13 @@ class ComplexFlowIntegrationTest {
             catId = ((Number)catResp.getBody().get("id")).longValue();
         }
 
+        ResponseEntity<Map> tagResp = postJson("/api/tags",
+                Map.of("name", "spring"), adminToken);
+        Long tagId = ((Number)tagResp.getBody().get("id")).longValue();
+
         ResponseEntity<Map> postResp = postJson("/api/posts",
-                Map.of("title", "React", "content", "Test", "categoryId", catId), t1);
+                Map.of("title", "React", "content", "Test", "categoryId", catId,
+                        "tagIds", List.of(tagId)), t1);
         Long postId = ((Number)postResp.getBody().get("id")).longValue();
 
         postJson("/api/posts/" + postId + "/reactions",

--- a/src/test/java/com/openisle/integration/PublishModeIntegrationTest.java
+++ b/src/test/java/com/openisle/integration/PublishModeIntegrationTest.java
@@ -73,8 +73,13 @@ class PublishModeIntegrationTest {
                 Map.of("name", "review"), adminToken);
         Long catId = ((Number)catResp.getBody().get("id")).longValue();
 
+        ResponseEntity<Map> tagResp = postJson("/api/tags",
+                Map.of("name", "t1"), adminToken);
+        Long tagId = ((Number)tagResp.getBody().get("id")).longValue();
+
         ResponseEntity<Map> postResp = postJson("/api/posts",
-                Map.of("title", "Need", "content", "Review", "categoryId", catId), userToken);
+                Map.of("title", "Need", "content", "Review", "categoryId", catId,
+                        "tagIds", List.of(tagId)), userToken);
         Long postId = ((Number)postResp.getBody().get("id")).longValue();
 
         List<?> list = rest.getForObject("/api/posts", List.class);

--- a/src/test/java/com/openisle/integration/SearchIntegrationTest.java
+++ b/src/test/java/com/openisle/integration/SearchIntegrationTest.java
@@ -63,8 +63,12 @@ class SearchIntegrationTest {
         ResponseEntity<Map> catResp = postJson("/api/categories", Map.of("name", "misc"), admin);
         Long catId = ((Number)catResp.getBody().get("id")).longValue();
 
+        ResponseEntity<Map> tagResp = postJson("/api/tags", Map.of("name", "misc"), admin);
+        Long tagId = ((Number)tagResp.getBody().get("id")).longValue();
+
         ResponseEntity<Map> postResp = postJson("/api/posts",
-                Map.of("title", "Hello World Nice", "content", "Some content", "categoryId", catId), user);
+                Map.of("title", "Hello World Nice", "content", "Some content", "categoryId", catId,
+                        "tagIds", List.of(tagId)), user);
         Long postId = ((Number)postResp.getBody().get("id")).longValue();
 
         postJson("/api/posts/" + postId + "/comments",


### PR DESCRIPTION
## Summary
- add `Tag` entity, repository, service, and controller
- allow posts to have multiple tags
- expose tag info via post APIs
- secure tag endpoints
- update integration and controller tests for tags

## Testing
- `mvn -q test` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6864bf703b80832bb4bcaf5972b66f2d