### PR TITLE
Support tag/category filters for ranking

### DIFF
--- a/open-isle-cli/src/views/HomePageView.vue
+++ b/open-isle-cli/src/views/HomePageView.vue
@@ -142,7 +142,16 @@ export default {
     }
 
     const buildRankUrl = () => {
-      return `${API_BASE_URL}/api/posts/ranking?page=${page.value}&pageSize=${pageSize}`
+      let url = `${API_BASE_URL}/api/posts/ranking?page=${page.value}&pageSize=${pageSize}`
+      if (selectedCategory.value) {
+        url += `&categoryId=${selectedCategory.value}`
+      }
+      if (selectedTags.value.length) {
+        selectedTags.value.forEach(t => {
+          url += `&tagIds=${t}`
+        })
+      }
+      return url
     }
 
     const fetchPosts = async (reset = false) => {
@@ -239,6 +248,8 @@ export default {
     watch([selectedCategory, selectedTags], () => {
       if (selectedTopic.value === '最新') {
         fetchPosts(true)
+      } else if (selectedTopic.value === '排行榜') {
+        fetchRanking(true)
       }
     })
 

--- a/src/main/java/com/openisle/controller/PostController.java
+++ b/src/main/java/com/openisle/controller/PostController.java
@@ -86,9 +86,22 @@ public class PostController {
     }
 
     @GetMapping("/ranking")
-    public List<PostDto> rankingPosts(@RequestParam(value = "page", required = false) Integer page,
+    public List<PostDto> rankingPosts(@RequestParam(value = "categoryId", required = false) Long categoryId,
+                                      @RequestParam(value = "categoryIds", required = false) List<Long> categoryIds,
+                                      @RequestParam(value = "tagId", required = false) Long tagId,
+                                      @RequestParam(value = "tagIds", required = false) List<Long> tagIds,
+                                      @RequestParam(value = "page", required = false) Integer page,
                                       @RequestParam(value = "pageSize", required = false) Integer pageSize) {
-        return postService.listPostsByViews(page, pageSize)
+        List<Long> ids = categoryIds;
+        if (categoryId != null) {
+            ids = java.util.List.of(categoryId);
+        }
+        List<Long> tids = tagIds;
+        if (tagId != null) {
+            tids = java.util.List.of(tagId);
+        }
+
+        return postService.listPostsByViews(ids, tids, page, pageSize)
                 .stream().map(this::toDto).collect(Collectors.toList());
     }
 

--- a/src/main/java/com/openisle/repository/PostRepository.java
+++ b/src/main/java/com/openisle/repository/PostRepository.java
@@ -25,6 +25,13 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findDistinctByTagsInAndStatus(List<Tag> tags, PostStatus status, Pageable pageable);
     List<Post> findDistinctByCategoryInAndTagsInAndStatus(List<Category> categories, List<Tag> tags, PostStatus status);
     List<Post> findDistinctByCategoryInAndTagsInAndStatus(List<Category> categories, List<Tag> tags, PostStatus status, Pageable pageable);
+
+    List<Post> findByCategoryInAndStatusOrderByViewsDesc(List<Category> categories, PostStatus status);
+    List<Post> findByCategoryInAndStatusOrderByViewsDesc(List<Category> categories, PostStatus status, Pageable pageable);
+    List<Post> findDistinctByTagsInAndStatusOrderByViewsDesc(List<Tag> tags, PostStatus status);
+    List<Post> findDistinctByTagsInAndStatusOrderByViewsDesc(List<Tag> tags, PostStatus status, Pageable pageable);
+    List<Post> findDistinctByCategoryInAndTagsInAndStatusOrderByViewsDesc(List<Category> categories, List<Tag> tags, PostStatus status);
+    List<Post> findDistinctByCategoryInAndTagsInAndStatusOrderByViewsDesc(List<Category> categories, List<Tag> tags, PostStatus status, Pageable pageable);
     List<Post> findByTitleContainingIgnoreCaseOrContentContainingIgnoreCaseAndStatus(String titleKeyword, String contentKeyword, PostStatus status);
     List<Post> findByContentContainingIgnoreCaseAndStatus(String keyword, PostStatus status);
     List<Post> findByTitleContainingIgnoreCaseAndStatus(String keyword, PostStatus status);

--- a/src/test/java/com/openisle/controller/PostControllerTest.java
+++ b/src/test/java/com/openisle/controller/PostControllerTest.java
@@ -220,4 +220,35 @@ class PostControllerTest {
         verify(postService).listPostsByCategoriesAndTags(eq(java.util.List.of(1L)), eq(java.util.List.of(1L, 2L)), eq(0), eq(5));
         verify(postService, never()).listPostsByCategories(any(), any(), any());
     }
+
+    @Test
+    void rankingPostsFiltered() throws Exception {
+        User user = new User();
+        user.setUsername("alice");
+        Category cat = new Category();
+        cat.setName("tech");
+        Tag tag = new Tag();
+        tag.setId(1L);
+        tag.setName("java");
+        Post post = new Post();
+        post.setId(3L);
+        post.setTitle("rank");
+        post.setCreatedAt(LocalDateTime.now());
+        post.setAuthor(user);
+        post.setCategory(cat);
+        post.setTags(java.util.Set.of(tag));
+
+        Mockito.when(postService.listPostsByViews(eq(java.util.List.of(1L)), eq(java.util.List.of(1L, 2L)), eq(0), eq(5)))
+                .thenReturn(List.of(post));
+
+        mockMvc.perform(get("/api/posts/ranking")
+                        .param("tagIds", "1,2")
+                        .param("page", "0")
+                        .param("pageSize", "5")
+                        .param("categoryId", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(3));
+
+        verify(postService).listPostsByViews(eq(java.util.List.of(1L)), eq(java.util.List.of(1L, 2L)), eq(0), eq(5));
+    }
 }


### PR DESCRIPTION
## Summary
- add repository methods for ranking posts filtered by tags and categories
- implement unified `listPostsByViews` logic that handles optional filters
- extend `/api/posts/ranking` endpoint with category and tag parameters
- update HomePage to send filters when viewing ranking and refresh on filter change
- test ranking filter handling

## Testing
- `mvn -q test` *(fails: Could not download Spring dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686e671e2854832ba735eec73c085df4