### PR TITLE
Add icon and description to tags and categories

### DIFF
--- a/src/main/java/com/openisle/controller/CategoryController.java
+++ b/src/main/java/com/openisle/controller/CategoryController.java
@@ -17,7 +17,7 @@ public class CategoryController {
 
     @PostMapping
     public CategoryDto create(@RequestBody CategoryRequest req) {
-        Category c = categoryService.createCategory(req.getName());
+        Category c = categoryService.createCategory(req.getName(), req.getDescribe(), req.getIcon());
         return toDto(c);
     }
 
@@ -42,17 +42,23 @@ public class CategoryController {
         CategoryDto dto = new CategoryDto();
         dto.setId(c.getId());
         dto.setName(c.getName());
+        dto.setIcon(c.getIcon());
+        dto.setDescribe(c.getDescribe());
         return dto;
     }
 
     @Data
     private static class CategoryRequest {
         private String name;
+        private String describe;
+        private String icon;
     }
 
     @Data
     private static class CategoryDto {
         private Long id;
         private String name;
+        private String describe;
+        private String icon;
     }
 }

--- a/src/main/java/com/openisle/controller/TagController.java
+++ b/src/main/java/com/openisle/controller/TagController.java
@@ -17,7 +17,7 @@ public class TagController {
 
     @PostMapping
     public TagDto create(@RequestBody TagRequest req) {
-        Tag tag = tagService.createTag(req.getName());
+        Tag tag = tagService.createTag(req.getName(), req.getDescribe(), req.getIcon());
         return toDto(tag);
     }
 
@@ -42,17 +42,23 @@ public class TagController {
         TagDto dto = new TagDto();
         dto.setId(tag.getId());
         dto.setName(tag.getName());
+        dto.setIcon(tag.getIcon());
+        dto.setDescribe(tag.getDescribe());
         return dto;
     }
 
     @Data
     private static class TagRequest {
         private String name;
+        private String describe;
+        private String icon;
     }
 
     @Data
     private static class TagDto {
         private Long id;
         private String name;
+        private String describe;
+        private String icon;
     }
 }

--- a/src/main/java/com/openisle/model/Category.java
+++ b/src/main/java/com/openisle/model/Category.java
@@ -17,4 +17,10 @@ public class Category {
 
     @Column(nullable = false, unique = true)
     private String name;
+
+    @Column(nullable = false)
+    private String icon;
+
+    @Column(nullable = false)
+    private String describe;
 }

--- a/src/main/java/com/openisle/model/Tag.java
+++ b/src/main/java/com/openisle/model/Tag.java
@@ -17,4 +17,10 @@ public class Tag {
 
     @Column(nullable = false, unique = true)
     private String name;
+
+    @Column
+    private String icon;
+
+    @Column(nullable = false)
+    private String describe;
 }

