### PR TITLE
Fix admin dropdown defaults & input focus style

### DIFF
--- a/open-isle-cli/src/components/BaseInput.vue
+++ b/open-isle-cli/src/components/BaseInput.vue
@@ -61,6 +61,10 @@ export default {
   gap: 10px;
 }
 
+.base-input:focus-within {
+  border-color: var(--primary-color);
+}
+
 .base-input-icon {
   opacity: 0.5;
   font-size: 16px;

--- a/open-isle-cli/src/components/Dropdown.vue
+++ b/open-isle-cli/src/components/Dropdown.vue
@@ -104,23 +104,29 @@ export default {
       }
     }
 
+    const loadOptions = async () => {
+      if (loaded.value) return
+      try {
+        loading.value = true
+        const res = await props.fetchOptions()
+        options.value = Array.isArray(res) ? res : []
+        loaded.value = true
+      } catch {
+        options.value = []
+      } finally {
+        loading.value = false
+      }
+    }
+
     watch(open, async val => {
       if (val && !loaded.value) {
-        try {
-          loading.value = true
-          const res = await props.fetchOptions()
-          options.value = Array.isArray(res) ? res : []
-          loaded.value = true
-        } catch {
-          options.value = []
-        } finally {
-          loading.value = false
-        }
+        await loadOptions()
       }
     })
 
     onMounted(() => {
       document.addEventListener('click', clickOutside)
+      loadOptions()
     })
 
     onBeforeUnmount(() => {


### PR DESCRIPTION
## Summary
- style BaseInput to highlight border on focus
- load dropdown options on mount so defaults show up

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686cbbde2824832b81d143092aa97600