### PR TITLE
Add token check API and client auth module

### DIFF
--- a/open-isle-cli/src/main.js
+++ b/open-isle-cli/src/main.js
@@ -5,6 +5,7 @@ import './assets/global.css'
 import Toast, { POSITION } from 'vue-toastification'
 import 'vue-toastification/dist/index.css'
 import { useToast } from 'vue-toastification'
+import { checkToken, clearToken } from './utils/auth'
 
 // Configurable API domain and port
 export const API_DOMAIN = 'http://127.0.0.1'
@@ -16,3 +17,9 @@ const app = createApp(App)
 app.use(router)
 app.use(Toast, { position: POSITION.TOP_RIGHT })
 app.mount('#app')
+
+checkToken().then(valid => {
+  if (!valid) {
+    clearToken()
+  }
+})

--- a/open-isle-cli/src/utils/auth.js
+++ b/open-isle-cli/src/utils/auth.js
@@ -1,0 +1,28 @@
+import { API_BASE_URL } from '../main'
+
+const TOKEN_KEY = 'token'
+
+export function getToken() {
+  return localStorage.getItem(TOKEN_KEY)
+}
+
+export function setToken(token) {
+  localStorage.setItem(TOKEN_KEY, token)
+}
+
+export function clearToken() {
+  localStorage.removeItem(TOKEN_KEY)
+}
+
+export async function checkToken() {
+  const token = getToken()
+  if (!token) return false
+  try {
+    const res = await fetch(`${API_BASE_URL}/api/auth/check`, {
+      headers: { Authorization: `Bearer ${token}` }
+    })
+    return res.ok
+  } catch (e) {
+    return false
+  }
+}

--- a/open-isle-cli/src/views/LoginPageView.vue
+++ b/open-isle-cli/src/views/LoginPageView.vue
@@ -56,6 +56,7 @@
 
 <script>
 import { API_BASE_URL, toast } from '../main'
+import { setToken } from '../utils/auth'
 export default {
   name: 'LoginPageView',
   data() {
@@ -77,7 +78,7 @@ export default {
         this.isWaitingForLogin = false
         const data = await res.json()
         if (res.ok && data.token) {
-          localStorage.setItem('token', data.token)
+          setToken(data.token)
           toast.success('登录成功')
           this.$router.push('/')
         } else {

--- a/src/main/java/com/openisle/controller/AuthController.java
+++ b/src/main/java/com/openisle/controller/AuthController.java
@@ -63,6 +63,11 @@ public class AuthController {
         }
     }
 
+    @GetMapping("/check")
+    public ResponseEntity<?> checkToken() {
+        return ResponseEntity.ok(Map.of("valid", true));
+    }
+
     @Data
     private static class RegisterRequest {
         private String username;


### PR DESCRIPTION
## Summary
- add auth utility for login state on the frontend
- check token validity on app startup
- store token using the new module in login page
- provide `/api/auth/check` endpoint to verify token

## Testing
- `npm run lint`
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868b89c31f0832b909b3a2292955f9a