### PR TITLE
Implement participants display

### DIFF
--- a/open-isle-cli/src/views/HomePageView.vue
+++ b/open-isle-cli/src/views/HomePageView.vue
@@ -66,9 +66,14 @@
           </div>
 
           <div class="article-member-avatars-container">
-            <div class="article-member-avatar-item" v-for="(avatar, idx) in article.members" :key="idx">
-              <img class="article-member-avatar-item-img" :src="avatar" alt="avatar">
-            </div>
+            <router-link
+              v-for="member in article.members"
+              :key="member.id"
+              class="article-member-avatar-item"
+              :to="`/users/${member.id}`"
+            >
+              <img class="article-member-avatar-item-img" :src="member.avatar" alt="avatar" />
+            </router-link>
           </div>
           <div class="article-comments">
             {{ article.comments }}
@@ -216,7 +221,7 @@ export default {
             description: p.content,
             category: p.category,
             tags: p.tags || [],
-            members: [],
+            members: (p.participants || []).map(m => ({ id: m.id, avatar: m.avatar })),
             comments: (p.comments || []).length,
             views: p.views,
             time: TimeManager.format(p.createdAt)
@@ -252,7 +257,7 @@ export default {
             description: p.content,
             category: p.category,
             tags: p.tags || [],
-            members: [],
+            members: (p.participants || []).map(m => ({ id: m.id, avatar: m.avatar })),
             comments: (p.comments || []).length,
             views: p.views,
             time: TimeManager.format(p.createdAt)

--- a/src/main/java/com/openisle/controller/PostController.java
+++ b/src/main/java/com/openisle/controller/PostController.java
@@ -128,6 +128,9 @@ public class PostController {
                 .collect(Collectors.toList());
         dto.setComments(comments);
 
+        java.util.List<com.openisle.model.User> participants = commentService.getParticipants(post.getId(), 5);
+        dto.setParticipants(participants.stream().map(this::toAuthorDto).collect(Collectors.toList()));
+
         return dto;
     }
 
@@ -219,6 +222,7 @@ public class PostController {
         private long views;
         private List<CommentDto> comments;
         private List<ReactionDto> reactions;
+        private java.util.List<AuthorDto> participants;
     }
 
     @Data

--- a/src/main/java/com/openisle/repository/CommentRepository.java
+++ b/src/main/java/com/openisle/repository/CommentRepository.java
@@ -13,4 +13,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findByParentOrderByCreatedAtAsc(Comment parent);
     List<Comment> findByAuthorOrderByCreatedAtDesc(User author, Pageable pageable);
     List<Comment> findByContentContainingIgnoreCase(String keyword);
+
+    @org.springframework.data.jpa.repository.Query("SELECT DISTINCT c.author FROM Comment c WHERE c.post = :post")
+    java.util.List<User> findDistinctAuthorsByPost(@org.springframework.data.repository.query.Param("post") Post post);
 }

--- a/src/main/java/com/openisle/service/CommentService.java
+++ b/src/main/java/com/openisle/service/CommentService.java
@@ -102,6 +102,16 @@ public class CommentService {
         return commentRepository.findByAuthorOrderByCreatedAtDesc(user, pageable);
     }
 
+    public java.util.List<User> getParticipants(Long postId, int limit) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("Post not found"));
+        java.util.LinkedHashSet<User> set = new java.util.LinkedHashSet<>();
+        set.add(post.getAuthor());
+        set.addAll(commentRepository.findDistinctAuthorsByPost(post));
+        java.util.List<User> list = new java.util.ArrayList<>(set);
+        return list.subList(0, Math.min(limit, list.size()));
+    }
+
     public java.util.List<Comment> getCommentsByIds(java.util.List<Long> ids) {
         return commentRepository.findAllById(ids);
     }

--- a/src/test/java/com/openisle/controller/PostControllerTest.java
+++ b/src/test/java/com/openisle/controller/PostControllerTest.java
@@ -73,6 +73,7 @@ class PostControllerTest {
         post.setAuthor(user);
         post.setCategory(cat);
         post.setTags(java.util.Set.of(tag));
+        Mockito.when(commentService.getParticipants(Mockito.anyLong(), Mockito.anyInt())).thenReturn(java.util.List.of());
         Mockito.when(postService.createPost(eq("alice"), eq(1L), eq("t"), eq("c"), eq(java.util.List.of(1L)))).thenReturn(post);
         Mockito.when(postService.viewPost(eq(1L), Mockito.isNull())).thenReturn(post);
 
@@ -110,6 +111,7 @@ class PostControllerTest {
         post.setAuthor(user);
         post.setCategory(cat);
         post.setTags(java.util.Set.of(tag));
+        Mockito.when(commentService.getParticipants(Mockito.anyLong(), Mockito.anyInt())).thenReturn(java.util.List.of());
         Mockito.when(postService.listPostsByCategories(Mockito.isNull(), Mockito.isNull(), Mockito.isNull()))
                 .thenReturn(List.of(post));
 
@@ -182,6 +184,7 @@ class PostControllerTest {
         Mockito.when(commentService.getCommentsForPost(1L)).thenReturn(List.of(comment));
         Mockito.when(commentService.getReplies(2L)).thenReturn(List.of(reply));
         Mockito.when(commentService.getReplies(3L)).thenReturn(List.of());
+        Mockito.when(commentService.getParticipants(Mockito.anyLong(), Mockito.anyInt())).thenReturn(java.util.List.of());
         Mockito.when(reactionService.getReactionsForPost(1L)).thenReturn(List.of(pr));
         Mockito.when(reactionService.getReactionsForComment(2L)).thenReturn(List.of(cr));
         Mockito.when(reactionService.getReactionsForComment(3L)).thenReturn(List.of());
@@ -209,6 +212,7 @@ class PostControllerTest {
         post.setAuthor(user);
         post.setCategory(cat);
         post.setTags(java.util.Set.of(tag));
+        Mockito.when(commentService.getParticipants(Mockito.anyLong(), Mockito.anyInt())).thenReturn(java.util.List.of());
 
         Mockito.when(postService.listPostsByCategoriesAndTags(eq(java.util.List.of(1L)), eq(java.util.List.of(1L, 2L)), eq(0), eq(5)))
                 .thenReturn(List.of(post));
@@ -241,6 +245,7 @@ class PostControllerTest {
         post.setAuthor(user);
         post.setCategory(cat);
         post.setTags(java.util.Set.of(tag));
+        Mockito.when(commentService.getParticipants(Mockito.anyLong(), Mockito.anyInt())).thenReturn(java.util.List.of());
 
         Mockito.when(postService.listPostsByViews(eq(java.util.List.of(1L)), eq(java.util.List.of(1L, 2L)), eq(0), eq(5)))
                 .thenReturn(List.of(post));


### PR DESCRIPTION
## Summary
- expose post participants via backend
- show participant avatars linking to profiles on home page
- adjust unit tests for new service call

## Testing
- `mvn -q test` *(fails: could not resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686f71afcc28832b8c078cb722fe42e2