### PR TITLE
Add none option for category and tag selectors

### DIFF
--- a/open-isle-cli/src/components/CategorySelect.vue
+++ b/open-isle-cli/src/components/CategorySelect.vue
@@ -18,7 +18,8 @@ export default {
     const fetchCategories = async () => {
       const res = await fetch(`${API_BASE_URL}/api/categories`)
       if (!res.ok) return []
-      return await res.json()
+      const data = await res.json()
+      return [{ id: '', name: '无分类' }, ...data]
     }
 
     const selected = computed({

--- a/open-isle-cli/src/components/TagSelect.vue
+++ b/open-isle-cli/src/components/TagSelect.vue
@@ -18,15 +18,22 @@ export default {
     const fetchTags = async () => {
       const res = await fetch(`${API_BASE_URL}/api/tags`)
       if (!res.ok) return []
-      return await res.json()
+      const data = await res.json()
+      return [{ id: 0, name: '无标签' }, ...data]
     }
 
     const selected = computed({
       get: () => props.modelValue,
       set: v => {
-        if (Array.isArray(v) && v.length > 2) {
-          toast.error('最多选择两个标签')
-          return
+        if (Array.isArray(v)) {
+          if (v.includes(0)) {
+            emit('update:modelValue', [])
+            return
+          }
+          if (v.length > 2) {
+            toast.error('最多选择两个标签')
+            return
+          }
         }
         emit('update:modelValue', v)
       }


### PR DESCRIPTION
## Summary
- show a `无分类` option in CategorySelect
- show a `无标签` option in TagSelect and clear selection when chosen

## Testing
- `mvn test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e5f4b5e3c832b91e96579b6b19e28