### PR TITLE
Add expand/collapse toggle for replies

### DIFF
--- a/open-isle-cli/src/components/CommentItem.vue
+++ b/open-isle-cli/src/components/CommentItem.vue
@@ -41,8 +41,12 @@
         </div>
       </div>
       <CommentEditor v-if="showEditor" @submit="submitReply" :loading="isWaitingForReply" />
-      <div v-if="comment.reply && comment.reply.length" class="reply-toggle" @click="toggleReplies">
-        {{ comment.reply.length }}条回复
+      <div
+        v-if="comment.reply && comment.reply.length"
+        class="reply-toggle"
+        @click="toggleReplies"
+      >
+        {{ showReplies ? '收起' : '展开' }}{{ comment.reply.length }}条回复
       </div>
       <div v-if="showReplies" class="reply-list">
         <BaseTimeline :items="comment.reply" >


### PR DESCRIPTION
## Summary
- improve comment list display
- show `展开`/`收起` text before reply count

## Testing
- `npm run lint`
- `mvn -q test` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_686d3828d0e8832b8b28de20f9401776