### PR TITLE
Fix integration tests for required category/tag fields

### DIFF
--- a/src/test/java/com/openisle/integration/ComplexFlowIntegrationTest.java
+++ b/src/test/java/com/openisle/integration/ComplexFlowIntegrationTest.java
@@ -66,11 +66,11 @@ class ComplexFlowIntegrationTest {
 
         String adminToken = registerAndLoginAsAdmin("admin", "admin@example.com");
         ResponseEntity<Map> catResp = postJson("/api/categories",
-                Map.of("name", "general"), adminToken);
+                Map.of("name", "general", "describe", "d", "icon", "i"), adminToken);
         Long catId = ((Number)catResp.getBody().get("id")).longValue();
 
         ResponseEntity<Map> tagResp = postJson("/api/tags",
-                Map.of("name", "java"), adminToken);
+                Map.of("name", "java", "describe", "d", "icon", "i"), adminToken);
         Long tagId = ((Number)tagResp.getBody().get("id")).longValue();
 
         ResponseEntity<Map> postResp = postJson("/api/posts",
@@ -123,12 +123,12 @@ class ComplexFlowIntegrationTest {
 
         if (catId == null) {
             ResponseEntity<Map> catResp = postJson("/api/categories",
-                    Map.of("name", "general"), adminToken);
+                    Map.of("name", "general", "describe", "d", "icon", "i"), adminToken);
             catId = ((Number)catResp.getBody().get("id")).longValue();
         }
 
         ResponseEntity<Map> tagResp = postJson("/api/tags",
-                Map.of("name", "spring"), adminToken);
+                Map.of("name", "spring", "describe", "d", "icon", "i"), adminToken);
         Long tagId = ((Number)tagResp.getBody().get("id")).longValue();
 
         ResponseEntity<Map> postResp = postJson("/api/posts",

--- a/src/test/java/com/openisle/integration/PublishModeIntegrationTest.java
+++ b/src/test/java/com/openisle/integration/PublishModeIntegrationTest.java
@@ -70,11 +70,11 @@ class PublishModeIntegrationTest {
         String adminToken = registerAndLoginAsAdmin("admin", "admin@example.com");
 
         ResponseEntity<Map> catResp = postJson("/api/categories",
-                Map.of("name", "review"), adminToken);
+                Map.of("name", "review", "describe", "d", "icon", "i"), adminToken);
         Long catId = ((Number)catResp.getBody().get("id")).longValue();
 
         ResponseEntity<Map> tagResp = postJson("/api/tags",
-                Map.of("name", "t1"), adminToken);
+                Map.of("name", "t1", "describe", "d", "icon", "i"), adminToken);
         Long tagId = ((Number)tagResp.getBody().get("id")).longValue();
 
         ResponseEntity<Map> postResp = postJson("/api/posts",

--- a/src/test/java/com/openisle/integration/SearchIntegrationTest.java
+++ b/src/test/java/com/openisle/integration/SearchIntegrationTest.java
@@ -60,10 +60,10 @@ class SearchIntegrationTest {
         String admin = registerAndLoginAsAdmin("admin", "a@a.com");
         String user = registerAndLogin("bob_nice", "b@b.com");
 
-        ResponseEntity<Map> catResp = postJson("/api/categories", Map.of("name", "misc"), admin);
+        ResponseEntity<Map> catResp = postJson("/api/categories", Map.of("name", "misc", "describe", "d", "icon", "i"), admin);
         Long catId = ((Number)catResp.getBody().get("id")).longValue();
 
-        ResponseEntity<Map> tagResp = postJson("/api/tags", Map.of("name", "misc"), admin);
+        ResponseEntity<Map> tagResp = postJson("/api/tags", Map.of("name", "misc", "describe", "d", "icon", "i"), admin);
         Long tagId = ((Number)tagResp.getBody().get("id")).longValue();
 
         ResponseEntity<Map> postResp = postJson("/api/posts",


### PR DESCRIPTION
## Summary
- update integration tests to supply `describe` and `icon` when creating categories and tags

## Testing
- `apt-get update -y`
- `apt-get install -y maven`
- `mvn -q test` *(fails: Could not resolve artifacts)*

------
https://chatgpt.com/codex/tasks/task_e_6864ebebb3b8832ba0b15d38760cb2b5