### PR TITLE
Improve tag creation error handling on publish

### DIFF
--- a/open-isle-cli/src/views/NewPostPageView.vue
+++ b/open-isle-cli/src/views/NewPostPageView.vue
@@ -138,6 +138,13 @@ export default {
             selectedTags.value[i] = data.id
             // update local TagSelect options handled by component
           } else {
+            let data
+            try {
+              data = await res.json()
+            } catch (e) {
+              data = null
+            }
+            toast.error((data && data.error) || '创建标签失败')
             throw new Error('create tag failed')
           }
         }


### PR DESCRIPTION
## Summary
- when creating tags during post submission, show backend error message

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f3181bec4832bb436257f04fb8b02