### PR TITLE
Fix null content handling in UserController

### DIFF
--- a/src/main/java/com/openisle/controller/UserController.java
+++ b/src/main/java/com/openisle/controller/UserController.java
@@ -175,11 +175,14 @@ public class UserController {
         PostMetaDto dto = new PostMetaDto();
         dto.setId(post.getId());
         dto.setTitle(post.getTitle());
+        String content = post.getContent();
+        if (content == null) {
+            content = "";
+        }
         if (snippetLength >= 0) {
-            String c = post.getContent();
-            dto.setSnippet(c.length() > snippetLength ? c.substring(0, snippetLength) : c);
+            dto.setSnippet(content.length() > snippetLength ? content.substring(0, snippetLength) : content);
         } else {
-            dto.setSnippet(post.getContent());
+            dto.setSnippet(content);
         }
         dto.setCreatedAt(post.getCreatedAt());
         dto.setCategory(post.getCategory().getName());


### PR DESCRIPTION
## Summary
- avoid NullPointerException when posts lack content by defaulting to empty string

## Testing
- `mvn test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686e9381461c832bb28b7d87d015e0f0