### PR TITLE
Implement tag creation by normal users

### DIFF
--- a/src/main/java/com/openisle/config/SecurityConfig.java
+++ b/src/main/java/com/openisle/config/SecurityConfig.java
@@ -90,7 +90,7 @@ public class SecurityConfig {
                     .requestMatchers(HttpMethod.GET, "/api/search/**").permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/users/**").permitAll()
                     .requestMatchers(HttpMethod.POST, "/api/categories/**").hasAuthority("ADMIN")
-                    .requestMatchers(HttpMethod.POST, "/api/tags/**").hasAuthority("ADMIN")
+                    .requestMatchers(HttpMethod.POST, "/api/tags/**").authenticated()
                     .requestMatchers(HttpMethod.DELETE, "/api/categories/**").hasAuthority("ADMIN")
                     .requestMatchers(HttpMethod.DELETE, "/api/tags/**").hasAuthority("ADMIN")
                     .requestMatchers("/api/admin/**").hasAuthority("ADMIN")

--- a/src/main/java/com/openisle/service/TagService.java
+++ b/src/main/java/com/openisle/service/TagService.java
@@ -11,8 +11,10 @@ import java.util.List;
 @RequiredArgsConstructor
 public class TagService {
     private final TagRepository tagRepository;
+    private final TagValidator tagValidator;
 
     public Tag createTag(String name, String description, String icon, String smallIcon) {
+        tagValidator.validate(name);
         Tag tag = new Tag();
         tag.setName(name);
         tag.setDescription(description);
@@ -25,6 +27,7 @@ public class TagService {
         Tag tag = tagRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Tag not found"));
         if (name != null) {
+            tagValidator.validate(name);
             tag.setName(name);
         }
         if (description != null) {

--- a/src/main/java/com/openisle/service/TagValidator.java
+++ b/src/main/java/com/openisle/service/TagValidator.java
@@ -1,0 +1,20 @@
+package com.openisle.service;
+
+import com.openisle.exception.FieldException;
+import org.springframework.stereotype.Service;
+
+import java.util.regex.Pattern;
+
+@Service
+public class TagValidator {
+    private static final Pattern ALLOWED = Pattern.compile("^[A-Za-z0-9\\u4e00-\\u9fa5]+$");
+
+    public void validate(String name) {
+        if (name == null || name.isBlank()) {
+            throw new FieldException("name", "Tag name cannot be empty");
+        }
+        if (!ALLOWED.matcher(name).matches()) {
+            throw new FieldException("name", "Tag name must be letters or numbers");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- allow authenticated users to POST /api/tags
- validate tag names via new `TagValidator`
- enable creating tags from the tag selector when publishing
- auto create new tags on post submission

## Testing
- `npm run lint`
- `mvn -q test` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686f26a57b10832bbd030d83048837dd