### PR TITLE
Add follow notification details

### DIFF
--- a/src/main/java/com/openisle/model/NotificationType.java
+++ b/src/main/java/com/openisle/model/NotificationType.java
@@ -14,6 +14,12 @@ public enum NotificationType {
     POST_REVIEWED,
     /** A subscribed post received a new comment */
     POST_UPDATED,
+    /** Someone you follow published a new post */
+    FOLLOWED_POST,
+    /** Someone started following you */
+    USER_FOLLOWED,
+    /** Someone unfollowed you */
+    USER_UNFOLLOWED,
     /** A user you subscribe to created a post or comment */
     USER_ACTIVITY
 }

--- a/src/main/java/com/openisle/service/PostService.java
+++ b/src/main/java/com/openisle/service/PostService.java
@@ -83,7 +83,14 @@ public class PostService {
         // notify followers of author
         for (User u : subscriptionService.getSubscribers(author.getUsername())) {
             if (!u.getId().equals(author.getId())) {
-                notificationService.createNotification(u, NotificationType.USER_ACTIVITY, post, null, null);
+                notificationService.createNotification(
+                        u,
+                        NotificationType.FOLLOWED_POST,
+                        post,
+                        null,
+                        null,
+                        author,
+                        null);
             }
         }
         return post;


### PR DESCRIPTION
## Summary
- include post author as the sender of FOLLOWED_POST notifications
- show names and links for follow notifications in message page
- handle new notification types in the message list

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686f894495fc832bbf31230315a4a78f