### PR TITLE
Fix comment editor vditor instance

### DIFF
--- a/open-isle-cli/src/components/CommentEditor.vue
+++ b/open-isle-cli/src/components/CommentEditor.vue
@@ -60,10 +60,7 @@ export default {
           'link',
           'image'
         ],
-        toolbarConfig: { pin: true },
-        after() {
-          vditorInstance.value = this
-        }
+        toolbarConfig: { pin: true }
       })
     })
 


### PR DESCRIPTION
## Summary
- fix CommentEditor `after` callback so Vditor instance persists

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686a734ed51c832b95c164edfdffd903