### PR TITLE
Fix editor draft loading

### DIFF
--- a/open-isle-cli/src/components/PostEditor.vue
+++ b/open-isle-cli/src/components/PostEditor.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script>
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, watch } from 'vue'
 import Vditor from 'vditor'
 import 'vditor/dist/index.css'
 
@@ -24,6 +24,15 @@ export default {
   },
   setup(props, { emit }) {
     const vditorInstance = ref(null)
+
+    watch(
+      () => props.modelValue,
+      val => {
+        if (vditorInstance.value && vditorInstance.value.getValue() !== val) {
+          vditorInstance.value.setValue(val)
+        }
+      }
+    )
 
     onMounted(() => {
       vditorInstance.value = new Vditor(props.editorId, {

--- a/open-isle-cli/src/views/NewPostPageView.vue
+++ b/open-isle-cli/src/views/NewPostPageView.vue
@@ -61,7 +61,9 @@ export default {
 
           toast.success('草稿已加载')
         }
-      } catch (e) {}
+      } catch (e) {
+        console.error(e)
+      }
     }
 
     onMounted(loadDraft)


### PR DESCRIPTION
## Summary
- watch for new content in PostEditor and update Vditor
- log error when loading draft fails

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6869e6676090832ba6f3049a58fe1f3c