### PR TITLE
Fix duplicate reaction creation

### DIFF
--- a/src/main/java/com/openisle/service/ReactionService.java
+++ b/src/main/java/com/openisle/service/ReactionService.java
@@ -28,6 +28,11 @@ public class ReactionService {
                 .orElseThrow(() -> new IllegalArgumentException("User not found"));
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new IllegalArgumentException("Post not found"));
+        java.util.Optional<Reaction> existing =
+                reactionRepository.findByUserAndPostAndType(user, post, type);
+        if (existing.isPresent()) {
+            return null;
+        }
         Reaction reaction = new Reaction();
         reaction.setUser(user);
         reaction.setPost(post);
@@ -44,6 +49,11 @@ public class ReactionService {
                 .orElseThrow(() -> new IllegalArgumentException("User not found"));
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new IllegalArgumentException("Comment not found"));
+        java.util.Optional<Reaction> existing =
+                reactionRepository.findByUserAndCommentAndType(user, comment, type);
+        if (existing.isPresent()) {
+            return null;
+        }
         Reaction reaction = new Reaction();
         reaction.setUser(user);
         reaction.setComment(comment);


### PR DESCRIPTION
## Summary
- avoid saving a new reaction when one already exists

## Testing
- `mvn -q test` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686e46ff5f50832b9d145d9d6d8ded2e