### PR TITLE
Add read/unread indicator on messages

### DIFF
--- a/open-isle-cli/src/utils/notification.js
+++ b/open-isle-cli/src/utils/notification.js
@@ -15,3 +15,21 @@ export async function fetchUnreadCount() {
     return 0
   }
 }
+
+export async function markNotificationsRead(ids) {
+  try {
+    const token = getToken()
+    if (!token || !ids || ids.length === 0) return false
+    const res = await fetch(`${API_BASE_URL}/api/notifications/read`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ ids })
+    })
+    return res.ok
+  } catch (e) {
+    return false
+  }
+}


### PR DESCRIPTION
## Summary
- allow marking notifications read from the client
- mark messages as read when any link is clicked
- indicate unread messages with a red dot and lower opacity for read ones

## Testing
- `npm run lint`
- `mvn test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_686e3ff92ae4832b8092012ffbbfa2e2