### PR TITLE
Add dropdown components for post creation

### DIFF
--- a/open-isle-cli/src/components/CategorySelect.vue
+++ b/open-isle-cli/src/components/CategorySelect.vue
@@ -1,0 +1,32 @@
+<template>
+  <Dropdown v-model="selected" :fetch-options="fetchCategories" placeholder="选择分类" />
+</template>
+
+<script>
+import { computed } from 'vue'
+import { API_BASE_URL } from '../main'
+import Dropdown from './Dropdown.vue'
+
+export default {
+  name: 'CategorySelect',
+  components: { Dropdown },
+  props: {
+    modelValue: { type: [String, Number], default: '' }
+  },
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    const fetchCategories = async () => {
+      const res = await fetch(`${API_BASE_URL}/api/categories`)
+      if (!res.ok) return []
+      return await res.json()
+    }
+
+    const selected = computed({
+      get: () => props.modelValue,
+      set: v => emit('update:modelValue', v)
+    })
+
+    return { fetchCategories, selected }
+  }
+}
+</script>

--- a/open-isle-cli/src/components/Dropdown.vue
+++ b/open-isle-cli/src/components/Dropdown.vue
@@ -1,0 +1,170 @@
+<template>
+  <div class="dropdown" ref="wrapper">
+    <div class="dropdown-display" @click="toggle">
+      <template v-if="multiple">
+        <span v-if="selectedLabels.length" class="selected-text">{{ selectedLabels.join(', ') }}</span>
+        <span v-else class="placeholder">{{ placeholder }}</span>
+      </template>
+      <template v-else>
+        <span v-if="selectedLabels.length" class="selected-text">{{ selectedLabels[0] }}</span>
+        <span v-else class="placeholder">{{ placeholder }}</span>
+      </template>
+      <i class="fas fa-caret-down dropdown-caret"></i>
+    </div>
+    <div v-if="open" class="dropdown-menu">
+      <div class="dropdown-search">
+        <i class="fas fa-search search-icon"></i>
+        <input type="text" v-model="search" placeholder="搜索" />
+      </div>
+      <div class="dropdown-option" v-for="o in filteredOptions" :key="o.id" @click="select(o.id)">
+        <img v-if="o.icon" :src="o.icon" class="option-icon" />
+        <span>{{ o.name }}</span>
+        <input v-if="multiple" type="checkbox" :checked="modelValue.includes(o.id)" @change.prevent />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue'
+
+export default {
+  name: 'BaseDropdown',
+  props: {
+    modelValue: { type: [Array, String, Number], default: () => [] },
+    placeholder: { type: String, default: '请选择' },
+    multiple: { type: Boolean, default: false },
+    fetchOptions: { type: Function, required: true }
+  },
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    const open = ref(false)
+    const search = ref('')
+    const options = ref([])
+    const loaded = ref(false)
+    const wrapper = ref(null)
+
+    const toggle = () => {
+      open.value = !open.value
+    }
+
+    const close = () => {
+      open.value = false
+    }
+
+    const select = id => {
+      if (props.multiple) {
+        const arr = Array.isArray(props.modelValue) ? [...props.modelValue] : []
+        const idx = arr.indexOf(id)
+        if (idx > -1) {
+          arr.splice(idx, 1)
+        } else {
+          arr.push(id)
+        }
+        emit('update:modelValue', arr)
+      } else {
+        emit('update:modelValue', id)
+        close()
+      }
+    }
+
+    const filteredOptions = computed(() => {
+      if (!search.value) return options.value
+      return options.value.filter(o => o.name.toLowerCase().includes(search.value.toLowerCase()))
+    })
+
+    const clickOutside = e => {
+      if (wrapper.value && !wrapper.value.contains(e.target)) {
+        close()
+      }
+    }
+
+    watch(open, async val => {
+      if (val && !loaded.value) {
+        try {
+          const res = await props.fetchOptions()
+          options.value = Array.isArray(res) ? res : []
+          loaded.value = true
+        } catch {
+          options.value = []
+        }
+      }
+    })
+
+    onMounted(() => {
+      document.addEventListener('click', clickOutside)
+    })
+
+    onBeforeUnmount(() => {
+      document.removeEventListener('click', clickOutside)
+    })
+
+    const selectedLabels = computed(() => {
+      if (props.multiple) {
+        return options.value.filter(o => (props.modelValue || []).includes(o.id)).map(o => o.name)
+      }
+      const match = options.value.find(o => o.id === props.modelValue)
+      return match ? [match.name] : []
+    })
+
+    return { open, toggle, select, search, filteredOptions, wrapper, selectedLabels }
+  }
+}
+</script>
+
+<style scoped>
+.dropdown {
+  position: relative;
+  width: 200px;
+}
+.dropdown-display {
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  padding: 5px 10px;
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.placeholder {
+  color: gray;
+}
+.dropdown-menu {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  background: white;
+  border: 1px solid #ccc;
+  z-index: 10;
+  max-height: 200px;
+  overflow-y: auto;
+}
+.dropdown-search {
+  display: flex;
+  align-items: center;
+  padding: 5px;
+  border-bottom: 1px solid #eee;
+}
+.dropdown-search input {
+  flex: 1;
+  border: none;
+  outline: none;
+  margin-left: 5px;
+}
+.dropdown-option {
+  display: flex;
+  align-items: center;
+  padding: 5px 10px;
+  gap: 5px;
+  cursor: pointer;
+}
+.dropdown-option:hover {
+  background-color: #f5f5f5;
+}
+.option-icon {
+  width: 16px;
+  height: 16px;
+}
+</style>
+

--- a/open-isle-cli/src/components/TagSelect.vue
+++ b/open-isle-cli/src/components/TagSelect.vue
@@ -1,0 +1,32 @@
+<template>
+  <Dropdown v-model="selected" :fetch-options="fetchTags" multiple placeholder="选择标签" />
+</template>
+
+<script>
+import { computed } from 'vue'
+import { API_BASE_URL } from '../main'
+import Dropdown from './Dropdown.vue'
+
+export default {
+  name: 'TagSelect',
+  components: { Dropdown },
+  props: {
+    modelValue: { type: Array, default: () => [] }
+  },
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    const fetchTags = async () => {
+      const res = await fetch(`${API_BASE_URL}/api/tags`)
+      if (!res.ok) return []
+      return await res.json()
+    }
+
+    const selected = computed({
+      get: () => props.modelValue,
+      set: v => emit('update:modelValue', v)
+    })
+
+    return { fetchTags, selected }
+  }
+}
+</script>

