### PR TITLE
Add update APIs for tags and categories

### DIFF
--- a/src/main/java/com/openisle/controller/CategoryController.java
+++ b/src/main/java/com/openisle/controller/CategoryController.java
@@ -21,6 +21,12 @@ public class CategoryController {
         return toDto(c);
     }
 
+    @PutMapping("/{id}")
+    public CategoryDto update(@PathVariable Long id, @RequestBody CategoryRequest req) {
+        Category c = categoryService.updateCategory(id, req.getName(), req.getDescribe(), req.getIcon());
+        return toDto(c);
+    }
+
     @DeleteMapping("/{id}")
     public void delete(@PathVariable Long id) {
         categoryService.deleteCategory(id);

--- a/src/main/java/com/openisle/controller/TagController.java
+++ b/src/main/java/com/openisle/controller/TagController.java
@@ -21,6 +21,12 @@ public class TagController {
         return toDto(tag);
     }
 
+    @PutMapping("/{id}")
+    public TagDto update(@PathVariable Long id, @RequestBody TagRequest req) {
+        Tag tag = tagService.updateTag(id, req.getName(), req.getDescribe(), req.getIcon());
+        return toDto(tag);
+    }
+
     @DeleteMapping("/{id}")
     public void delete(@PathVariable Long id) {
         tagService.deleteTag(id);

--- a/src/main/java/com/openisle/service/CategoryService.java
+++ b/src/main/java/com/openisle/service/CategoryService.java
@@ -20,6 +20,21 @@ public class CategoryService {
         return categoryRepository.save(category);
     }
 
+    public Category updateCategory(Long id, String name, String describe, String icon) {
+        Category category = categoryRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Category not found"));
+        if (name != null) {
+            category.setName(name);
+        }
+        if (describe != null) {
+            category.setDescribe(describe);
+        }
+        if (icon != null) {
+            category.setIcon(icon);
+        }
+        return categoryRepository.save(category);
+    }
+
     public void deleteCategory(Long id) {
         categoryRepository.deleteById(id);
     }

--- a/src/main/java/com/openisle/service/TagService.java
+++ b/src/main/java/com/openisle/service/TagService.java
@@ -20,6 +20,21 @@ public class TagService {
         return tagRepository.save(tag);
     }
 
+    public Tag updateTag(Long id, String name, String describe, String icon) {
+        Tag tag = tagRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Tag not found"));
+        if (name != null) {
+            tag.setName(name);
+        }
+        if (describe != null) {
+            tag.setDescribe(describe);
+        }
+        if (icon != null) {
+            tag.setIcon(icon);
+        }
+        return tagRepository.save(tag);
+    }
+
     public void deleteTag(Long id) {
         tagRepository.deleteById(id);
     }

--- a/src/test/java/com/openisle/controller/CategoryControllerTest.java
+++ b/src/test/java/com/openisle/controller/CategoryControllerTest.java
@@ -64,4 +64,23 @@ class CategoryControllerTest {
                 .andExpect(jsonPath("$[0].describe").value("d2"))
                 .andExpect(jsonPath("$[0].icon").value("i2"));
     }
+
+    @Test
+    void updateCategory() throws Exception {
+        Category c = new Category();
+        c.setId(3L);
+        c.setName("tech");
+        c.setDescribe("d3");
+        c.setIcon("i3");
+        Mockito.when(categoryService.updateCategory(eq(3L), eq("tech"), eq("d3"), eq("i3"))).thenReturn(c);
+
+        mockMvc.perform(put("/api/categories/3")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"tech\",\"describe\":\"d3\",\"icon\":\"i3\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(3))
+                .andExpect(jsonPath("$.name").value("tech"))
+                .andExpect(jsonPath("$.describe").value("d3"))
+                .andExpect(jsonPath("$.icon").value("i3"));
+    }
 }

--- a/src/test/java/com/openisle/controller/TagControllerTest.java
+++ b/src/test/java/com/openisle/controller/TagControllerTest.java
@@ -65,4 +65,23 @@ class TagControllerTest {
                 .andExpect(jsonPath("$[0].describe").value("d2"))
                 .andExpect(jsonPath("$[0].icon").value("i2"));
     }
+
+    @Test
+    void updateTag() throws Exception {
+        Tag t = new Tag();
+        t.setId(3L);
+        t.setName("java");
+        t.setDescribe("d3");
+        t.setIcon("i3");
+        Mockito.when(tagService.updateTag(eq(3L), eq("java"), eq("d3"), eq("i3"))).thenReturn(t);
+
+        mockMvc.perform(put("/api/tags/3")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"java\",\"describe\":\"d3\",\"icon\":\"i3\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(3))
+                .andExpect(jsonPath("$.name").value("java"))
+                .andExpect(jsonPath("$.describe").value("d3"))
+                .andExpect(jsonPath("$.icon").value("i3"));
+    }
 }


### PR DESCRIPTION
## Summary
- allow updating tags
- allow updating categories
- test new tag update API
- test new category update API

## Testing
- `mvn -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6864ce5a9b00832b847f8c471b0cf2b1