### PR TITLE
Add author details in post and comment APIs

### DIFF
--- a/src/main/java/com/openisle/controller/CommentController.java
+++ b/src/main/java/com/openisle/controller/CommentController.java
@@ -70,7 +70,15 @@ public class CommentController {
         dto.setId(comment.getId());
         dto.setContent(comment.getContent());
         dto.setCreatedAt(comment.getCreatedAt());
-        dto.setAuthor(comment.getAuthor().getUsername());
+        dto.setAuthor(toAuthorDto(comment.getAuthor()));
+        return dto;
+    }
+
+    private AuthorDto toAuthorDto(com.openisle.model.User user) {
+        AuthorDto dto = new AuthorDto();
+        dto.setId(user.getId());
+        dto.setUsername(user.getUsername());
+        dto.setAvatar(user.getAvatar());
         return dto;
     }
 
@@ -85,7 +93,14 @@ public class CommentController {
         private Long id;
         private String content;
         private LocalDateTime createdAt;
-        private String author;
+        private AuthorDto author;
         private List<CommentDto> replies;
+    }
+
+    @Data
+    private static class AuthorDto {
+        private Long id;
+        private String username;
+        private String avatar;
     }
 }

--- a/src/main/java/com/openisle/controller/PostController.java
+++ b/src/main/java/com/openisle/controller/PostController.java
@@ -83,7 +83,7 @@ public class PostController {
         dto.setTitle(post.getTitle());
         dto.setContent(post.getContent());
         dto.setCreatedAt(post.getCreatedAt());
-        dto.setAuthor(post.getAuthor().getUsername());
+        dto.setAuthor(toAuthorDto(post.getAuthor()));
         dto.setCategory(toCategoryDto(post.getCategory()));
         dto.setTags(post.getTags().stream().map(this::toTagDto).collect(Collectors.toList()));
         dto.setViews(post.getViews());
@@ -124,7 +124,7 @@ public class PostController {
         dto.setId(comment.getId());
         dto.setContent(comment.getContent());
         dto.setCreatedAt(comment.getCreatedAt());
-        dto.setAuthor(comment.getAuthor().getUsername());
+        dto.setAuthor(toAuthorDto(comment.getAuthor()));
         return dto;
     }
 
@@ -162,6 +162,14 @@ public class PostController {
         return dto;
     }
 
+    private AuthorDto toAuthorDto(com.openisle.model.User user) {
+        AuthorDto dto = new AuthorDto();
+        dto.setId(user.getId());
+        dto.setUsername(user.getUsername());
+        dto.setAvatar(user.getAvatar());
+        return dto;
+    }
+
     @Data
     private static class PostRequest {
         private Long categoryId;
@@ -177,7 +185,7 @@ public class PostController {
         private String title;
         private String content;
         private LocalDateTime createdAt;
-        private String author;
+        private AuthorDto author;
         private CategoryDto category;
         private java.util.List<TagDto> tags;
         private long views;
@@ -204,11 +212,18 @@ public class PostController {
     }
 
     @Data
+    private static class AuthorDto {
+        private Long id;
+        private String username;
+        private String avatar;
+    }
+
+    @Data
     private static class CommentDto {
         private Long id;
         private String content;
         private LocalDateTime createdAt;
-        private String author;
+        private AuthorDto author;
         private List<CommentDto> replies;
         private List<ReactionDto> reactions;
     }


### PR DESCRIPTION
## Summary
- return author info instead of plain name on post and comment APIs

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686ab094a6d0832b8f7d25f96390d531