### PR TITLE
Fix SearchService NPE in tests

### DIFF
--- a/src/main/java/com/openisle/service/SearchService.java
+++ b/src/main/java/com/openisle/service/SearchService.java
@@ -67,7 +67,7 @@ public class SearchService {
                                     "post",
                                     p.getId(),
                                     p.getTitle(),
-                                    p.getCategory().getName(),
+                                    p.getCategory() != null ? p.getCategory().getName() : null,
                                     extractSnippet(p.getContent(), keyword, false),
                                     null
                             )),
@@ -76,7 +76,7 @@ public class SearchService {
                                     "post_title",
                                     p.getId(),
                                     p.getTitle(),
-                                    p.getCategory().getName(),
+                                    p.getCategory() != null ? p.getCategory().getName() : null,
                                     extractSnippet(p.getContent(), keyword, true),
                                     null
                             ))


### PR DESCRIPTION
## Summary
- avoid null pointer in SearchService when posts have no category

## Testing
- `mvn -q -DskipTests=false test` *(fails: could not resolve Spring parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686e90d7f02c832badd2f18b27670c9f