### PR TITLE
Add user settings page and admin config API

### DIFF
--- a/open-isle-cli/src/views/SettingsPageView.vue
+++ b/open-isle-cli/src/views/SettingsPageView.vue
@@ -1,18 +1,165 @@
 <template>
   <div class="settings-page">
     <h2>设置</h2>
-    <p>这里是设置页面。</p>
+    <div class="profile-section">
+      <div class="avatar-row">
+        <img :src="avatar" class="avatar-preview" />
+        <input type="file" @change="onAvatarChange" />
+      </div>
+      <div class="form-row">
+        <label>用户名</label>
+        <input v-model="username" type="text" />
+      </div>
+      <div class="form-row">
+        <label>自我介绍</label>
+        <textarea v-model="introduction" rows="3" />
+      </div>
+    </div>
+    <div v-if="role === 'ADMIN'" class="admin-section">
+      <h3>管理员设置</h3>
+      <div class="form-row">
+        <label>发布规则</label>
+        <select v-model="publishMode">
+          <option value="DIRECT">直接发布</option>
+          <option value="REVIEW">审核后发布</option>
+        </select>
+      </div>
+      <div class="form-row">
+        <label>密码强度</label>
+        <select v-model="passwordStrength">
+          <option value="LOW">低</option>
+          <option value="MEDIUM">中</option>
+          <option value="HIGH">高</option>
+        </select>
+      </div>
+    </div>
+    <div class="buttons">
+      <button @click="cancel">取消</button>
+      <button @click="save">保存</button>
+    </div>
   </div>
 </template>
 
 <script>
