### PR TITLE
fix: restore scroll index tracking

### DIFF
--- a/open-isle-cli/src/views/PostPageView.vue
+++ b/open-isle-cli/src/views/PostPageView.vue
@@ -75,6 +75,7 @@
               :comment="item"
               :level="level + 1"
               :default-show-replies="item.openReplies"
+              ref="postItems"
             />
           </template>
         </BaseTimeline>


### PR DESCRIPTION
## Summary
- add comment refs so the custom scroller updates again

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686b80e95580832b89e4bc7fb81fda3f