### PR TITLE
Implement admin notifications for post reviews

### DIFF
--- a/src/main/java/com/openisle/model/NotificationType.java
+++ b/src/main/java/com/openisle/model/NotificationType.java
@@ -12,6 +12,8 @@ public enum NotificationType {
     REACTION,
     /** Your post under review was approved or rejected */
     POST_REVIEWED,
+    /** A new post requires review by administrators */
+    POST_REVIEW_REQUIRED,
     /** A subscribed post received a new comment */
     POST_UPDATED,
     /** Someone subscribed to your post */

--- a/src/main/java/com/openisle/repository/UserRepository.java
+++ b/src/main/java/com/openisle/repository/UserRepository.java
@@ -8,4 +8,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUsername(String username);
     Optional<User> findByEmail(String email);
     java.util.List<User> findByUsernameContainingIgnoreCase(String keyword);
+    java.util.List<User> findByRole(com.openisle.model.Role role);
 }

--- a/src/test/java/com/openisle/integration/PublishModeIntegrationTest.java
+++ b/src/test/java/com/openisle/integration/PublishModeIntegrationTest.java
@@ -84,6 +84,14 @@ class PublishModeIntegrationTest {
                         "tagIds", List.of(tagId)), userToken);
         Long postId = ((Number)postResp.getBody().get("id")).longValue();
 
+        // author can view pending post
+        ResponseEntity<Map> authorView = get("/api/posts/" + postId, Map.class, userToken);
+        assertEquals(HttpStatus.OK, authorView.getStatusCode());
+
+        // anonymous cannot view pending post
+        ResponseEntity<Map> anonView = get("/api/posts/" + postId, Map.class, null);
+        assertEquals(HttpStatus.BAD_REQUEST, anonView.getStatusCode());
+
         List<?> list = rest.getForObject("/api/posts", List.class);
         assertTrue(list.isEmpty(), "Post should not be listed before approval");
 
@@ -95,5 +103,8 @@ class PublishModeIntegrationTest {
 
         List<?> listAfter = rest.getForObject("/api/posts", List.class);
         assertEquals(1, listAfter.size(), "Post should appear after approval");
+
+        ResponseEntity<Map> viewAfter = get("/api/posts/" + postId, Map.class, null);
+        assertEquals(HttpStatus.OK, viewAfter.getStatusCode());
     }
 }


### PR DESCRIPTION
## Summary
- notify admins when a post enters pending state
- allow admins and authors to view non-published posts
- expose admin lookup by role
- test post visibility in review mode

## Testing
- `mvn -q test` *(fails: Could not download dependencies)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6870a67b7b48832b9cd92ebd9fb89920