+import { API_BASE_URL, toast } from '../main'
+import { getToken, fetchCurrentUser } from '../utils/auth'
 export default {
-  name: 'SettingsPageView'
+  name: 'SettingsPageView',
+  data() {
+    return {
+      username: '',
+      introduction: '',
+      avatar: '',
+      avatarFile: null,
+      role: '',
+      publishMode: 'DIRECT',
+      passwordStrength: 'LOW'
+    }
+  },
+  async mounted() {
+    const user = await fetchCurrentUser()
+    if (user) {
+      this.username = user.username
+      this.introduction = user.introduction || ''
+      this.avatar = user.avatar
+      this.role = user.role
+      if (this.role === 'ADMIN') {
+        this.loadAdminConfig()
+      }
+    }
+  },
+  methods: {
+    onAvatarChange(e) {
+      this.avatarFile = e.target.files[0]
+    },
+    async loadAdminConfig() {
+      try {
+        const token = getToken()
+        const res = await fetch(`${API_BASE_URL}/api/admin/config`, {
+          headers: { Authorization: `Bearer ${token}` }
+        })
+        if (res.ok) {
+          const data = await res.json()
+          this.publishMode = data.publishMode
+          this.passwordStrength = data.passwordStrength
+        }
+      } catch (e) {
+        // ignore
+      }
+    },
+    async save() {
+      const token = getToken()
+      if (this.avatarFile) {
+        const form = new FormData()
+        form.append('file', this.avatarFile)
+        const res = await fetch(`${API_BASE_URL}/api/users/me/avatar`, {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${token}` },
+          body: form
+        })
+        const data = await res.json()
+        if (res.ok) {
+          this.avatar = data.url
+        } else {
+          toast.error(data.error || '上传失败')
+          return
+        }
+      }
+      const res = await fetch(`${API_BASE_URL}/api/users/me`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ username: this.username, introduction: this.introduction })
+      })
+      if (!res.ok) {
+        const data = await res.json()
+        toast.error(data.error || '保存失败')
+        return
+      }
+      if (this.role === 'ADMIN') {
+        await fetch(`${API_BASE_URL}/api/admin/config`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+          body: JSON.stringify({ publishMode: this.publishMode, passwordStrength: this.passwordStrength })
+        })
+      }
+      toast.success('保存成功')
+    },
+    cancel() {
+      window.location.reload()
+    }
+  }
 }
 </script>
 
 <style scoped>
 .settings-page {
   padding: 20px;
+}
+.avatar-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 15px;
+}
+.avatar-preview {
+  width: 80px;
+  height: 80px;
+  border-radius: 40px;
+  object-fit: cover;
+}
+.form-row {
+  margin-bottom: 15px;
+  display: flex;
+  flex-direction: column;
+}
+.admin-section {
+  margin-top: 30px;
+  padding-top: 10px;
+  border-top: 1px solid #ccc;
+}
+.buttons {
+  margin-top: 20px;
+  display: flex;
+  gap: 10px;
 }
 </style>

--- a/src/main/java/com/openisle/controller/AdminConfigController.java
+++ b/src/main/java/com/openisle/controller/AdminConfigController.java
@@ -1,0 +1,42 @@
+package com.openisle.controller;
+
+import com.openisle.model.PasswordStrength;
+import com.openisle.model.PublishMode;
+import com.openisle.service.PasswordValidator;
+import com.openisle.service.PostService;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/admin/config")
+@RequiredArgsConstructor
+public class AdminConfigController {
+    private final PostService postService;
+    private final PasswordValidator passwordValidator;
+
+    @GetMapping
+    public ConfigDto getConfig() {
+        ConfigDto dto = new ConfigDto();
+        dto.setPublishMode(postService.getPublishMode());
+        dto.setPasswordStrength(passwordValidator.getStrength());
+        return dto;
+    }
+
+    @PostMapping
+    public ConfigDto updateConfig(@RequestBody ConfigDto dto) {
+        if (dto.getPublishMode() != null) {
+            postService.setPublishMode(dto.getPublishMode());
+        }
+        if (dto.getPasswordStrength() != null) {
+            passwordValidator.setStrength(dto.getPasswordStrength());
+        }
+        return getConfig();
+    }
+
+    @Data
+    public static class ConfigDto {
+        private PublishMode publishMode;
+        private PasswordStrength passwordStrength;
+    }
+}

--- a/src/main/java/com/openisle/controller/UserController.java
+++ b/src/main/java/com/openisle/controller/UserController.java
@@ -64,6 +64,13 @@ public class UserController {
         return ResponseEntity.ok(Map.of("url", url));
     }
 
+    @PutMapping("/me")
+    public ResponseEntity<UserDto> updateProfile(@RequestBody UpdateProfileDto dto,
+                                                 Authentication auth) {
+        User user = userService.updateProfile(auth.getName(), dto.getUsername(), dto.getIntroduction());
+        return ResponseEntity.ok(toDto(user));
+    }
+
     @GetMapping("/{username}")
     public ResponseEntity<UserDto> getUser(@PathVariable String username) {
         User user = userService.findByUsername(username).orElseThrow();
@@ -128,6 +135,8 @@ public class UserController {
         dto.setUsername(user.getUsername());
         dto.setEmail(user.getEmail());
         dto.setAvatar(user.getAvatar());
+        dto.setRole(user.getRole().name());
+        dto.setIntroduction(user.getIntroduction());
         dto.setFollowers(subscriptionService.countSubscribers(user.getUsername()));
         dto.setFollowing(subscriptionService.countSubscribed(user.getUsername()));
         return dto;
@@ -158,6 +167,8 @@ public class UserController {
         private String username;
         private String email;
         private String avatar;
+        private String role;
+        private String introduction;
         private long followers;
         private long following;
     }
@@ -177,6 +188,12 @@ public class UserController {
         private String content;
         private java.time.LocalDateTime createdAt;
         private Long postId;
+    }
+
+    @Data
+    private static class UpdateProfileDto {
+        private String username;
+        private String introduction;
     }
 
     @Data

--- a/src/main/java/com/openisle/model/User.java
+++ b/src/main/java/com/openisle/model/User.java
@@ -37,6 +37,9 @@ public class User {
 
     private String avatar;
 
+    @Column(length = 1000)
+    private String introduction;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Role role = Role.USER;

--- a/src/main/java/com/openisle/service/PasswordValidator.java
+++ b/src/main/java/com/openisle/service/PasswordValidator.java
@@ -7,9 +7,17 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class PasswordValidator {
-    private final PasswordStrength strength;
+    private PasswordStrength strength;
 
     public PasswordValidator(@Value("${app.password.strength:LOW}") PasswordStrength strength) {
+        this.strength = strength;
+    }
+
+    public PasswordStrength getStrength() {
+        return strength;
+    }
+
+    public void setStrength(PasswordStrength strength) {
         this.strength = strength;
     }
 

--- a/src/main/java/com/openisle/service/PostService.java
+++ b/src/main/java/com/openisle/service/PostService.java
@@ -24,7 +24,7 @@ public class PostService {
     private final UserRepository userRepository;
     private final CategoryRepository categoryRepository;
     private final TagRepository tagRepository;
-    private final PublishMode publishMode;
+    private PublishMode publishMode;
     private final NotificationService notificationService;
     private final SubscriptionService subscriptionService;
 
@@ -42,6 +42,14 @@ public class PostService {
         this.tagRepository = tagRepository;
         this.notificationService = notificationService;
         this.subscriptionService = subscriptionService;
+        this.publishMode = publishMode;
+    }
+
+    public PublishMode getPublishMode() {
+        return publishMode;
+    }
+
+    public void setPublishMode(PublishMode publishMode) {
         this.publishMode = publishMode;
     }
 

--- a/src/main/java/com/openisle/service/UserService.java
+++ b/src/main/java/com/openisle/service/UserService.java
@@ -94,4 +94,19 @@ public class UserService {
         user.setAvatar(avatarUrl);
         return userRepository.save(user);
     }
+
+    public User updateProfile(String currentUsername, String newUsername, String introduction) {
+        User user = userRepository.findByUsername(currentUsername)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+        if (newUsername != null && !newUsername.equals(currentUsername)) {
+            userRepository.findByUsername(newUsername).ifPresent(u -> {
+                throw new FieldException("username", "User name already exists");
+            });
+            user.setUsername(newUsername);
+        }
+        if (introduction != null) {
+            user.setIntroduction(introduction);
+        }
+        return userRepository.save(user);
+    }
 }


### PR DESCRIPTION
## Summary
- support runtime config changes via `AdminConfigController`
- add `introduction` and `role` fields to user DTO
- allow updating profile info (username and intro)
- support changing publish mode and password strength
- implement front-end settings page

## Testing
- `npm run lint`
- ❌ `mvn test` *(failed: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686bbe4b6904832bb31274279491ef21