--- a/src/main/java/com/openisle/service/CategoryService.java
+++ b/src/main/java/com/openisle/service/CategoryService.java
@@ -12,9 +12,11 @@ import java.util.List;
 public class CategoryService {
     private final CategoryRepository categoryRepository;
 
-    public Category createCategory(String name) {
+    public Category createCategory(String name, String describe, String icon) {
         Category category = new Category();
         category.setName(name);
+        category.setDescribe(describe);
+        category.setIcon(icon);
         return categoryRepository.save(category);
     }
 

--- a/src/main/java/com/openisle/service/TagService.java
+++ b/src/main/java/com/openisle/service/TagService.java
@@ -12,9 +12,11 @@ import java.util.List;
 public class TagService {
     private final TagRepository tagRepository;
 
-    public Tag createTag(String name) {
+    public Tag createTag(String name, String describe, String icon) {
         Tag tag = new Tag();
         tag.setName(name);
+        tag.setDescribe(describe);
+        tag.setIcon(icon);
         return tagRepository.save(tag);
     }
 

--- a/src/test/java/com/openisle/controller/CategoryControllerTest.java
+++ b/src/test/java/com/openisle/controller/CategoryControllerTest.java
@@ -31,14 +31,18 @@ class CategoryControllerTest {
         Category c = new Category();
         c.setId(1L);
         c.setName("tech");
-        Mockito.when(categoryService.createCategory(eq("tech"))).thenReturn(c);
+        c.setDescribe("d");
+        c.setIcon("i");
+        Mockito.when(categoryService.createCategory(eq("tech"), eq("d"), eq("i"))).thenReturn(c);
         Mockito.when(categoryService.getCategory(1L)).thenReturn(c);
 
         mockMvc.perform(post("/api/categories")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"name\":\"tech\"}"))
+                        .content("{\"name\":\"tech\",\"describe\":\"d\",\"icon\":\"i\"}"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.name").value("tech"));
+                .andExpect(jsonPath("$.name").value("tech"))
+                .andExpect(jsonPath("$.describe").value("d"))
+                .andExpect(jsonPath("$.icon").value("i"));
 
         mockMvc.perform(get("/api/categories/1"))
                 .andExpect(status().isOk())
@@ -50,10 +54,14 @@ class CategoryControllerTest {
         Category c = new Category();
         c.setId(2L);
         c.setName("life");
+        c.setDescribe("d2");
+        c.setIcon("i2");
         Mockito.when(categoryService.listCategories()).thenReturn(List.of(c));
 
         mockMvc.perform(get("/api/categories"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].name").value("life"));
+                .andExpect(jsonPath("$[0].name").value("life"))
+                .andExpect(jsonPath("$[0].describe").value("d2"))
+                .andExpect(jsonPath("$[0].icon").value("i2"));
     }
 }

--- a/src/test/java/com/openisle/controller/PostControllerTest.java
+++ b/src/test/java/com/openisle/controller/PostControllerTest.java
@@ -49,9 +49,13 @@ class PostControllerTest {
         Category cat = new Category();
         cat.setId(1L);
         cat.setName("tech");
+        cat.setDescribe("d");
+        cat.setIcon("i");
         Tag tag = new Tag();
         tag.setId(1L);
         tag.setName("java");
+        tag.setDescribe("td");
+        tag.setIcon("ti");
         Post post = new Post();
         post.setId(1L);
         post.setTitle("t");
@@ -82,9 +86,13 @@ class PostControllerTest {
         Category cat = new Category();
         cat.setId(1L);
         cat.setName("tech");
+        cat.setDescribe("d");
+        cat.setIcon("i");
         Tag tag = new Tag();
         tag.setId(1L);
         tag.setName("java");
+        tag.setDescribe("td");
+        tag.setIcon("ti");
         Post post = new Post();
         post.setId(2L);
         post.setTitle("hello");

--- a/src/test/java/com/openisle/controller/TagControllerTest.java
+++ b/src/test/java/com/openisle/controller/TagControllerTest.java
@@ -31,14 +31,18 @@ class TagControllerTest {
         Tag t = new Tag();
         t.setId(1L);
         t.setName("java");
-        Mockito.when(tagService.createTag(eq("java"))).thenReturn(t);
+        t.setDescribe("d");
+        t.setIcon("i");
+        Mockito.when(tagService.createTag(eq("java"), eq("d"), eq("i"))).thenReturn(t);
         Mockito.when(tagService.getTag(1L)).thenReturn(t);
 
         mockMvc.perform(post("/api/tags")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"name\":\"java\"}"))
+                        .content("{\"name\":\"java\",\"describe\":\"d\",\"icon\":\"i\"}"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.name").value("java"));
+                .andExpect(jsonPath("$.name").value("java"))
+                .andExpect(jsonPath("$.describe").value("d"))
+                .andExpect(jsonPath("$.icon").value("i"));
 
         mockMvc.perform(get("/api/tags/1"))
                 .andExpect(status().isOk())
@@ -50,10 +54,15 @@ class TagControllerTest {
         Tag t = new Tag();
         t.setId(2L);
         t.setName("spring");
+        t.setDescribe("d2");
+        t.setIcon("i2");
         Mockito.when(tagService.listTags()).thenReturn(List.of(t));
 
         mockMvc.perform(get("/api/tags"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].name").value("spring"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].name").value("spring"))
+                .andExpect(jsonPath("$[0].describe").value("d2"))
+                .andExpect(jsonPath("$[0].icon").value("i2"));
     }
 }


### PR DESCRIPTION
## Summary
- extend Tag and Category models with icon and description fields
- update services and controllers for new fields
- adjust tests accordingly
- fix PostController test setup

## Testing
- `mvn -q test` *(fails: Could not transfer artifact spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_6864c404fc1c832ba444b1fdcc00739c