### PR TITLE
Add notification module

### DIFF
--- a/src/main/java/com/openisle/controller/AdminPostController.java
+++ b/src/main/java/com/openisle/controller/AdminPostController.java
@@ -31,6 +31,11 @@ public class AdminPostController {
         return toDto(postService.approvePost(id));
     }
 
+    @PostMapping("/{id}/reject")
+    public PostDto reject(@PathVariable Long id) {
+        return toDto(postService.rejectPost(id));
+    }
+
     private PostDto toDto(Post post) {
         PostDto dto = new PostDto();
         dto.setId(post.getId());

--- a/src/main/java/com/openisle/controller/NotificationController.java
+++ b/src/main/java/com/openisle/controller/NotificationController.java
@@ -1,0 +1,62 @@
+package com.openisle.controller;
+
+import com.openisle.model.Notification;
+import com.openisle.model.NotificationType;
+import com.openisle.service.NotificationService;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/** Endpoints for user notifications. */
+@RestController
+@RequestMapping("/api/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+    private final NotificationService notificationService;
+
+    @GetMapping
+    public List<NotificationDto> list(@RequestParam(value = "read", required = false) Boolean read,
+                                      Authentication auth) {
+        return notificationService.listNotifications(auth.getName(), read).stream()
+                .map(this::toDto)
+                .collect(Collectors.toList());
+    }
+
+    @PostMapping("/read")
+    public void markRead(@RequestBody MarkReadRequest req, Authentication auth) {
+        notificationService.markRead(auth.getName(), req.getIds());
+    }
+
+    private NotificationDto toDto(Notification n) {
+        NotificationDto dto = new NotificationDto();
+        dto.setId(n.getId());
+        dto.setType(n.getType());
+        dto.setPostId(n.getPost() != null ? n.getPost().getId() : null);
+        dto.setCommentId(n.getComment() != null ? n.getComment().getId() : null);
+        dto.setApproved(n.getApproved());
+        dto.setRead(n.isRead());
+        dto.setCreatedAt(n.getCreatedAt());
+        return dto;
+    }
+
+    @Data
+    private static class MarkReadRequest {
+        private List<Long> ids;
+    }
+
+    @Data
+    private static class NotificationDto {
+        private Long id;
+        private NotificationType type;
+        private Long postId;
+        private Long commentId;
+        private Boolean approved;
+        private boolean read;
+        private LocalDateTime createdAt;
+    }
+}

--- a/src/main/java/com/openisle/controller/PostController.java
+++ b/src/main/java/com/openisle/controller/PostController.java
@@ -44,8 +44,9 @@ public class PostController {
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<PostDto> getPost(@PathVariable Long id) {
-        Post post = postService.getPost(id);
+    public ResponseEntity<PostDto> getPost(@PathVariable Long id, Authentication auth) {
+        String viewer = auth != null ? auth.getName() : null;
+        Post post = postService.viewPost(id, viewer);
         return ResponseEntity.ok(toDto(post));
     }
 

--- a/src/main/java/com/openisle/model/Notification.java
+++ b/src/main/java/com/openisle/model/Notification.java
@@ -1,0 +1,52 @@
+package com.openisle.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+/**
+ * Entity representing a user notification.
+ */
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@Table(name = "notifications")
+public class Notification {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private NotificationType type;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
+
+    @Column
+    private Boolean approved;
+
+    @Column(nullable = false)
+    private boolean read = false;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/openisle/model/NotificationType.java
+++ b/src/main/java/com/openisle/model/NotificationType.java
@@ -1,0 +1,15 @@
+package com.openisle.model;
+
+/**
+ * Types of user notifications.
+ */
+public enum NotificationType {
+    /** Someone viewed your post */
+    POST_VIEWED,
+    /** Someone replied to your post or comment */
+    COMMENT_REPLY,
+    /** Someone reacted to your post or comment */
+    REACTION,
+    /** Your post under review was approved or rejected */
+    POST_REVIEWED
+}

--- a/src/main/java/com/openisle/model/PostStatus.java
+++ b/src/main/java/com/openisle/model/PostStatus.java
@@ -5,5 +5,6 @@ package com.openisle.model;
  */
 public enum PostStatus {
     PUBLISHED,
-    PENDING
+    PENDING,
+    REJECTED
 }

--- a/src/main/java/com/openisle/repository/NotificationRepository.java
+++ b/src/main/java/com/openisle/repository/NotificationRepository.java
@@ -1,0 +1,13 @@
+package com.openisle.repository;
+
+import com.openisle.model.Notification;
+import com.openisle.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+/** Repository for Notification entities. */
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    List<Notification> findByUserOrderByCreatedAtDesc(User user);
+    List<Notification> findByUserAndReadOrderByCreatedAtDesc(User user, boolean read);
+}

--- a/src/main/java/com/openisle/service/NotificationService.java
+++ b/src/main/java/com/openisle/service/NotificationService.java
@@ -1,0 +1,48 @@
+package com.openisle.service;
+
+import com.openisle.model.*;
+import com.openisle.repository.NotificationRepository;
+import com.openisle.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/** Service for creating and retrieving notifications. */
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+    private final NotificationRepository notificationRepository;
+    private final UserRepository userRepository;
+
+    public Notification createNotification(User user, NotificationType type, Post post, Comment comment, Boolean approved) {
+        Notification n = new Notification();
+        n.setUser(user);
+        n.setType(type);
+        n.setPost(post);
+        n.setComment(comment);
+        n.setApproved(approved);
+        return notificationRepository.save(n);
+    }
+
+    public List<Notification> listNotifications(String username, Boolean read) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+        if (read == null) {
+            return notificationRepository.findByUserOrderByCreatedAtDesc(user);
+        }
+        return notificationRepository.findByUserAndReadOrderByCreatedAtDesc(user, read);
+    }
+
+    public void markRead(String username, List<Long> ids) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+        List<Notification> notifs = notificationRepository.findAllById(ids);
+        for (Notification n : notifs) {
+            if (n.getUser().getId().equals(user.getId())) {
+                n.setRead(true);
+            }
+        }
+        notificationRepository.saveAll(notifs);
+    }
+}


### PR DESCRIPTION
## Summary
- add `Notification` entity and related enum
- support persistence via `NotificationRepository`
- implement `NotificationService` and `NotificationController`
- fire notifications on post views, replies, reactions and review results
- extend `PostStatus` with `REJECTED`
- add admin endpoint to reject posts

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6864f77ec014832babccd4e9516307ea