### PR TITLE
Add small icon support for categories and tags

### DIFF
--- a/src/main/java/com/openisle/controller/CategoryController.java
+++ b/src/main/java/com/openisle/controller/CategoryController.java
@@ -19,13 +19,13 @@ public class CategoryController {
 
     @PostMapping
     public CategoryDto create(@RequestBody CategoryRequest req) {
-        Category c = categoryService.createCategory(req.getName(), req.getDescribe(), req.getIcon());
+        Category c = categoryService.createCategory(req.getName(), req.getDescribe(), req.getIcon(), req.getSmallIcon());
         return toDto(c);
     }
 
     @PutMapping("/{id}")
     public CategoryDto update(@PathVariable Long id, @RequestBody CategoryRequest req) {
-        Category c = categoryService.updateCategory(id, req.getName(), req.getDescribe(), req.getIcon());
+        Category c = categoryService.updateCategory(id, req.getName(), req.getDescribe(), req.getIcon(), req.getSmallIcon());
         return toDto(c);
     }
 
@@ -66,6 +66,7 @@ public class CategoryController {
         dto.setId(c.getId());
         dto.setName(c.getName());
         dto.setIcon(c.getIcon());
+        dto.setSmallIcon(c.getSmallIcon());
         dto.setDescribe(c.getDescribe());
         return dto;
     }
@@ -75,6 +76,7 @@ public class CategoryController {
         private String name;
         private String describe;
         private String icon;
+        private String smallIcon;
     }
 
     @Data
@@ -83,6 +85,7 @@ public class CategoryController {
         private String name;
         private String describe;
         private String icon;
+        private String smallIcon;
     }
 
     @Data

--- a/src/main/java/com/openisle/controller/TagController.java
+++ b/src/main/java/com/openisle/controller/TagController.java
@@ -19,13 +19,13 @@ public class TagController {
 
     @PostMapping
     public TagDto create(@RequestBody TagRequest req) {
-        Tag tag = tagService.createTag(req.getName(), req.getDescribe(), req.getIcon());
+        Tag tag = tagService.createTag(req.getName(), req.getDescribe(), req.getIcon(), req.getSmallIcon());
         return toDto(tag);
     }
 
     @PutMapping("/{id}")
     public TagDto update(@PathVariable Long id, @RequestBody TagRequest req) {
-        Tag tag = tagService.updateTag(id, req.getName(), req.getDescribe(), req.getIcon());
+        Tag tag = tagService.updateTag(id, req.getName(), req.getDescribe(), req.getIcon(), req.getSmallIcon());
         return toDto(tag);
     }
 
@@ -66,6 +66,7 @@ public class TagController {
         dto.setId(tag.getId());
         dto.setName(tag.getName());
         dto.setIcon(tag.getIcon());
+        dto.setSmallIcon(tag.getSmallIcon());
         dto.setDescribe(tag.getDescribe());
         return dto;
     }
@@ -75,6 +76,7 @@ public class TagController {
         private String name;
         private String describe;
         private String icon;
+        private String smallIcon;
     }
 
     @Data
@@ -83,6 +85,7 @@ public class TagController {
         private String name;
         private String describe;
         private String icon;
+        private String smallIcon;
     }
 
     @Data

--- a/src/main/java/com/openisle/model/Category.java
+++ b/src/main/java/com/openisle/model/Category.java
@@ -21,6 +21,9 @@ public class Category {
     @Column(nullable = false)
     private String icon;
 
+    @Column
+    private String smallIcon;
+
     @Column(nullable = false)
     private String describe;
 }

--- a/src/main/java/com/openisle/model/Tag.java
+++ b/src/main/java/com/openisle/model/Tag.java
@@ -21,6 +21,9 @@ public class Tag {
     @Column
     private String icon;
 
+    @Column
+    private String smallIcon;
+
     @Column(nullable = false)
     private String describe;
 }

--- a/src/main/java/com/openisle/service/CategoryService.java
+++ b/src/main/java/com/openisle/service/CategoryService.java
@@ -12,15 +12,16 @@ import java.util.List;
 public class CategoryService {
     private final CategoryRepository categoryRepository;
 
-    public Category createCategory(String name, String describe, String icon) {
+    public Category createCategory(String name, String describe, String icon, String smallIcon) {
         Category category = new Category();
         category.setName(name);
         category.setDescribe(describe);
         category.setIcon(icon);
+        category.setSmallIcon(smallIcon);
         return categoryRepository.save(category);
     }
 
-    public Category updateCategory(Long id, String name, String describe, String icon) {
+    public Category updateCategory(Long id, String name, String describe, String icon, String smallIcon) {
         Category category = categoryRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Category not found"));
         if (name != null) {
@@ -31,6 +32,9 @@ public class CategoryService {
         }
         if (icon != null) {
             category.setIcon(icon);
+        }
+        if (smallIcon != null) {
+            category.setSmallIcon(smallIcon);
         }
         return categoryRepository.save(category);
     }

--- a/src/main/java/com/openisle/service/TagService.java
+++ b/src/main/java/com/openisle/service/TagService.java
@@ -12,15 +12,16 @@ import java.util.List;
 public class TagService {
     private final TagRepository tagRepository;
 
-    public Tag createTag(String name, String describe, String icon) {
+    public Tag createTag(String name, String describe, String icon, String smallIcon) {
         Tag tag = new Tag();
         tag.setName(name);
         tag.setDescribe(describe);
         tag.setIcon(icon);
+        tag.setSmallIcon(smallIcon);
         return tagRepository.save(tag);
     }
 
-    public Tag updateTag(Long id, String name, String describe, String icon) {
+    public Tag updateTag(Long id, String name, String describe, String icon, String smallIcon) {
         Tag tag = tagRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Tag not found"));
         if (name != null) {
@@ -31,6 +32,9 @@ public class TagService {
         }
         if (icon != null) {
             tag.setIcon(icon);
+        }
+        if (smallIcon != null) {
+            tag.setSmallIcon(smallIcon);
         }
         return tagRepository.save(tag);
     }

--- a/src/test/java/com/openisle/controller/CategoryControllerTest.java
+++ b/src/test/java/com/openisle/controller/CategoryControllerTest.java
@@ -37,16 +37,18 @@ class CategoryControllerTest {
         c.setName("tech");
         c.setDescribe("d");
         c.setIcon("i");
-        Mockito.when(categoryService.createCategory(eq("tech"), eq("d"), eq("i"))).thenReturn(c);
+        c.setSmallIcon("s1");
+        Mockito.when(categoryService.createCategory(eq("tech"), eq("d"), eq("i"), eq("s1"))).thenReturn(c);
         Mockito.when(categoryService.getCategory(1L)).thenReturn(c);
 
         mockMvc.perform(post("/api/categories")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"name\":\"tech\",\"describe\":\"d\",\"icon\":\"i\"}"))
+                        .content("{\"name\":\"tech\",\"describe\":\"d\",\"icon\":\"i\",\"smallIcon\":\"s1\"}"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.name").value("tech"))
                 .andExpect(jsonPath("$.describe").value("d"))
-                .andExpect(jsonPath("$.icon").value("i"));
+                .andExpect(jsonPath("$.icon").value("i"))
+                .andExpect(jsonPath("$.smallIcon").value("s1"));
 
         mockMvc.perform(get("/api/categories/1"))
                 .andExpect(status().isOk())
@@ -60,13 +62,15 @@ class CategoryControllerTest {
         c.setName("life");
         c.setDescribe("d2");
         c.setIcon("i2");
+        c.setSmallIcon("s2");
         Mockito.when(categoryService.listCategories()).thenReturn(List.of(c));
 
         mockMvc.perform(get("/api/categories"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].name").value("life"))
                 .andExpect(jsonPath("$[0].describe").value("d2"))
-                .andExpect(jsonPath("$[0].icon").value("i2"));
+                .andExpect(jsonPath("$[0].icon").value("i2"))
+                .andExpect(jsonPath("$[0].smallIcon").value("s2"));
     }
 
     @Test
@@ -76,15 +80,17 @@ class CategoryControllerTest {
         c.setName("tech");
         c.setDescribe("d3");
         c.setIcon("i3");
-        Mockito.when(categoryService.updateCategory(eq(3L), eq("tech"), eq("d3"), eq("i3"))).thenReturn(c);
+        c.setSmallIcon("s3");
+        Mockito.when(categoryService.updateCategory(eq(3L), eq("tech"), eq("d3"), eq("i3"), eq("s3"))).thenReturn(c);
 
         mockMvc.perform(put("/api/categories/3")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"name\":\"tech\",\"describe\":\"d3\",\"icon\":\"i3\"}"))
+                        .content("{\"name\":\"tech\",\"describe\":\"d3\",\"icon\":\"i3\",\"smallIcon\":\"s3\"}"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(3))
                 .andExpect(jsonPath("$.name").value("tech"))
                 .andExpect(jsonPath("$.describe").value("d3"))
-                .andExpect(jsonPath("$.icon").value("i3"));
+                .andExpect(jsonPath("$.icon").value("i3"))
+                .andExpect(jsonPath("$.smallIcon").value("s3"));
     }
 }

--- a/src/test/java/com/openisle/controller/TagControllerTest.java
+++ b/src/test/java/com/openisle/controller/TagControllerTest.java
@@ -37,16 +37,18 @@ class TagControllerTest {
         t.setName("java");
         t.setDescribe("d");
         t.setIcon("i");
-        Mockito.when(tagService.createTag(eq("java"), eq("d"), eq("i"))).thenReturn(t);
+        t.setSmallIcon("s1");
+        Mockito.when(tagService.createTag(eq("java"), eq("d"), eq("i"), eq("s1"))).thenReturn(t);
         Mockito.when(tagService.getTag(1L)).thenReturn(t);
 
         mockMvc.perform(post("/api/tags")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"name\":\"java\",\"describe\":\"d\",\"icon\":\"i\"}"))
+                        .content("{\"name\":\"java\",\"describe\":\"d\",\"icon\":\"i\",\"smallIcon\":\"s1\"}"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.name").value("java"))
                 .andExpect(jsonPath("$.describe").value("d"))
-                .andExpect(jsonPath("$.icon").value("i"));
+                .andExpect(jsonPath("$.icon").value("i"))
+                .andExpect(jsonPath("$.smallIcon").value("s1"));
 
         mockMvc.perform(get("/api/tags/1"))
                 .andExpect(status().isOk())
@@ -60,6 +62,7 @@ class TagControllerTest {
         t.setName("spring");
         t.setDescribe("d2");
         t.setIcon("i2");
+        t.setSmallIcon("s2");
         Mockito.when(tagService.listTags()).thenReturn(List.of(t));
 
         mockMvc.perform(get("/api/tags"))
@@ -67,7 +70,8 @@ class TagControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].name").value("spring"))
                 .andExpect(jsonPath("$[0].describe").value("d2"))
-                .andExpect(jsonPath("$[0].icon").value("i2"));
+                .andExpect(jsonPath("$[0].icon").value("i2"))
+                .andExpect(jsonPath("$[0].smallIcon").value("s2"));
     }
 
     @Test
@@ -77,15 +81,17 @@ class TagControllerTest {
         t.setName("java");
         t.setDescribe("d3");
         t.setIcon("i3");
-        Mockito.when(tagService.updateTag(eq(3L), eq("java"), eq("d3"), eq("i3"))).thenReturn(t);
+        t.setSmallIcon("s3");
+        Mockito.when(tagService.updateTag(eq(3L), eq("java"), eq("d3"), eq("i3"), eq("s3"))).thenReturn(t);
 
         mockMvc.perform(put("/api/tags/3")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"name\":\"java\",\"describe\":\"d3\",\"icon\":\"i3\"}"))
+                        .content("{\"name\":\"java\",\"describe\":\"d3\",\"icon\":\"i3\",\"smallIcon\":\"s3\"}"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(3))
                 .andExpect(jsonPath("$.name").value("java"))
                 .andExpect(jsonPath("$.describe").value("d3"))
-                .andExpect(jsonPath("$.icon").value("i3"));
+                .andExpect(jsonPath("$.icon").value("i3"))
+                .andExpect(jsonPath("$.smallIcon").value("s3"));
     }
 }


### PR DESCRIPTION
## Summary
- allow `Category` and `Tag` entities to store optional `smallIcon`
- expose `smallIcon` in controllers and services
- test the new fields in controller tests

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM because repo.maven.apache.org is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6868ec7b5e50832b9bf0c81286b96b2d