### PR TITLE
Enforce minimal username length

### DIFF
--- a/open-isle-cli/src/views/SettingsPageView.vue
+++ b/open-isle-cli/src/views/SettingsPageView.vue
@@ -12,8 +12,9 @@
         </label>
       </div>
       <div class="form-row username-row">
-        <BaseInput icon="fas fa-user" v-model="username" placeholder="用户名" />
+        <BaseInput icon="fas fa-user" v-model="username" @input="usernameError = ''" placeholder="用户名" />
         <div class="username-description">用户名是你在社区的唯一标识</div>
+        <div v-if="usernameError" class="error-message">{{ usernameError }}</div>
       </div>
       <div class="form-row">
         <label>自我介绍</label>
@@ -50,6 +51,7 @@ export default {
     return {
       username: '',
       introduction: '',
+      usernameError: '',
       avatar: '',
       avatarFile: null,
       role: '',
@@ -103,6 +105,16 @@ export default {
     },
     async save() {
       const token = getToken()
+      this.usernameError = ''
+      if (!this.username) {
+        this.usernameError = '用户名不能为空'
+      } else if (this.username.length < 6) {
+        this.usernameError = '用户名至少6位'
+      }
+      if (this.usernameError) {
+        toast.error(this.usernameError)
+        return
+      }
       if (this.avatarFile) {
         const form = new FormData()
         form.append('file', this.avatarFile)
@@ -220,5 +232,13 @@ export default {
 /* hover 触发 */
 .avatar-container:hover .avatar-overlay {
   opacity: 1;
+}
+
+.error-message {
+  color: red;
+  font-size: 14px;
+  width: calc(100% - 40px);
+  margin-top: -10px;
+  margin-bottom: 10px;
 }
 </style>

--- a/open-isle-cli/src/views/SignupPageView.vue
+++ b/open-isle-cli/src/views/SignupPageView.vue
@@ -120,6 +120,8 @@ export default {
       }
       if (!this.username) {
         this.usernameError = '用户名不能为空'
+      } else if (this.username.length < 6) {
+        this.usernameError = '用户名至少6位'
       }
       if (this.emailError || this.passwordError || this.usernameError) {
         return

--- a/src/main/java/com/openisle/service/UserService.java
+++ b/src/main/java/com/openisle/service/UserService.java
@@ -3,6 +3,7 @@ package com.openisle.service;
 import com.openisle.model.User;
 import com.openisle.model.Role;
 import com.openisle.service.PasswordValidator;
+import com.openisle.service.UsernameValidator;
 import com.openisle.exception.FieldException;
 import com.openisle.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -18,9 +19,11 @@ import java.util.Random;
 public class UserService {
     private final UserRepository userRepository;
     private final PasswordValidator passwordValidator;
+    private final UsernameValidator usernameValidator;
     private final PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
 
     public User register(String username, String email, String password) {
+        usernameValidator.validate(username);
         passwordValidator.validate(password);
         // ── 先按用户名查 ──────────────────────────────────────────
         Optional<User> byUsername = userRepository.findByUsername(username);
@@ -99,6 +102,7 @@ public class UserService {
         User user = userRepository.findByUsername(currentUsername)
                 .orElseThrow(() -> new IllegalArgumentException("User not found"));
         if (newUsername != null && !newUsername.equals(currentUsername)) {
+            usernameValidator.validate(newUsername);
             userRepository.findByUsername(newUsername).ifPresent(u -> {
                 throw new FieldException("username", "User name already exists");
             });

--- a/src/main/java/com/openisle/service/UsernameValidator.java
+++ b/src/main/java/com/openisle/service/UsernameValidator.java
@@ -1,0 +1,22 @@
+package com.openisle.service;
+
+import com.openisle.exception.FieldException;
+import org.springframework.stereotype.Service;
+
+/**
+ * Simple validator for usernames.
+ */
+@Service
+public class UsernameValidator {
+    /**
+     * Validate the username string.
+     *
+     * @param username the username to validate
+     */
+    public void validate(String username) {
+        if (username == null || username.length() < 6) {
+            throw new FieldException("username", "Username must be at least 6 characters long");
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- validate usernames on backend
- add new username check to sign up page
- display error and validate username on settings page

## Testing
- `npm run lint`
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c9c33fefc832b99660d57fe82a2b9