### PR TITLE
Update reaction feature

### DIFF
--- a/open-isle-cli/src/components/ReactionsGroup.vue
+++ b/open-isle-cli/src/components/ReactionsGroup.vue
@@ -58,7 +58,15 @@ const iconMap = {
   LIKE: '❤️',
   DISLIKE: '👎',
   RECOMMEND: '👏',
-  ANGRY: '😡'
+  ANGRY: '😡',
+  FLUSHED: '😳',
+  STAR_STRUCK: '🤩',
+  ROFL: '🤣',
+  HOLDING_BACK_TEARS: '🥹',
+  MIND_BLOWN: '🤯',
+  POOP: '💩',
+  CLOWN: '🤡',
+  SKULL: '☠️'
 }
 
 export default {

--- a/open-isle-cli/src/views/MessagePageView.vue
+++ b/open-isle-cli/src/views/MessagePageView.vue
@@ -153,7 +153,15 @@ export default {
       LIKE: '❤️',
       DISLIKE: '👎',
       RECOMMEND: '👏',
-      ANGRY: '😡'
+      ANGRY: '😡',
+      FLUSHED: '😳',
+      STAR_STRUCK: '🤩',
+      ROFL: '🤣',
+      HOLDING_BACK_TEARS: '🥹',
+      MIND_BLOWN: '🤯',
+      POOP: '💩',
+      CLOWN: '🤡',
+      SKULL: '☠️'
     }
 
     const sanitizeDescription = (text) => {

--- a/src/main/java/com/openisle/model/Reaction.java
+++ b/src/main/java/com/openisle/model/Reaction.java
@@ -12,7 +12,11 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
-@Table(name = "reactions")
+@Table(name = "reactions",
+       uniqueConstraints = {
+           @UniqueConstraint(columnNames = {"user_id", "post_id", "type"}),
+           @UniqueConstraint(columnNames = {"user_id", "comment_id", "type"})
+       })
 public class Reaction {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/openisle/model/ReactionType.java
+++ b/src/main/java/com/openisle/model/ReactionType.java
@@ -7,5 +7,13 @@ public enum ReactionType {
     LIKE,
     DISLIKE,
     RECOMMEND,
-    ANGRY
+    ANGRY,
+    FLUSHED,
+    STAR_STRUCK,
+    ROFL,
+    HOLDING_BACK_TEARS,
+    MIND_BLOWN,
+    POOP,
+    CLOWN,
+    SKULL
 }

--- a/src/main/java/com/openisle/service/ReactionService.java
+++ b/src/main/java/com/openisle/service/ReactionService.java
@@ -28,6 +28,12 @@ public class ReactionService {
                 .orElseThrow(() -> new IllegalArgumentException("User not found"));
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new IllegalArgumentException("Post not found"));
+        java.util.Optional<Reaction> existing =
+                reactionRepository.findByUserAndPostAndType(user, post, type);
+        if (existing.isPresent()) {
+            reactionRepository.delete(existing.get());
+            return null;
+        }
         Reaction reaction = new Reaction();
         reaction.setUser(user);
         reaction.setPost(post);
@@ -44,6 +50,12 @@ public class ReactionService {
                 .orElseThrow(() -> new IllegalArgumentException("User not found"));
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new IllegalArgumentException("Comment not found"));
+        java.util.Optional<Reaction> existing =
+                reactionRepository.findByUserAndCommentAndType(user, comment, type);
+        if (existing.isPresent()) {
+            reactionRepository.delete(existing.get());
+            return null;
+        }
         Reaction reaction = new Reaction();
         reaction.setUser(user);
         reaction.setComment(comment);


### PR DESCRIPTION
## Summary
- enforce unique reaction per type on posts/comments
- add new reaction types
- expose new reaction icons on the frontend

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68709e41eef0832b94ed6bf4ffc69a7b