### PR TITLE
Fix integration tests with valid usernames

### DIFF
--- a/src/test/java/com/openisle/integration/ComplexFlowIntegrationTest.java
+++ b/src/test/java/com/openisle/integration/ComplexFlowIntegrationTest.java
@@ -61,10 +61,10 @@ class ComplexFlowIntegrationTest {
 
     @Test
     void nestedCommentsVisibleInPost() {
-        String t1 = registerAndLogin("alice", "a@example.com");
-        String t2 = registerAndLogin("bob", "b@example.com");
+        String t1 = registerAndLogin("alice1", "a@example.com");
+        String t2 = registerAndLogin("bob123", "b@example.com");
 
-        String adminToken = registerAndLoginAsAdmin("admin", "admin@example.com");
+        String adminToken = registerAndLoginAsAdmin("admin1", "admin@example.com");
         ResponseEntity<Map> catResp = postJson("/api/categories",
                 Map.of("name", "general", "description", "d", "icon", "i"), adminToken);
         Long catId = ((Number)catResp.getBody().get("id")).longValue();
@@ -106,8 +106,8 @@ class ComplexFlowIntegrationTest {
 
     @Test
     void reactionsReturnedForPostAndComment() {
-        String t1 = registerAndLogin("carol", "c@example.com");
-        String t2 = registerAndLogin("dave", "d@example.com");
+        String t1 = registerAndLogin("carol1", "c@example.com");
+        String t2 = registerAndLogin("dave12", "d@example.com");
 
         String adminToken = registerAndLoginAsAdmin("admin2", "admin2@example.com");
         List<Map<String, Object>> categories = (List<Map<String, Object>>) rest.getForObject("/api/categories", List.class);

--- a/src/test/java/com/openisle/integration/PublishModeIntegrationTest.java
+++ b/src/test/java/com/openisle/integration/PublishModeIntegrationTest.java
@@ -66,8 +66,8 @@ class PublishModeIntegrationTest {
 
     @Test
     void postRequiresApproval() {
-        String userToken = registerAndLogin("eve", "e@example.com");
-        String adminToken = registerAndLoginAsAdmin("admin", "admin@example.com");
+        String userToken = registerAndLogin("eve123", "e@example.com");
+        String adminToken = registerAndLoginAsAdmin("admin1", "admin@example.com");
 
         ResponseEntity<Map> catResp = postJson("/api/categories",
                 Map.of("name", "review", "description", "d", "icon", "i"), adminToken);

--- a/src/test/java/com/openisle/integration/SearchIntegrationTest.java
+++ b/src/test/java/com/openisle/integration/SearchIntegrationTest.java
@@ -57,7 +57,7 @@ class SearchIntegrationTest {
 
     @Test
     void globalSearchReturnsMixedResults() {
-        String admin = registerAndLoginAsAdmin("admin", "a@a.com");
+        String admin = registerAndLoginAsAdmin("admin1", "a@a.com");
         String user = registerAndLogin("bob_nice", "b@b.com");
 
         ResponseEntity<Map> catResp = postJson("/api/categories", Map.of("name", "misc", "description", "d", "icon", "i"), admin);


### PR DESCRIPTION
## Summary
- update integration tests to use usernames of at least 6 characters

## Testing
- `mvn -q test -Dtest=com.openisle.integration.SearchIntegrationTest` *(fails: Non-resolvable parent POM, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686e91052490832baad4fb8281357ec9