### PR TITLE
Allow multiple reactions per user

### DIFF
--- a/src/main/java/com/openisle/model/Reaction.java
+++ b/src/main/java/com/openisle/model/Reaction.java
@@ -12,11 +12,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
-@Table(name = "reactions",
-       uniqueConstraints = {
-           @UniqueConstraint(columnNames = {"user_id", "post_id", "type"}),
-           @UniqueConstraint(columnNames = {"user_id", "comment_id", "type"})
-       })
+@Table(name = "reactions")
 public class Reaction {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/openisle/service/ReactionService.java
+++ b/src/main/java/com/openisle/service/ReactionService.java
@@ -28,11 +28,6 @@ public class ReactionService {
                 .orElseThrow(() -> new IllegalArgumentException("User not found"));
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new IllegalArgumentException("Post not found"));
-        java.util.Optional<Reaction> existing = reactionRepository.findByUserAndPostAndType(user, post, type);
-        if (existing.isPresent()) {
-            reactionRepository.delete(existing.get());
-            return null;
-        }
         Reaction reaction = new Reaction();
         reaction.setUser(user);
         reaction.setPost(post);
@@ -49,11 +44,6 @@ public class ReactionService {
                 .orElseThrow(() -> new IllegalArgumentException("User not found"));
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new IllegalArgumentException("Comment not found"));
-        java.util.Optional<Reaction> existing = reactionRepository.findByUserAndCommentAndType(user, comment, type);
-        if (existing.isPresent()) {
-            reactionRepository.delete(existing.get());
-            return null;
-        }
         Reaction reaction = new Reaction();
         reaction.setUser(user);
         reaction.setComment(comment);


### PR DESCRIPTION
## Summary
- drop uniqueness constraints from `Reaction`
- always create a new reaction instead of toggling

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686e431580d8832bb9c3a6e202a8ca5b