### PR TITLE
Implement profile follow tab

### DIFF
--- a/open-isle-cli/src/components/UserList.vue
+++ b/open-isle-cli/src/components/UserList.vue
@@ -1,0 +1,52 @@
+<template>
+  <div class="user-list">
+    <div v-for="u in users" :key="u.id" class="user-item">
+      <img :src="u.avatar" alt="avatar" class="user-avatar" />
+      <div class="user-info">
+        <div class="user-name">{{ u.username }}</div>
+        <div v-if="u.introduction" class="user-intro">{{ u.introduction }}</div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'UserList',
+  props: {
+    users: { type: Array, default: () => [] }
+  }
+}
+</script>
+
+<style scoped>
+.user-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.user-item {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 10px;
+}
+.user-avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  object-fit: cover;
+}
+.user-info {
+  display: flex;
+  flex-direction: column;
+}
+.user-name {
+  font-weight: bold;
+}
+.user-intro {
+  font-size: 14px;
+  opacity: 0.7;
+}
+</style>


### PR DESCRIPTION
## Summary
- lazy-load profile timeline and followers
- add followers/following tabs with loading indicator
- create reusable `UserList` component for displaying users

## Testing
- `npm --prefix open-isle-cli run lint` *(fails: vue-cli-service not found)*
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f7387765c832b99ac89f7af852083