### PR TITLE
Change tag filter to AND logic

### DIFF
--- a/src/main/java/com/openisle/repository/PostRepository.java
+++ b/src/main/java/com/openisle/repository/PostRepository.java
@@ -26,6 +26,31 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findDistinctByCategoryInAndTagsInAndStatus(List<Category> categories, List<Tag> tags, PostStatus status);
     List<Post> findDistinctByCategoryInAndTagsInAndStatus(List<Category> categories, List<Tag> tags, PostStatus status, Pageable pageable);
 
+    // Queries requiring all provided tags to be present
+    @Query("SELECT p FROM Post p JOIN p.tags t WHERE t IN :tags AND p.status = :status GROUP BY p.id HAVING COUNT(DISTINCT t.id) = :tagCount")
+    List<Post> findByAllTags(@Param("tags") List<Tag> tags, @Param("status") PostStatus status, @Param("tagCount") long tagCount);
+
+    @Query(value = "SELECT p FROM Post p JOIN p.tags t WHERE t IN :tags AND p.status = :status GROUP BY p.id HAVING COUNT(DISTINCT t.id) = :tagCount")
+    List<Post> findByAllTags(@Param("tags") List<Tag> tags, @Param("status") PostStatus status, @Param("tagCount") long tagCount, Pageable pageable);
+
+    @Query("SELECT p FROM Post p JOIN p.tags t WHERE t IN :tags AND p.status = :status GROUP BY p.id HAVING COUNT(DISTINCT t.id) = :tagCount ORDER BY p.views DESC")
+    List<Post> findByAllTagsOrderByViewsDesc(@Param("tags") List<Tag> tags, @Param("status") PostStatus status, @Param("tagCount") long tagCount);
+
+    @Query(value = "SELECT p FROM Post p JOIN p.tags t WHERE t IN :tags AND p.status = :status GROUP BY p.id HAVING COUNT(DISTINCT t.id) = :tagCount ORDER BY p.views DESC")
+    List<Post> findByAllTagsOrderByViewsDesc(@Param("tags") List<Tag> tags, @Param("status") PostStatus status, @Param("tagCount") long tagCount, Pageable pageable);
+
+    @Query("SELECT p FROM Post p JOIN p.tags t WHERE p.category IN :categories AND t IN :tags AND p.status = :status GROUP BY p.id HAVING COUNT(DISTINCT t.id) = :tagCount")
+    List<Post> findByCategoriesAndAllTags(@Param("categories") List<Category> categories, @Param("tags") List<Tag> tags, @Param("status") PostStatus status, @Param("tagCount") long tagCount);
+
+    @Query(value = "SELECT p FROM Post p JOIN p.tags t WHERE p.category IN :categories AND t IN :tags AND p.status = :status GROUP BY p.id HAVING COUNT(DISTINCT t.id) = :tagCount")
+    List<Post> findByCategoriesAndAllTags(@Param("categories") List<Category> categories, @Param("tags") List<Tag> tags, @Param("status") PostStatus status, @Param("tagCount") long tagCount, Pageable pageable);
+
+    @Query("SELECT p FROM Post p JOIN p.tags t WHERE p.category IN :categories AND t IN :tags AND p.status = :status GROUP BY p.id HAVING COUNT(DISTINCT t.id) = :tagCount ORDER BY p.views DESC")
+    List<Post> findByCategoriesAndAllTagsOrderByViewsDesc(@Param("categories") List<Category> categories, @Param("tags") List<Tag> tags, @Param("status") PostStatus status, @Param("tagCount") long tagCount);
+
+    @Query(value = "SELECT p FROM Post p JOIN p.tags t WHERE p.category IN :categories AND t IN :tags AND p.status = :status GROUP BY p.id HAVING COUNT(DISTINCT t.id) = :tagCount ORDER BY p.views DESC")
+    List<Post> findByCategoriesAndAllTagsOrderByViewsDesc(@Param("categories") List<Category> categories, @Param("tags") List<Tag> tags, @Param("status") PostStatus status, @Param("tagCount") long tagCount, Pageable pageable);
+
     List<Post> findByCategoryInAndStatusOrderByViewsDesc(List<Category> categories, PostStatus status);
     List<Post> findByCategoryInAndStatusOrderByViewsDesc(List<Category> categories, PostStatus status, Pageable pageable);
     List<Post> findDistinctByTagsInAndStatusOrderByViewsDesc(List<Tag> tags, PostStatus status);

