### PR TITLE
Add complex controller test cases

### DIFF
--- a/src/test/java/com/openisle/controller/PostControllerTest.java
+++ b/src/test/java/com/openisle/controller/PostControllerTest.java
@@ -26,12 +26,17 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import org.springframework.test.util.ReflectionTestUtils;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
 
 @WebMvcTest(PostController.class)
 @AutoConfigureMockMvc(addFilters = false)
 class PostControllerTest {
     @Autowired
     private MockMvc mockMvc;
+    @Autowired
+    private PostController postController;
 
     @MockBean
     private PostService postService;
@@ -107,5 +112,112 @@ class PostControllerTest {
         mockMvc.perform(get("/api/posts"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].title").value("hello"));
+    }
+
+    @Test
+    void createPostRejectsInvalidCaptcha() throws Exception {
+        org.springframework.test.util.ReflectionTestUtils.setField(postController, "captchaEnabled", true);
+        org.springframework.test.util.ReflectionTestUtils.setField(postController, "postCaptchaEnabled", true);
+        Mockito.when(captchaService.verify("bad")).thenReturn(false);
+
+        mockMvc.perform(post("/api/posts")
+                        .contentType("application/json")
+                        .content("{\"title\":\"t\",\"content\":\"c\",\"categoryId\":1,\"tagIds\":[1],\"captcha\":\"bad\"}")
+                        .principal(new UsernamePasswordAuthenticationToken("alice", "p")))
+                .andExpect(status().isBadRequest());
+
+        verify(postService, never()).createPost(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void getPostWithNestedData() throws Exception {
+        User user = new User();
+        user.setUsername("alice");
+        Category cat = new Category();
+        cat.setId(1L);
+        cat.setName("tech");
+        Tag tag = new Tag();
+        tag.setId(1L);
+        tag.setName("java");
+        Post post = new Post();
+        post.setId(1L);
+        post.setTitle("t");
+        post.setContent("c");
+        post.setCreatedAt(LocalDateTime.now());
+        post.setAuthor(user);
+        post.setCategory(cat);
+        post.setTags(java.util.Set.of(tag));
+
+        com.openisle.model.Comment comment = new com.openisle.model.Comment();
+        comment.setId(2L);
+        comment.setContent("hi");
+        comment.setCreatedAt(LocalDateTime.now());
+        comment.setAuthor(user);
+        comment.setPost(post);
+
+        com.openisle.model.Comment reply = new com.openisle.model.Comment();
+        reply.setId(3L);
+        reply.setContent("reply");
+        reply.setCreatedAt(LocalDateTime.now());
+        reply.setAuthor(user);
+        reply.setPost(post);
+
+        com.openisle.model.Reaction pr = new com.openisle.model.Reaction();
+        pr.setId(10L);
+        pr.setUser(user);
+        pr.setPost(post);
+        pr.setType(com.openisle.model.ReactionType.LIKE);
+
+        com.openisle.model.Reaction cr = new com.openisle.model.Reaction();
+        cr.setId(11L);
+        cr.setUser(user);
+        cr.setComment(comment);
+        cr.setType(com.openisle.model.ReactionType.LIKE);
+
+        Mockito.when(postService.getPost(1L)).thenReturn(post);
+        Mockito.when(commentService.getCommentsForPost(1L)).thenReturn(List.of(comment));
+        Mockito.when(commentService.getReplies(2L)).thenReturn(List.of(reply));
+        Mockito.when(commentService.getReplies(3L)).thenReturn(List.of());
+        Mockito.when(reactionService.getReactionsForPost(1L)).thenReturn(List.of(pr));
+        Mockito.when(reactionService.getReactionsForComment(2L)).thenReturn(List.of(cr));
+        Mockito.when(reactionService.getReactionsForComment(3L)).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/posts/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.reactions[0].id").value(10))
+                .andExpect(jsonPath("$.comments[0].replies[0].id").value(3))
+                .andExpect(jsonPath("$.comments[0].reactions[0].id").value(11));
+    }
+
+    @Test
+    void listPostsByTags() throws Exception {
+        User user = new User();
+        user.setUsername("alice");
+        Category cat = new Category();
+        cat.setName("tech");
+        Tag tag = new Tag();
+        tag.setId(1L);
+        tag.setName("java");
+        Post post = new Post();
+        post.setId(2L);
+        post.setTitle("hello");
+        post.setCreatedAt(LocalDateTime.now());
+        post.setAuthor(user);
+        post.setCategory(cat);
+        post.setTags(java.util.Set.of(tag));
+
+        Mockito.when(postService.listPostsByTags(eq(java.util.List.of(1L, 2L)), eq(0), eq(5)))
+                .thenReturn(List.of(post));
+
+        mockMvc.perform(get("/api/posts")
+                        .param("tagIds", "1,2")
+                        .param("page", "0")
+                        .param("pageSize", "5")
+                        .param("categoryId", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(2));
+
+        verify(postService).listPostsByTags(eq(java.util.List.of(1L, 2L)), eq(0), eq(5));
+        verify(postService, never()).listPostsByCategories(any(), any(), any());
     }
 }

--- a/src/test/java/com/openisle/controller/SearchControllerTest.java
+++ b/src/test/java/com/openisle/controller/SearchControllerTest.java
@@ -63,4 +63,28 @@ class SearchControllerTest {
                 .andExpect(jsonPath("$[1].type").value("post"))
                 .andExpect(jsonPath("$[2].type").value("comment"));
     }
+
+    @Test
+    void searchPostsByTitle() throws Exception {
+        Post p = new Post();
+        p.setId(2L);
+        p.setTitle("spring");
+        Mockito.when(searchService.searchPostsByTitle("spr")).thenReturn(List.of(p));
+
+        mockMvc.perform(get("/api/search/posts/title").param("keyword", "spr"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].title").value("spring"));
+    }
+
+    @Test
+    void searchPosts() throws Exception {
+        Post p = new Post();
+        p.setId(5L);
+        p.setTitle("hello");
+        Mockito.when(searchService.searchPosts("he")).thenReturn(List.of(p));
+
+        mockMvc.perform(get("/api/search/posts").param("keyword", "he"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(5));
+    }
 }


### PR DESCRIPTION
## Summary
- add tests for captcha validation, nested comments, tag filtering in `PostControllerTest`
- add title and general post search tests in `SearchControllerTest`

## Testing
- `mvn -q test` *(fails: Could not transfer artifact spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_6864d5ce78ac832ba5129dd232888252