### PR TITLE
Add disabled and loading state to comment editor

### DIFF
--- a/open-isle-cli/src/components/CommentItem.vue
+++ b/open-isle-cli/src/components/CommentItem.vue
@@ -40,7 +40,7 @@
           </div>
         </div>
       </div>
-      <CommentEditor v-if="showEditor" @submit="submitReply" />
+      <CommentEditor v-if="showEditor" @submit="submitReply" :loading="isWaitingForReply" />
       <div v-if="comment.reply && comment.reply.length" class="reply-toggle" @click="toggleReplies">
         {{ comment.reply.length }}条回复
       </div>
@@ -77,6 +77,7 @@ const CommentItem = {
   setup(props) {
     const showReplies = ref(false)
     const showEditor = ref(false)
+    const isWaitingForReply = ref(false)
     const toggleReplies = () => {
       showReplies.value = !showReplies.value
     }
@@ -85,9 +86,11 @@ const CommentItem = {
     }
     const submitReply = async (text) => {
       if (!text.trim()) return
+      isWaitingForReply.value = true
       const token = getToken()
       if (!token) {
         toast.error('请先登录')
+        isWaitingForReply.value = false
         return
       }
       try {
@@ -120,13 +123,15 @@ const CommentItem = {
         }
       } catch (e) {
         toast.error('回复失败')
+      } finally {
+        isWaitingForReply.value = false
       }
     }
     const copyCommentLink = () => {
       const link = `${location.origin}${location.pathname}#comment-${props.comment.id}`
       navigator.clipboard.writeText(link)
     }
-    return { showReplies, toggleReplies, showEditor, toggleEditor, submitReply, copyCommentLink, renderMarkdown }
+    return { showReplies, toggleReplies, showEditor, toggleEditor, submitReply, copyCommentLink, renderMarkdown, isWaitingForReply }
   }
 }
 CommentItem.components = { CommentItem, CommentEditor }

--- a/open-isle-cli/src/views/PostPageView.vue
+++ b/open-isle-cli/src/views/PostPageView.vue
@@ -65,7 +65,7 @@
         </div>
       </div>
 
-      <CommentEditor @submit="postComment" />
+      <CommentEditor @submit="postComment" :loading="isWaitingPostingComment" />
 
       <div class="comments-container">
         <CommentItem v-for="comment in comments" :key="comment.id" :comment="comment" :level="0" ref="postItems" />
@@ -112,6 +112,7 @@ export default {
     const tags = ref([])
     const comments = ref([])
     const isWaitingFetchingPost = ref(false);
+    const isWaitingPostingComment = ref(false);
     const postTime = ref('')
     const postItems = ref([])
     const mainContainer = ref(null)
@@ -169,9 +170,11 @@ export default {
 
     const postComment = async (text) => {
       if (!text.trim()) return
+      isWaitingPostingComment.value = true
       const token = getToken()
       if (!token) {
         toast.error('请先登录')
+        isWaitingPostingComment.value = false
         return
       }
       try {
@@ -188,6 +191,8 @@ export default {
         }
       } catch (e) {
         toast.error('评论失败')
+      } finally {
+        isWaitingPostingComment.value = false
       }
     }
 
@@ -227,7 +232,8 @@ export default {
       onScroll: updateCurrentIndex,
       copyPostLink,
       renderMarkdown,
-      isWaitingFetchingPost
+      isWaitingFetchingPost,
+      isWaitingPostingComment
     }
   }
 }


### PR DESCRIPTION
## Summary
- disable comment submit button when empty or loading
- show a spinner and disable interactions while submitting
- wire up new loading prop in comment list and post page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686a797a59f0832b8702616cb3f33e46