### PR TITLE
Add snippet preview settings and enrich comment info

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,6 +20,8 @@ app.upload.max-size=${UPLOAD_MAX_SIZE:5242880}
 # Default list size for user posts and replies
 app.user.posts-limit=${USER_POSTS_LIMIT:10}
 app.user.replies-limit=${USER_REPLIES_LIMIT:50}
+# Length of extracted snippets for posts and search (-1 to disable truncation)
+app.snippet-length=${SNIPPET_LENGTH:50}
 
 # Captcha configuration
 app.captcha.enabled=${CAPTCHA_ENABLED:false}


### PR DESCRIPTION
## Summary
- allow configuring snippet length via `app.snippet-length`
- return snippet preview in post metadata
- include post meta and optional parent comment in user comment info
- use configurable snippet length in search service

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e0e18d174832b9bd9b38474873090