### PR TITLE
Return full category and tag objects in post API

### DIFF
--- a/src/main/java/com/openisle/controller/AdminPostController.java
+++ b/src/main/java/com/openisle/controller/AdminPostController.java
@@ -43,8 +43,18 @@ public class AdminPostController {
         dto.setContent(post.getContent());
         dto.setCreatedAt(post.getCreatedAt());
         dto.setAuthor(post.getAuthor().getUsername());
-        dto.setCategory(post.getCategory().getName());
+        dto.setCategory(toCategoryDto(post.getCategory()));
         dto.setViews(post.getViews());
+        return dto;
+    }
+
+    private CategoryDto toCategoryDto(com.openisle.model.Category c) {
+        CategoryDto dto = new CategoryDto();
+        dto.setId(c.getId());
+        dto.setName(c.getName());
+        dto.setDescription(c.getDescription());
+        dto.setIcon(c.getIcon());
+        dto.setSmallIcon(c.getSmallIcon());
         return dto;
     }
 
@@ -55,7 +65,16 @@ public class AdminPostController {
         private String content;
         private LocalDateTime createdAt;
         private String author;
-        private String category;
+        private CategoryDto category;
         private long views;
+    }
+
+    @Data
+    private static class CategoryDto {
+        private Long id;
+        private String name;
+        private String description;
+        private String icon;
+        private String smallIcon;
     }
 }

--- a/src/main/java/com/openisle/controller/PostController.java
+++ b/src/main/java/com/openisle/controller/PostController.java
@@ -84,8 +84,8 @@ public class PostController {
         dto.setContent(post.getContent());
         dto.setCreatedAt(post.getCreatedAt());
         dto.setAuthor(post.getAuthor().getUsername());
-        dto.setCategory(post.getCategory().getName());
-        dto.setTags(post.getTags().stream().map(com.openisle.model.Tag::getName).collect(Collectors.toList()));
+        dto.setCategory(toCategoryDto(post.getCategory()));
+        dto.setTags(post.getTags().stream().map(this::toTagDto).collect(Collectors.toList()));
         dto.setViews(post.getViews());
 
         List<ReactionDto> reactions = reactionService.getReactionsForPost(post.getId())
@@ -142,6 +142,26 @@ public class PostController {
         return dto;
     }
 
+    private CategoryDto toCategoryDto(com.openisle.model.Category category) {
+        CategoryDto dto = new CategoryDto();
+        dto.setId(category.getId());
+        dto.setName(category.getName());
+        dto.setDescription(category.getDescription());
+        dto.setIcon(category.getIcon());
+        dto.setSmallIcon(category.getSmallIcon());
+        return dto;
+    }
+
+    private TagDto toTagDto(com.openisle.model.Tag tag) {
+        TagDto dto = new TagDto();
+        dto.setId(tag.getId());
+        dto.setName(tag.getName());
+        dto.setDescription(tag.getDescription());
+        dto.setIcon(tag.getIcon());
+        dto.setSmallIcon(tag.getSmallIcon());
+        return dto;
+    }
+
     @Data
     private static class PostRequest {
         private Long categoryId;
@@ -158,11 +178,29 @@ public class PostController {
         private String content;
         private LocalDateTime createdAt;
         private String author;
-        private String category;
-        private java.util.List<String> tags;
+        private CategoryDto category;
+        private java.util.List<TagDto> tags;
         private long views;
         private List<CommentDto> comments;
         private List<ReactionDto> reactions;
+    }
+
+    @Data
+    private static class CategoryDto {
+        private Long id;
+        private String name;
+        private String description;
+        private String icon;
+        private String smallIcon;
+    }
+
+    @Data
+    private static class TagDto {
+        private Long id;
+        private String name;
+        private String description;
+        private String icon;
+        private String smallIcon;
     }
 
     @Data


### PR DESCRIPTION
## Summary
- extend post responses with detailed category and tag objects
- update admin post view to expose category details

## Testing
- `mvn test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686a6b79ec98832b9e1c55336afc8365