### PR TITLE
Fix post filtering logic

### DIFF
--- a/src/main/java/com/openisle/controller/PostController.java
+++ b/src/main/java/com/openisle/controller/PostController.java
@@ -64,11 +64,19 @@ public class PostController {
         if (categoryId != null) {
             ids = java.util.List.of(categoryId);
         }
-        if ((tagId != null || (tagIds != null && !tagIds.isEmpty()))) {
-            List<Long> tids = tagIds;
-            if (tagId != null) {
-                tids = java.util.List.of(tagId);
-            }
+        List<Long> tids = tagIds;
+        if (tagId != null) {
+            tids = java.util.List.of(tagId);
+        }
+
+        boolean hasCategories = ids != null && !ids.isEmpty();
+        boolean hasTags = tids != null && !tids.isEmpty();
+
+        if (hasCategories && hasTags) {
+            return postService.listPostsByCategoriesAndTags(ids, tids, page, pageSize)
+                    .stream().map(this::toDto).collect(Collectors.toList());
+        }
+        if (hasTags) {
             return postService.listPostsByTags(tids, page, pageSize)
                     .stream().map(this::toDto).collect(Collectors.toList());
         }

--- a/src/main/java/com/openisle/repository/PostRepository.java
+++ b/src/main/java/com/openisle/repository/PostRepository.java
@@ -21,6 +21,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findByCategoryInAndStatus(List<Category> categories, PostStatus status, Pageable pageable);
     List<Post> findDistinctByTagsInAndStatus(List<Tag> tags, PostStatus status);
     List<Post> findDistinctByTagsInAndStatus(List<Tag> tags, PostStatus status, Pageable pageable);
+    List<Post> findDistinctByCategoryInAndTagsInAndStatus(List<Category> categories, List<Tag> tags, PostStatus status);
+    List<Post> findDistinctByCategoryInAndTagsInAndStatus(List<Category> categories, List<Tag> tags, PostStatus status, Pageable pageable);
     List<Post> findByTitleContainingIgnoreCaseOrContentContainingIgnoreCaseAndStatus(String titleKeyword, String contentKeyword, PostStatus status);
     List<Post> findByContentContainingIgnoreCaseAndStatus(String keyword, PostStatus status);
     List<Post> findByTitleContainingIgnoreCaseAndStatus(String keyword, PostStatus status);

--- a/src/main/java/com/openisle/service/PostService.java
+++ b/src/main/java/com/openisle/service/PostService.java
@@ -168,6 +168,31 @@ public class PostService {
         return postRepository.findDistinctByTagsInAndStatus(tags, PostStatus.PUBLISHED);
     }
 
+    public List<Post> listPostsByCategoriesAndTags(java.util.List<Long> categoryIds,
+                                                   java.util.List<Long> tagIds,
+                                                   Integer page,
+                                                   Integer pageSize) {
+        if (categoryIds == null || categoryIds.isEmpty() || tagIds == null || tagIds.isEmpty()) {
+            return java.util.List.of();
+        }
+
+        Pageable pageable = null;
+        if (page != null && pageSize != null) {
+            pageable = PageRequest.of(page, pageSize);
+        }
+
+        java.util.List<Category> categories = categoryRepository.findAllById(categoryIds);
+        java.util.List<com.openisle.model.Tag> tags = tagRepository.findAllById(tagIds);
+        if (categories.isEmpty() || tags.isEmpty()) {
+            return java.util.List.of();
+        }
+
+        if (pageable != null) {
+            return postRepository.findDistinctByCategoryInAndTagsInAndStatus(categories, tags, PostStatus.PUBLISHED, pageable);
+        }
+        return postRepository.findDistinctByCategoryInAndTagsInAndStatus(categories, tags, PostStatus.PUBLISHED);
+    }
+
     public List<Post> listPendingPosts() {
         return postRepository.findByStatus(PostStatus.PENDING);
     }

--- a/src/test/java/com/openisle/controller/PostControllerTest.java
+++ b/src/test/java/com/openisle/controller/PostControllerTest.java
@@ -190,7 +190,7 @@ class PostControllerTest {
     }
 
     @Test
-    void listPostsByTags() throws Exception {
+    void listPostsByCategoriesAndTags() throws Exception {
         User user = new User();
         user.setUsername("alice");
         Category cat = new Category();
@@ -206,7 +206,7 @@ class PostControllerTest {
         post.setCategory(cat);
         post.setTags(java.util.Set.of(tag));
 
-        Mockito.when(postService.listPostsByTags(eq(java.util.List.of(1L, 2L)), eq(0), eq(5)))
+        Mockito.when(postService.listPostsByCategoriesAndTags(eq(java.util.List.of(1L)), eq(java.util.List.of(1L, 2L)), eq(0), eq(5)))
                 .thenReturn(List.of(post));
 
         mockMvc.perform(get("/api/posts")
@@ -217,7 +217,7 @@ class PostControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].id").value(2));
 
-        verify(postService).listPostsByTags(eq(java.util.List.of(1L, 2L)), eq(0), eq(5));
+        verify(postService).listPostsByCategoriesAndTags(eq(java.util.List.of(1L)), eq(java.util.List.of(1L, 2L)), eq(0), eq(5));
         verify(postService, never()).listPostsByCategories(any(), any(), any());
     }
 }


### PR DESCRIPTION
## Summary
- add query methods for category & tag filtering
- support category+tag logic in PostService and PostController
- update tests

## Testing
- `mvn -q -DskipTests=false test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686e5921b9b8832ba1bdd17eff31f3ba