### PR TITLE
Fix 400 error when fetching draft

### DIFF
--- a/src/main/java/com/openisle/service/DraftService.java
+++ b/src/main/java/com/openisle/service/DraftService.java
@@ -8,6 +8,7 @@ import com.openisle.repository.CategoryRepository;
 import com.openisle.repository.DraftRepository;
 import com.openisle.repository.TagRepository;
 import com.openisle.repository.UserRepository;
+import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -24,6 +25,7 @@ public class DraftService {
     private final CategoryRepository categoryRepository;
     private final TagRepository tagRepository;
 
+    @Transactional
     public Draft saveDraft(String username, Long categoryId, String title, String content, List<Long> tagIds) {
         User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> new IllegalArgumentException("User not found"));
@@ -46,11 +48,13 @@ public class DraftService {
         return draftRepository.save(draft);
     }
 
+    @Transactional(readOnly = true)
     public Optional<Draft> getDraft(String username) {
         return userRepository.findByUsername(username)
                 .flatMap(draftRepository::findByAuthor);
     }
 
+    @Transactional
     public void deleteDraft(String username) {
         userRepository.findByUsername(username)
                 .ifPresent(draftRepository::deleteByAuthor);


### PR DESCRIPTION
## Summary
- make draft service transactional so lazy JPA relations load correctly

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6869e060a56c832ba1f7fe95703cf7c5