### PR TITLE
Fix filter dropdown preloading

### DIFF
--- a/open-isle-cli/src/components/CategorySelect.vue
+++ b/open-isle-cli/src/components/CategorySelect.vue
@@ -1,5 +1,5 @@
 <template>
-  <Dropdown v-model="selected" :fetch-options="fetchCategories" placeholder="选择分类">
+  <Dropdown v-model="selected" :fetch-options="fetchCategories" placeholder="选择分类" :initial-options="providedOptions">
     <template #option="{ option }">
       <div class="option-container">
         <div class="option-main">
@@ -17,7 +17,7 @@
 </template>
 
 <script>
-import { computed } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { API_BASE_URL } from '../main'
 import Dropdown from './Dropdown.vue'
 
@@ -25,11 +25,24 @@ export default {
   name: 'CategorySelect',
   components: { Dropdown },
   props: {
-    modelValue: { type: [String, Number], default: '' }
+    modelValue: { type: [String, Number], default: '' },
+    options: { type: Array, default: () => [] }
   },
   emits: ['update:modelValue'],
   setup(props, { emit }) {
+    const providedOptions = ref(Array.isArray(props.options) ? [...props.options] : [])
+
+    watch(
+      () => props.options,
+      val => {
+        providedOptions.value = Array.isArray(val) ? [...val] : []
+      }
+    )
+
     const fetchCategories = async () => {
+      if (providedOptions.value.length) {
+        return [{ id: '', name: '无分类' }, ...providedOptions.value]
+      }
       const res = await fetch(`${API_BASE_URL}/api/categories`)
       if (!res.ok) return []
       const data = await res.json()
@@ -46,7 +59,7 @@ export default {
       set: v => emit('update:modelValue', v)
     })
 
-    return { fetchCategories, selected, isImageIcon }
+    return { fetchCategories, selected, isImageIcon, providedOptions }
   }
 }
 </script>

--- a/open-isle-cli/src/components/Dropdown.vue
+++ b/open-isle-cli/src/components/Dropdown.vue
@@ -71,7 +71,8 @@ export default {
     remote: { type: Boolean, default: false },
     menuClass: { type: String, default: '' },
     optionClass: { type: String, default: '' },
-    showSearch: { type: Boolean, default: true }
+    showSearch: { type: Boolean, default: true },
+    initialOptions: { type: Array, default: () => [] }
   },
   emits: ['update:modelValue'],
   setup(props, { emit }) {
@@ -80,7 +81,7 @@ export default {
     const setSearch = (val) => {
       search.value = val
     }
-    const options = ref([])
+    const options = ref(Array.isArray(props.initialOptions) ? [...props.initialOptions] : [])
     const loaded = ref(false)
     const loading = ref(false)
     const wrapper = ref(null)
@@ -135,6 +136,15 @@ export default {
         loading.value = false
       }
     }
+
+    watch(
+      () => props.initialOptions,
+      val => {
+        if (Array.isArray(val)) {
+          options.value = [...val]
+        }
+      }
+    )
 
     watch(open, async val => {
       if (val) {


### PR DESCRIPTION
## Summary
- update dropdown component to support `initialOptions`
- allow TagSelect & CategorySelect to preload options via prop
- preload selected tags/categories in HomePageView

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686f52778bbc832baeb34d0621e28704