### PR TITLE
Add post subscription notifications

### DIFF
--- a/open-isle-cli/src/views/MessagePageView.vue
+++ b/open-isle-cli/src/views/MessagePageView.vue
@@ -95,6 +95,28 @@
                 </router-link>
               </div>
             </template>
+            <template v-else-if="item.type === 'POST_SUBSCRIBED'">
+              <div class="notif-content-container">
+                <router-link class="notif-content-text" @click="markRead(item.id)" :to="`/users/${item.fromUser.id}`">
+                  {{ item.fromUser.username }}
+                </router-link>
+                订阅了你的文章
+                <router-link class="notif-content-text" @click="markRead(item.id)" :to="`/posts/${item.post.id}`">
+                  {{ sanitizeDescription(item.post.title) }}
+                </router-link>
+              </div>
+            </template>
+            <template v-else-if="item.type === 'POST_UNSUBSCRIBED'">
+              <div class="notif-content-container">
+                <router-link class="notif-content-text" @click="markRead(item.id)" :to="`/users/${item.fromUser.id}`">
+                  {{ item.fromUser.username }}
+                </router-link>
+                取消订阅了你的文章
+                <router-link class="notif-content-text" @click="markRead(item.id)" :to="`/posts/${item.post.id}`">
+                  {{ sanitizeDescription(item.post.title) }}
+                </router-link>
+              </div>
+            </template>
             <template v-else>
               <div class="notif-content-container">
                 {{ formatType(item.type) }}
@@ -146,7 +168,9 @@ export default {
       USER_ACTIVITY: 'fas fa-user',
       FOLLOWED_POST: 'fas fa-feather-alt',
       USER_FOLLOWED: 'fas fa-user-plus',
-      USER_UNFOLLOWED: 'fas fa-user-minus'
+      USER_UNFOLLOWED: 'fas fa-user-minus',
+      POST_SUBSCRIBED: 'fas fa-bookmark',
+      POST_UNSUBSCRIBED: 'fas fa-bookmark'
     }
 
     const reactionEmojiMap = {
@@ -223,6 +247,17 @@ export default {
                   }
                 }
               })
+            } else if (n.type === 'POST_SUBSCRIBED' || n.type === 'POST_UNSUBSCRIBED') {
+              notifications.value.push({
+                ...n,
+                icon: iconMap[n.type],
+                iconClick: () => {
+                  if (n.post) {
+                    markRead(n.id)
+                    router.push(`/posts/${n.post.id}`)
+                  }
+                }
+              })
             } else {
               notifications.value.push({
                 ...n,
@@ -249,6 +284,10 @@ export default {
           return '关注的帖子有新评论'
         case 'FOLLOWED_POST':
           return '关注的用户发布了新文章'
+        case 'POST_SUBSCRIBED':
+          return '有人订阅了你的文章'
+        case 'POST_UNSUBSCRIBED':
+          return '有人取消订阅你的文章'
         case 'USER_FOLLOWED':
           return '有人关注了你'
         case 'USER_UNFOLLOWED':

--- a/src/main/java/com/openisle/model/NotificationType.java
+++ b/src/main/java/com/openisle/model/NotificationType.java
@@ -14,6 +14,10 @@ public enum NotificationType {
     POST_REVIEWED,
     /** A subscribed post received a new comment */
     POST_UPDATED,
+    /** Someone subscribed to your post */
+    POST_SUBSCRIBED,
+    /** Someone unsubscribed from your post */
+    POST_UNSUBSCRIBED,
     /** Someone you follow published a new post */
     FOLLOWED_POST,
     /** Someone started following you */


### PR DESCRIPTION
## Summary
- send notifications when posts are subscribed/unsubscribed
- expose post subscription status in post details
- support subscribing/unsubscribing to posts in UI
- display related notifications in message center

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68709946f31c832b9b59ef62faa116a5