### PR TITLE
Fix nested comment link expansion

### DIFF
--- a/open-isle-cli/src/components/CommentItem.vue
+++ b/open-isle-cli/src/components/CommentItem.vue
@@ -58,7 +58,7 @@
 </template>
 
 <script>
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 import CommentEditor from './CommentEditor.vue'
 import { renderMarkdown } from '../utils/markdown'
 import { API_BASE_URL, toast } from '../main'
@@ -81,6 +81,12 @@ const CommentItem = {
   },
   setup(props) {
     const showReplies = ref(props.defaultShowReplies)
+    watch(
+      () => props.defaultShowReplies,
+      (val) => {
+        showReplies.value = val
+      }
+    )
     const showEditor = ref(false)
     const isWaitingForReply = ref(false)
     const toggleReplies = () => {


### PR DESCRIPTION
## Summary
- ensure comment replies expand when changing `defaultShowReplies`

## Testing
- `npm --prefix open-isle-cli run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686b5e1e59dc832b90b293517b19c626