### PR TITLE
Improve reaction notification detail

### DIFF
--- a/open-isle-cli/src/components/BaseTimeline.vue
+++ b/open-isle-cli/src/components/BaseTimeline.vue
@@ -8,6 +8,7 @@
       >
         <img v-if="item.src" :src="item.src" class="timeline-img" />
         <i v-else-if="item.icon" :class="item.icon"></i>
+        <span v-else-if="item.emoji" class="timeline-emoji">{{ item.emoji }}</span>
       </div>
       <div class="timeline-content">
         <slot name="item" :item="item">{{ item.content }}</slot>
@@ -61,6 +62,11 @@ export default {
   height: 100%;
   object-fit: cover;
   border-radius: 50%;
+}
+
+.timeline-emoji {
+  font-size: 20px;
+  line-height: 1;
 }
 
 .timeline-item::before {

--- a/open-isle-cli/src/views/MessagePageView.vue
+++ b/open-isle-cli/src/views/MessagePageView.vue
@@ -45,6 +45,28 @@
                 </span>
               </div>
             </template>
+            <template v-else-if="item.type === 'REACTION' && item.post && !item.comment">
+              <div class="notif-content-container">
+                <span class="notif-user">{{ item.fromUser.username }} </span> 对我的文章
+                <span>
+                  <router-link class="notif-content-text" @click="markRead(item.id)" :to="`/posts/${item.post.id}`">
+                    {{ sanitizeDescription(item.post.title) }}
+                  </router-link>
+                </span>
+                表达了 "{{ item.emoji }}"
+              </div>
+            </template>
+            <template v-else-if="item.type === 'REACTION' && item.comment">
+              <div class="notif-content-container">
+                <span class="notif-user">{{ item.fromUser.username }} </span> 对我的评论
+                <span>
+                  <router-link class="notif-content-text" @click="markRead(item.id)" :to="`/posts/${item.post.id}#comment-${item.comment.id}`">
+                    {{ sanitizeDescription(item.comment.content) }}
+                  </router-link>
+                </span>
+                表达了 "{{ item.emoji }}"
+              </div>
+            </template>
             <template v-else>
               <div class="notif-content-container">
                 {{ formatType(item.type) }}
@@ -91,10 +113,16 @@ export default {
     const iconMap = {
       POST_VIEWED: 'fas fa-eye',
       COMMENT_REPLY: 'fas fa-reply',
-      REACTION: 'fas fa-thumbs-up',
       POST_REVIEWED: 'fas fa-check',
       POST_UPDATED: 'fas fa-comment-dots',
       USER_ACTIVITY: 'fas fa-user'
+    }
+
+    const reactionEmojiMap = {
+      LIKE: '❤️',
+      DISLIKE: '👎',
+      RECOMMEND: '👏',
+      ANGRY: '😡'
     }
 
     const sanitizeDescription = (text) => {
@@ -129,6 +157,17 @@ export default {
               iconClick: () => {
                 markRead(n.id)
                 router.push(`/users/${n.comment.author.id}`)
+              }
+            })
+          } else if (n.type === 'REACTION') {
+            notifications.value.push({
+              ...n,
+              emoji: reactionEmojiMap[n.reactionType],
+              iconClick: () => {
+                if (n.fromUser) {
+                  markRead(n.id)
+                  router.push(`/users/${n.fromUser.id}`)
+                }
               }
             })
           } else {

--- a/src/main/java/com/openisle/controller/NotificationController.java
+++ b/src/main/java/com/openisle/controller/NotificationController.java
@@ -2,6 +2,7 @@ package com.openisle.controller;
 
 import com.openisle.model.Notification;
 import com.openisle.model.NotificationType;
+import com.openisle.model.ReactionType;
 import com.openisle.model.Comment;
 import com.openisle.model.Post;
 import com.openisle.service.NotificationService;
@@ -56,6 +57,12 @@ public class NotificationController {
                 dto.setParentComment(toCommentDto(parent));
             }
         }
+        if (n.getFromUser() != null) {
+            dto.setFromUser(toAuthorDto(n.getFromUser()));
+        }
+        if (n.getReactionType() != null) {
+            dto.setReactionType(n.getReactionType());
+        }
         dto.setApproved(n.getApproved());
         dto.setRead(n.isRead());
         dto.setCreatedAt(n.getCreatedAt());
@@ -98,6 +105,8 @@ public class NotificationController {
         private PostDto post;
         private CommentDto comment;
         private CommentDto parentComment;
+        private AuthorDto fromUser;
+        private ReactionType reactionType;
         private Boolean approved;
         private boolean read;
         private LocalDateTime createdAt;

--- a/src/main/java/com/openisle/model/Notification.java
+++ b/src/main/java/com/openisle/model/Notification.java
@@ -37,6 +37,14 @@ public class Notification {
     @JoinColumn(name = "comment_id")
     private Comment comment;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "from_user_id")
+    private User fromUser;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "reaction_type")
+    private ReactionType reactionType;
+
     @Column
     private Boolean approved;
 

--- a/src/main/java/com/openisle/service/NotificationService.java
+++ b/src/main/java/com/openisle/service/NotificationService.java
@@ -16,12 +16,19 @@ public class NotificationService {
     private final UserRepository userRepository;
 
     public Notification createNotification(User user, NotificationType type, Post post, Comment comment, Boolean approved) {
+        return createNotification(user, type, post, comment, approved, null, null);
+    }
+
+    public Notification createNotification(User user, NotificationType type, Post post, Comment comment, Boolean approved,
+                                           User fromUser, ReactionType reactionType) {
         Notification n = new Notification();
         n.setUser(user);
         n.setType(type);
         n.setPost(post);
         n.setComment(comment);
         n.setApproved(approved);
+        n.setFromUser(fromUser);
+        n.setReactionType(reactionType);
         return notificationRepository.save(n);
     }
 

--- a/src/main/java/com/openisle/service/ReactionService.java
+++ b/src/main/java/com/openisle/service/ReactionService.java
@@ -34,7 +34,7 @@ public class ReactionService {
         reaction.setType(type);
         reaction = reactionRepository.save(reaction);
         if (!user.getId().equals(post.getAuthor().getId())) {
-            notificationService.createNotification(post.getAuthor(), NotificationType.REACTION, post, null, null);
+            notificationService.createNotification(post.getAuthor(), NotificationType.REACTION, post, null, null, user, type);
         }
         return reaction;
     }
@@ -51,7 +51,7 @@ public class ReactionService {
         reaction.setType(type);
         reaction = reactionRepository.save(reaction);
         if (!user.getId().equals(comment.getAuthor().getId())) {
-            notificationService.createNotification(comment.getAuthor(), NotificationType.REACTION, null, comment, null);
+            notificationService.createNotification(comment.getAuthor(), NotificationType.REACTION, comment.getPost(), comment, null, user, type);
         }
         return reaction;
     }


### PR DESCRIPTION
## Summary
- add fromUser and reactionType fields to Notification entity and DTO
- expand NotificationService to accept actor and reaction type
- include post info for comment reactions and store actor
- support emoji icons in BaseTimeline component
- show detailed reaction notices with emoji on the message page

## Testing
- `mvn test` *(fails: command not found)*
- `npm run lint` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e50381dac832bb5b7afe7907d5890