### PR TITLE
Implement ranking posts by views

### DIFF
--- a/src/main/java/com/openisle/controller/PostController.java
+++ b/src/main/java/com/openisle/controller/PostController.java
@@ -78,10 +78,17 @@ public class PostController {
         }
         if (hasTags) {
             return postService.listPostsByTags(tids, page, pageSize)
-                    .stream().map(this::toDto).collect(Collectors.toList());
+                .stream().map(this::toDto).collect(Collectors.toList());
         }
 
         return postService.listPostsByCategories(ids, page, pageSize)
+                .stream().map(this::toDto).collect(Collectors.toList());
+    }
+
+    @GetMapping("/ranking")
+    public List<PostDto> rankingPosts(@RequestParam(value = "page", required = false) Integer page,
+                                      @RequestParam(value = "pageSize", required = false) Integer pageSize) {
+        return postService.listPostsByViews(page, pageSize)
                 .stream().map(this::toDto).collect(Collectors.toList());
     }
 

--- a/src/main/java/com/openisle/repository/PostRepository.java
+++ b/src/main/java/com/openisle/repository/PostRepository.java
@@ -16,6 +16,8 @@ import org.springframework.data.repository.query.Param;
 public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findByStatus(PostStatus status);
     List<Post> findByStatus(PostStatus status, Pageable pageable);
+    List<Post> findByStatusOrderByViewsDesc(PostStatus status);
+    List<Post> findByStatusOrderByViewsDesc(PostStatus status, Pageable pageable);
     List<Post> findByAuthorAndStatusOrderByCreatedAtDesc(User author, PostStatus status, Pageable pageable);
     List<Post> findByCategoryInAndStatus(List<Category> categories, PostStatus status);
     List<Post> findByCategoryInAndStatus(List<Category> categories, PostStatus status, Pageable pageable);

--- a/src/main/java/com/openisle/service/PostService.java
+++ b/src/main/java/com/openisle/service/PostService.java
@@ -107,6 +107,17 @@ public class PostService {
         return listPostsByCategories(null, null, null);
     }
 
+    public List<Post> listPostsByViews(Integer page, Integer pageSize) {
+        Pageable pageable = null;
+        if (page != null && pageSize != null) {
+            pageable = PageRequest.of(page, pageSize);
+        }
+        if (pageable != null) {
+            return postRepository.findByStatusOrderByViewsDesc(PostStatus.PUBLISHED, pageable);
+        }
+        return postRepository.findByStatusOrderByViewsDesc(PostStatus.PUBLISHED);
+    }
+
     public List<Post> listPostsByCategories(java.util.List<Long> categoryIds,
                                             Integer page,
                                             Integer pageSize) {


### PR DESCRIPTION
## Summary
- list posts by views in `PostService` and `PostRepository`
- expose `/api/posts/ranking` endpoint
- implement ranking tab on homepage

## Testing
- `mvn -q test` *(fails: command not found)*
- `npm test` in `open-isle-cli` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686e63e20be8832ba02c824ae35874cb