### PR TITLE
Make ArticleTags reusable

### DIFF
--- a/open-isle-cli/src/components/ArticleTags.vue
+++ b/open-isle-cli/src/components/ArticleTags.vue
@@ -1,0 +1,28 @@
+<template>
+  <div class="article-tags-container">
+    <div
+      class="article-info-item"
+      v-for="tag in tags"
+      :key="tag.id || tag.name"
+    >
+      <img
+        v-if="tag.smallIcon"
+        class="article-info-item-img"
+        :src="tag.smallIcon"
+        :alt="tag.name"
+      />
+      <div class="article-info-item-text">{{ tag.name }}</div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'ArticleTags',
+  props: {
+    tags: { type: Array, default: () => [] }
+  }
+}
+</script>
+
+<!-- 此组件不包含样式，使用方可根据需要自行定义 -->

--- a/open-isle-cli/src/views/HomePageView.vue
+++ b/open-isle-cli/src/views/HomePageView.vue
@@ -61,12 +61,7 @@
               <div class="article-info-item-text">{{ article.category.name }}</div>
             </div>
 
-            <div class="article-tags-container">
-              <div class="article-info-item" v-for="tag in article.tags" :key="tag">
-                <img class="article-info-item-img" :src="tag.smallIcon" alt="tag">
-                <div class="article-info-item-text">{{ tag.name }}</div>
-              </div>
-            </div>
+            <ArticleTags :tags="article.tags" />
           </div>
         </div>
 
@@ -96,6 +91,7 @@ import { stripMarkdown } from '../utils/markdown'
 import { API_BASE_URL } from '../main'
 import CategorySelect from '../components/CategorySelect.vue'
 import TagSelect from '../components/TagSelect.vue'
+import ArticleTags from '../components/ArticleTags.vue'
 import { hatch } from 'ldrs'
 hatch.register()
 
@@ -104,7 +100,8 @@ export default {
   name: 'HomePageView',
   components: {
     CategorySelect,
-    TagSelect
+    TagSelect,
+    ArticleTags
   },
   data() {
     return {

--- a/open-isle-cli/src/views/PostPageView.vue
+++ b/open-isle-cli/src/views/PostPageView.vue
@@ -12,12 +12,7 @@
             <div class="article-info-item-text">{{ category.name }}</div>
           </div>
 
-          <div class="article-tags-container">
-            <div class="article-info-item" v-for="tag in tags" :key="tag">
-              <img class="article-info-item-img" :src="tag.smallIcon" alt="tag">
-              <div class="article-info-item-text">{{ tag.name }}</div>
-            </div>
-          </div>
+          <ArticleTags :tags="tags" />
         </div>
       </div>
 
@@ -106,6 +101,7 @@ import { useRoute } from 'vue-router'
 import CommentItem from '../components/CommentItem.vue'
 import CommentEditor from '../components/CommentEditor.vue'
 import BaseTimeline from '../components/BaseTimeline.vue'
+import ArticleTags from '../components/ArticleTags.vue'
 import { renderMarkdown } from '../utils/markdown'
 import { API_BASE_URL, toast } from '../main'
 import { getToken } from '../utils/auth'
@@ -114,7 +110,7 @@ hatch.register()
 
 export default {
   name: 'PostPageView',
-  components: { CommentItem, CommentEditor, BaseTimeline },
+  components: { CommentItem, CommentEditor, BaseTimeline, ArticleTags },
   setup() {
     const route = useRoute()
     const postId = route.params.id


### PR DESCRIPTION
## Summary
- create `ArticleTags` component to show tag list
- use `ArticleTags` on home page
- use `ArticleTags` on post page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686cd25b2ee8832bb982b26982a8e0d0