### PR TITLE
Fix Vditor init timing

### DIFF
--- a/open-isle-cli/src/components/CommentEditor.vue
+++ b/open-isle-cli/src/components/CommentEditor.vue
@@ -60,7 +60,10 @@ export default {
           'link',
           'image'
         ],
-        toolbarConfig: { pin: true }
+        toolbarConfig: { pin: true },
+        after() {
+          vditorInstance.value = this
+        }
       })
     })
 

--- a/open-isle-cli/src/components/PostEditor.vue
+++ b/open-isle-cli/src/components/PostEditor.vue
@@ -57,9 +57,11 @@ export default {
         cache: { enable: false },
         input(value) {
           emit('update:modelValue', value)
+        },
+        after() {
+          vditorInstance.value.setValue(props.modelValue)
         }
       })
-      vditorInstance.value.setValue(props.modelValue)
     })
 
     return {}


### PR DESCRIPTION
## Summary
- fix the editor initialization timing so that Vditor is fully ready before calling setValue

## Testing
- `npm run lint`
- `CI=true npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686791fdb8f4832bbeee113c9e54fbea