### PR TITLE
Fix nested comment links

### DIFF
--- a/open-isle-cli/src/components/CommentItem.vue
+++ b/open-isle-cli/src/components/CommentItem.vue
@@ -50,6 +50,7 @@
           :key="r.id"
           :comment="r"
           :level="level + 1"
+          :default-show-replies="r.openReplies"
         />
       </div>
     </div>
@@ -72,10 +73,14 @@ const CommentItem = {
     level: {
       type: Number,
       default: 0
+    },
+    defaultShowReplies: {
+      type: Boolean,
+      default: false
     }
   },
   setup(props) {
-    const showReplies = ref(false)
+    const showReplies = ref(props.defaultShowReplies)
     const showEditor = ref(false)
     const isWaitingForReply = ref(false)
     const toggleReplies = () => {
@@ -114,8 +119,10 @@ const CommentItem = {
               time: new Date(r.createdAt).toLocaleDateString('zh-CN', { month: 'numeric', day: 'numeric' }),
               avatar: r.avatar,
               text: r.content,
-              reply: []
-            }))
+              reply: [],
+              openReplies: false
+            })),
+            openReplies: false
           })
           showEditor.value = false
           toast.success('回复成功')


### PR DESCRIPTION
## Summary
- keep replies collapsed state in comment data so nested links open correctly
- expand comment threads when navigating to hash URLs
- set initial reply state from new `defaultShowReplies`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686b59edb0f4832b80a70716be10e604