### PR TITLE
Implement toast on copy and wait comment anchor

### DIFF
--- a/open-isle-cli/src/components/CommentItem.vue
+++ b/open-isle-cli/src/components/CommentItem.vue
@@ -130,7 +130,9 @@ const CommentItem = {
     }
     const copyCommentLink = () => {
       const link = `${location.origin}${location.pathname}#comment-${props.comment.id}`
-      navigator.clipboard.writeText(link)
+      navigator.clipboard.writeText(link).then(() => {
+        toast.success('已复制')
+      })
     }
     return { showReplies, toggleReplies, showEditor, toggleEditor, submitReply, copyCommentLink, renderMarkdown, isWaitingForReply }
   }

--- a/open-isle-cli/src/views/PostPageView.vue
+++ b/open-isle-cli/src/views/PostPageView.vue
@@ -89,7 +89,7 @@
 </template>
 
 <script>
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, nextTick } from 'vue'
 import { useRoute } from 'vue-router'
 import CommentItem from '../components/CommentItem.vue'
 import CommentEditor from '../components/CommentEditor.vue'
@@ -200,15 +200,16 @@ export default {
     }
 
     const copyPostLink = () => {
-      navigator.clipboard.writeText(location.href.split('#')[0])
+      navigator.clipboard.writeText(location.href.split('#')[0]).then(() => {
+        toast.success('已复制')
+      })
     }
 
-    onMounted(() => {
-      fetchPost()
-      updateCurrentIndex()
+    const jumpToHashComment = async () => {
       const hash = location.hash
       if (hash.startsWith('#comment-')) {
         const id = hash.substring('#comment-'.length)
+        await nextTick()
         const el = document.getElementById('comment-' + id)
         if (el && mainContainer.value) {
           mainContainer.value.scrollTo({ top: el.offsetTop, behavior: 'instant' })
@@ -216,6 +217,12 @@ export default {
           setTimeout(() => el.classList.remove('comment-highlight'), 2000)
         }
       }
+    }
+
+    onMounted(async () => {
+      await fetchPost()
+      updateCurrentIndex()
+      await jumpToHashComment()
     })
 
     return {


### PR DESCRIPTION
## Summary
- show toast when copying comment links
- show toast when copying post links
- jump to comment only after post content is loaded

## Testing
- `npm install`
- `npm run lint`
- `which mvn || echo 'mvn not found'`

------
https://chatgpt.com/codex/tasks/task_e_686b567c50a0832b994e7169b2161124