### PR TITLE
Fix PostControllerTest by mocking DraftService

### DIFF
--- a/src/test/java/com/openisle/controller/PostControllerTest.java
+++ b/src/test/java/com/openisle/controller/PostControllerTest.java
@@ -8,6 +8,7 @@ import com.openisle.service.PostService;
 import com.openisle.service.CommentService;
 import com.openisle.service.ReactionService;
 import com.openisle.service.CaptchaService;
+import com.openisle.service.DraftService;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -46,6 +47,8 @@ class PostControllerTest {
     private ReactionService reactionService;
     @MockBean
     private CaptchaService captchaService;
+    @MockBean
+    private DraftService draftService;
 
     @Test
     void createAndGetPost() throws Exception {


### PR DESCRIPTION
## Summary
- fix PostControllerTest by adding a MockBean for `DraftService`

## Testing
- `mvn -q test -Dtest=PostControllerTest` *(fails: Unable to resolve Maven dependencies due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686e8d9db218832b95e1de6ddec26640