--- a/src/main/java/com/openisle/service/PostService.java
+++ b/src/main/java/com/openisle/service/PostService.java
@@ -141,11 +141,11 @@ public class PostService {
                     return java.util.List.of();
                 }
                 if (pageable != null) {
-                    return postRepository.findDistinctByCategoryInAndTagsInAndStatusOrderByViewsDesc(
-                            categories, tags, PostStatus.PUBLISHED, pageable);
+                    return postRepository.findByCategoriesAndAllTagsOrderByViewsDesc(
+                            categories, tags, PostStatus.PUBLISHED, tags.size(), pageable);
                 }
-                return postRepository.findDistinctByCategoryInAndTagsInAndStatusOrderByViewsDesc(
-                        categories, tags, PostStatus.PUBLISHED);
+                return postRepository.findByCategoriesAndAllTagsOrderByViewsDesc(
+                        categories, tags, PostStatus.PUBLISHED, tags.size());
             }
             if (pageable != null) {
                 return postRepository.findByCategoryInAndStatusOrderByViewsDesc(categories, PostStatus.PUBLISHED, pageable);
@@ -158,9 +158,9 @@ public class PostService {
             return java.util.List.of();
         }
         if (pageable != null) {
-            return postRepository.findDistinctByTagsInAndStatusOrderByViewsDesc(tags, PostStatus.PUBLISHED, pageable);
+            return postRepository.findByAllTagsOrderByViewsDesc(tags, PostStatus.PUBLISHED, tags.size(), pageable);
         }
-        return postRepository.findDistinctByTagsInAndStatusOrderByViewsDesc(tags, PostStatus.PUBLISHED);
+        return postRepository.findByAllTagsOrderByViewsDesc(tags, PostStatus.PUBLISHED, tags.size());
     }
 
     public List<Post> listPostsByCategories(java.util.List<Long> categoryIds,
@@ -219,9 +219,9 @@ public class PostService {
         }
 
         if (pageable != null) {
-            return postRepository.findDistinctByTagsInAndStatus(tags, PostStatus.PUBLISHED, pageable);
+            return postRepository.findByAllTags(tags, PostStatus.PUBLISHED, tags.size(), pageable);
         }
-        return postRepository.findDistinctByTagsInAndStatus(tags, PostStatus.PUBLISHED);
+        return postRepository.findByAllTags(tags, PostStatus.PUBLISHED, tags.size());
     }
 
     public List<Post> listPostsByCategoriesAndTags(java.util.List<Long> categoryIds,
@@ -244,9 +244,9 @@ public class PostService {
         }
 
         if (pageable != null) {
-            return postRepository.findDistinctByCategoryInAndTagsInAndStatus(categories, tags, PostStatus.PUBLISHED, pageable);
+            return postRepository.findByCategoriesAndAllTags(categories, tags, PostStatus.PUBLISHED, tags.size(), pageable);
         }
-        return postRepository.findDistinctByCategoryInAndTagsInAndStatus(categories, tags, PostStatus.PUBLISHED);
+        return postRepository.findByCategoriesAndAllTags(categories, tags, PostStatus.PUBLISHED, tags.size());
     }
 
     public List<Post> listPendingPosts() {


### PR DESCRIPTION
## Summary
- require posts to match all selected tags when filtering
- add repository methods for AND semantics

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686f456d8780832b8df8caadefb90b42