### PR TITLE
Fix PublishModeIntegrationTest user verification

### DIFF
--- a/src/test/java/com/openisle/integration/PublishModeIntegrationTest.java
+++ b/src/test/java/com/openisle/integration/PublishModeIntegrationTest.java
@@ -36,8 +36,10 @@ class PublishModeIntegrationTest {
         rest.postForEntity("/api/auth/register", new HttpEntity<>(
                 Map.of("username", username, "email", email, "password", "pass123"), h), Map.class);
         User u = users.findByUsername(username).orElseThrow();
-        rest.postForEntity("/api/auth/verify", new HttpEntity<>(
-                Map.of("username", username, "code", u.getVerificationCode()), h), Map.class);
+        if (u.getVerificationCode() != null) {
+            rest.postForEntity("/api/auth/verify", new HttpEntity<>(
+                    Map.of("username", username, "code", u.getVerificationCode()), h), Map.class);
+        }
         ResponseEntity<Map> resp = rest.postForEntity("/api/auth/login", new HttpEntity<>(
                 Map.of("username", username, "password", "pass123"), h), Map.class);
         return (String) resp.getBody().get("token");


### PR DESCRIPTION
## Summary
- handle already-verified users when registering in integration test

## Testing
- `mvn -q -Dtest=com.openisle.integration.PublishModeIntegrationTest test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686e90ed17b0832b99494d8d594fe1e4