### PR TITLE
Make API base URL configurable

### DIFF
--- a/open-isle-cli/src/main.js
+++ b/open-isle-cli/src/main.js
@@ -3,4 +3,11 @@ import App from './App.vue'
 import router from './router'
 import './assets/global.css'
 
+// Configurable API domain and port
+export const API_DOMAIN =
+  process.env.VUE_APP_API_DOMAIN ||
+  `${window.location.protocol}//${window.location.hostname}`
+export const API_PORT = process.env.VUE_APP_API_PORT || window.location.port
+export const API_BASE_URL = API_PORT ? `${API_DOMAIN}:${API_PORT}` : API_DOMAIN
+
 createApp(App).use(router).mount('#app')

--- a/open-isle-cli/src/views/LoginPageView.vue
+++ b/open-isle-cli/src/views/LoginPageView.vue
@@ -48,6 +48,7 @@
 </template>
 
 <script>
+import { API_BASE_URL } from '../main'
 export default {
   name: 'LoginPageView',
   data() {
@@ -59,7 +60,7 @@ export default {
   methods: {
     async submitLogin() {
       try {
-        const res = await fetch('/api/auth/login', {
+        const res = await fetch(`${API_BASE_URL}/api/auth/login`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ username: this.username, password: this.password })

--- a/open-isle-cli/src/views/SignupPageView.vue
+++ b/open-isle-cli/src/views/SignupPageView.vue
@@ -82,6 +82,7 @@
 </template>
 
 <script>
+import { API_BASE_URL } from '../main'
 export default {
   name: 'SignupPageView',
 
@@ -98,7 +99,7 @@ export default {
   methods: {
     async sendVerification() {
       try {
-        const res = await fetch('/api/auth/register', {
+        const res = await fetch(`${API_BASE_URL}/api/auth/register`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
@@ -120,7 +121,7 @@ export default {
     },
     async verifyCode() {
       try {
-        const res = await fetch('/api/auth/verify', {
+        const res = await fetch(`${API_BASE_URL}/api/auth/verify`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ username: this.username, code: this.code })


### PR DESCRIPTION
## Summary
- configure frontend API domain and port in `main.js`
- use `API_BASE_URL` for login and signup requests

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*
- `mvn -q test` *(fails: mvn: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867abd2fb40832ba6c090f310b5e74f