### PR TITLE
Fix user replies test to set post category

### DIFF
--- a/src/test/java/com/openisle/controller/UserControllerTest.java
+++ b/src/test/java/com/openisle/controller/UserControllerTest.java
@@ -114,6 +114,9 @@ class UserControllerTest {
         user.setUsername("bob");
         com.openisle.model.Post post = new com.openisle.model.Post();
         post.setId(5L);
+        com.openisle.model.Category cat = new com.openisle.model.Category();
+        cat.setName("tech");
+        post.setCategory(cat);
         com.openisle.model.Comment comment = new com.openisle.model.Comment();
         comment.setId(4L);
         comment.setContent("hi");


### PR DESCRIPTION
## Summary
- fix `listUserReplies` test by giving the post a category

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686e94f089d4832ba22d202255564832