### PR TITLE
Fix category filter initialization

### DIFF
--- a/open-isle-cli/src/views/HomePageView.vue
+++ b/open-isle-cli/src/views/HomePageView.vue
@@ -121,7 +121,11 @@ export default {
   },
   setup() {
     const route = useRoute()
-    const selectedCategory = ref(route.query.category ? decodeURIComponent(route.query.category) : '')
+    const selectedCategory = ref('')
+    if (route.query.category) {
+      const c = decodeURIComponent(route.query.category)
+      selectedCategory.value = isNaN(c) ? c : Number(c)
+    }
     const selectedTags = ref([])
     if (route.query.tags) {
       const t = Array.isArray(route.query.tags) ? route.query.tags.join(',') : route.query.tags


### PR DESCRIPTION
## Summary
- parse numeric `category` query parameter into a number

## Testing
- `npm --prefix open-isle-cli run lint`
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f5bf94ce0832baf6504d03b1ae945