### PR TITLE
Fix Google Auth compile error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,11 @@
       <version>2.2.0</version>
     </dependency>
     <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client-jackson2</artifactId>
+      <version>1.43.3</version>
+    </dependency>
+    <dependency>
       <groupId>com.qcloud</groupId>
       <artifactId>cos_api</artifactId>
       <version>5.6.247</version>


### PR DESCRIPTION
## Summary
- add missing Jackson module for Google auth token parsing

## Testing
- `mvn -q -DskipTests compile` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6868ea282178832b8ceb7e6d231178a3