--- a/open-isle-cli/src/views/NewPostPageView.vue
+++ b/open-isle-cli/src/views/NewPostPageView.vue
@@ -6,15 +6,8 @@
         <PostEditor v-model="content" />
       </div>
       <div class="post-options">
-        <select class="category-select" v-model="selectedCategory">
-          <option disabled value="">请选择分类</option>
-          <option v-for="c in categories" :key="c.id" :value="c.id">{{ c.name }}</option>
-        </select>
-        <div class="tag-select">
-          <label class="tag-item" v-for="t in tags" :key="t.id">
-            <input type="checkbox" :value="t.id" v-model="selectedTags" /> {{ t.name }}
-          </label>
-        </div>
+        <CategorySelect v-model="selectedCategory" />
+        <TagSelect v-model="selectedTags" />
       </div>
       <div class="post-submit" @click="submitPost">发布</div>
     </div>
@@ -24,22 +17,15 @@
 <script>
 import { ref } from 'vue'
 import PostEditor from '../components/PostEditor.vue'
+import CategorySelect from '../components/CategorySelect.vue'
+import TagSelect from '../components/TagSelect.vue'
 
 export default {
   name: 'NewPostPageView',
-  components: { PostEditor },
+  components: { PostEditor, CategorySelect, TagSelect },
   setup() {
     const title = ref('')
     const content = ref('')
-    const categories = ref([
-      { id: 1, name: '闲聊' },
-      { id: 2, name: '技术' }
-    ])
-    const tags = ref([
-      { id: 1, name: 'Java' },
-      { id: 2, name: 'Python' },
-      { id: 3, name: 'AI' }
-    ])
     const selectedCategory = ref('')
     const selectedTags = ref([])
     const submitPost = () => {
@@ -49,7 +35,7 @@ export default {
       console.log('tags:', selectedTags.value)
       // 在此处可以调用接口提交帖子
     }
-    return { title, content, categories, tags, selectedCategory, selectedTags, submitPost }
+    return { title, content, selectedCategory, selectedTags, submitPost }
   }
 }
 </script>
@@ -97,21 +83,5 @@ export default {
   gap: 10px;
 }
 
-.category-select {
-  padding: 5px 10px;
-  border-radius: 5px;
-}
-
-.tag-select {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-}
-
-.tag-item {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-}
 </style>
 


### PR DESCRIPTION
## Summary
- add a generic `BaseDropdown` component
- implement `TagSelect` and `CategorySelect` on top of it
- update `NewPostPageView` to use the new dropdowns

## Testing
- `npm run lint`
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6868ee59e2c8832b96f3fcf81fca39c5