### PR TITLE
Limit tags and integrate post publish

### DIFF
--- a/open-isle-cli/src/components/TagSelect.vue
+++ b/open-isle-cli/src/components/TagSelect.vue
@@ -4,7 +4,7 @@
 
 <script>
 import { computed } from 'vue'
-import { API_BASE_URL } from '../main'
+import { API_BASE_URL, toast } from '../main'
 import Dropdown from './Dropdown.vue'
 
 export default {
@@ -23,7 +23,13 @@ export default {
 
     const selected = computed({
       get: () => props.modelValue,
-      set: v => emit('update:modelValue', v)
+      set: v => {
+        if (Array.isArray(v) && v.length > 2) {
+          toast.error('最多选择两个标签')
+          return
+        }
+        emit('update:modelValue', v)
+      }
     })
 
     return { fetchTags, selected }

--- a/src/main/java/com/openisle/service/PostService.java
+++ b/src/main/java/com/openisle/service/PostService.java
@@ -53,6 +53,9 @@ public class PostService {
         if (tagIds == null || tagIds.isEmpty()) {
             throw new IllegalArgumentException("At least one tag required");
         }
+        if (tagIds.size() > 2) {
+            throw new IllegalArgumentException("At most two tags allowed");
+        }
         User author = userRepository.findByUsername(username)
                 .orElseThrow(() -> new IllegalArgumentException("User not found"));
         Category category = categoryRepository.findById(categoryId)


### PR DESCRIPTION
## Summary
- enforce two-tag limit when creating posts on backend
- prevent selecting more than two tags in UI
- hook up publish API with validations on New Post page

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_686964acadd4832bbc96ae9574536e8b