### PR TITLE
Fix PasswordValidator tests

### DIFF
--- a/src/test/java/com/openisle/service/PasswordValidatorTest.java
+++ b/src/test/java/com/openisle/service/PasswordValidatorTest.java
@@ -1,6 +1,7 @@
 package com.openisle.service;
 
 import com.openisle.model.PasswordStrength;
+import com.openisle.exception.FieldException;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -11,7 +12,7 @@ class PasswordValidatorTest {
     void lowStrengthRequiresSixChars() {
         PasswordValidator validator = new PasswordValidator(PasswordStrength.LOW);
 
-        assertThrows(IllegalArgumentException.class, () -> validator.validate("12345"));
+        assertThrows(FieldException.class, () -> validator.validate("12345"));
         assertDoesNotThrow(() -> validator.validate("123456"));
     }
 
@@ -19,9 +20,9 @@ class PasswordValidatorTest {
     void mediumStrengthRules() {
         PasswordValidator validator = new PasswordValidator(PasswordStrength.MEDIUM);
 
-        assertThrows(IllegalArgumentException.class, () -> validator.validate("abc123"));
-        assertThrows(IllegalArgumentException.class, () -> validator.validate("abcdefgh"));
-        assertThrows(IllegalArgumentException.class, () -> validator.validate("12345678"));
+        assertThrows(FieldException.class, () -> validator.validate("abc123"));
+        assertThrows(FieldException.class, () -> validator.validate("abcdefgh"));
+        assertThrows(FieldException.class, () -> validator.validate("12345678"));
         assertDoesNotThrow(() -> validator.validate("abcd1234"));
     }
 
@@ -29,11 +30,11 @@ class PasswordValidatorTest {
     void highStrengthRules() {
         PasswordValidator validator = new PasswordValidator(PasswordStrength.HIGH);
 
-        assertThrows(IllegalArgumentException.class, () -> validator.validate("Abc123$"));
-        assertThrows(IllegalArgumentException.class, () -> validator.validate("abcd1234$xyz"));
-        assertThrows(IllegalArgumentException.class, () -> validator.validate("ABCD1234$XYZ"));
-        assertThrows(IllegalArgumentException.class, () -> validator.validate("AbcdABCDabcd"));
-        assertThrows(IllegalArgumentException.class, () -> validator.validate("Abcd1234abcd"));
+        assertThrows(FieldException.class, () -> validator.validate("Abc123$"));
+        assertThrows(FieldException.class, () -> validator.validate("abcd1234$xyz"));
+        assertThrows(FieldException.class, () -> validator.validate("ABCD1234$XYZ"));
+        assertThrows(FieldException.class, () -> validator.validate("AbcdABCDabcd"));
+        assertThrows(FieldException.class, () -> validator.validate("Abcd1234abcd"));
         assertDoesNotThrow(() -> validator.validate("Abcd1234$xyz"));
     }
 }


### PR DESCRIPTION
## Summary
- update PasswordValidatorTest to check for `FieldException`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686e910e20c8832b890972b38b9e9d7f