### PR TITLE
Implement post and tag review workflow

### DIFF
--- a/open-isle-cli/src/utils/auth.js
+++ b/open-isle-cli/src/utils/auth.js
@@ -4,16 +4,19 @@ import { reactive } from 'vue'
 const TOKEN_KEY = 'token'
 const USER_ID_KEY = 'userId'
 const USERNAME_KEY = 'username'
+const ROLE_KEY = 'role'
 
 export const authState = reactive({
   loggedIn: false,
   userId: null,
-  username: null
+  username: null,
+  role: null
 })
 
 authState.loggedIn = localStorage.getItem(TOKEN_KEY) !== null && localStorage.getItem(TOKEN_KEY) !== ''
 authState.userId = localStorage.getItem(USER_ID_KEY)
 authState.username = localStorage.getItem(USERNAME_KEY)
+authState.role = localStorage.getItem(ROLE_KEY)
 
 export function getToken() {
   return localStorage.getItem(TOKEN_KEY)
@@ -33,6 +36,10 @@ export function clearToken() {
 export function setUserInfo({ id, username }) {
   authState.userId = id
   authState.username = username
+  if (arguments[0] && arguments[0].role) {
+    authState.role = arguments[0].role
+    localStorage.setItem(ROLE_KEY, arguments[0].role)
+  }
   if (id !== undefined && id !== null) localStorage.setItem(USER_ID_KEY, id)
   if (username) localStorage.setItem(USERNAME_KEY, username)
 }
@@ -40,8 +47,10 @@ export function setUserInfo({ id, username }) {
 export function clearUserInfo() {
   localStorage.removeItem(USER_ID_KEY)
   localStorage.removeItem(USERNAME_KEY)
+  localStorage.removeItem(ROLE_KEY)
   authState.userId = null
   authState.username = null
+  authState.role = null
 }
 
 export async function fetchCurrentUser() {
@@ -61,7 +70,7 @@ export async function fetchCurrentUser() {
 export async function loadCurrentUser() {
   const user = await fetchCurrentUser()
   if (user) {
-    setUserInfo({ id: user.id, username: user.username })
+    setUserInfo({ id: user.id, username: user.username, role: user.role })
   }
   return user
 }

--- a/open-isle-cli/src/views/MessagePageView.vue
+++ b/open-isle-cli/src/views/MessagePageView.vue
@@ -187,6 +187,7 @@ export default {
       POST_VIEWED: 'fas fa-eye',
       COMMENT_REPLY: 'fas fa-reply',
       POST_REVIEWED: 'fas fa-check',
+      POST_REVIEW_REQUEST: 'fas fa-gavel',
       POST_UPDATED: 'fas fa-comment-dots',
       USER_ACTIVITY: 'fas fa-user',
       FOLLOWED_POST: 'fas fa-feather-alt',
@@ -310,6 +311,18 @@ export default {
                   }
                 }
               })
+            } else if (n.type === 'POST_REVIEW_REQUEST') {
+              notifications.value.push({
+                ...n,
+                src: n.fromUser ? n.fromUser.avatar : null,
+                icon: n.fromUser ? undefined : iconMap[n.type],
+                iconClick: () => {
+                  if (n.post) {
+                    markRead(n.id)
+                    router.push(`/posts/${n.post.id}`)
+                  }
+                }
+              })
             } else {
               notifications.value.push({
                 ...n,
@@ -330,6 +343,8 @@ export default {
           return '有人回复了你'
         case 'REACTION':
           return '有人点赞'
+        case 'POST_REVIEW_REQUEST':
+          return '帖子待审核'
         case 'POST_REVIEWED':
           return '帖子审核结果'
         case 'POST_UPDATED':

--- a/src/main/java/com/openisle/controller/AdminPostController.java
+++ b/src/main/java/com/openisle/controller/AdminPostController.java
@@ -45,6 +45,7 @@ public class AdminPostController {
         dto.setAuthor(post.getAuthor().getUsername());
         dto.setCategory(toCategoryDto(post.getCategory()));
         dto.setViews(post.getViews());
+        dto.setStatus(post.getStatus());
         return dto;
     }
 
@@ -67,6 +68,7 @@ public class AdminPostController {
         private String author;
         private CategoryDto category;
         private long views;
+        private com.openisle.model.PostStatus status;
     }
 
     @Data

--- a/src/main/java/com/openisle/controller/AdminTagController.java
+++ b/src/main/java/com/openisle/controller/AdminTagController.java
@@ -1,0 +1,54 @@
+package com.openisle.controller;
+
+import com.openisle.model.Tag;
+import com.openisle.service.TagService;
+import com.openisle.service.PostService;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/admin/tags")
+@RequiredArgsConstructor
+public class AdminTagController {
+    private final TagService tagService;
+    private final PostService postService;
+
+    @GetMapping("/pending")
+    public List<TagDto> pendingTags() {
+        return tagService.listPendingTags().stream()
+                .map(t -> toDto(t, postService.countPostsByTag(t.getId())))
+                .collect(Collectors.toList());
+    }
+
+    @PostMapping("/{id}/approve")
+    public TagDto approve(@PathVariable Long id) {
+        Tag tag = tagService.approveTag(id);
+        long count = postService.countPostsByTag(tag.getId());
+        return toDto(tag, count);
+    }
+
+    private TagDto toDto(Tag tag, long count) {
+        TagDto dto = new TagDto();
+        dto.setId(tag.getId());
+        dto.setName(tag.getName());
+        dto.setDescription(tag.getDescription());
+        dto.setIcon(tag.getIcon());
+        dto.setSmallIcon(tag.getSmallIcon());
+        dto.setCount(count);
+        return dto;
+    }
+
+    @Data
+    private static class TagDto {
+        private Long id;
+        private String name;
+        private String description;
+        private String icon;
+        private String smallIcon;
+        private Long count;
+    }
+}

--- a/src/main/java/com/openisle/controller/PostController.java
+++ b/src/main/java/com/openisle/controller/PostController.java
@@ -117,6 +117,7 @@ public class PostController {
         dto.setCategory(toCategoryDto(post.getCategory()));
         dto.setTags(post.getTags().stream().map(this::toTagDto).collect(Collectors.toList()));
         dto.setViews(post.getViews());
+        dto.setStatus(post.getStatus());
 
         List<ReactionDto> reactions = reactionService.getReactionsForPost(post.getId())
                 .stream()
@@ -232,6 +233,7 @@ public class PostController {
         private CategoryDto category;
         private java.util.List<TagDto> tags;
         private long views;
+        private com.openisle.model.PostStatus status;
         private List<CommentDto> comments;
         private List<ReactionDto> reactions;
         private java.util.List<AuthorDto> participants;

--- a/src/main/java/com/openisle/model/NotificationType.java
+++ b/src/main/java/com/openisle/model/NotificationType.java
@@ -10,6 +10,8 @@ public enum NotificationType {
     COMMENT_REPLY,
     /** Someone reacted to your post or comment */
     REACTION,
+    /** A new post is waiting for review */
+    POST_REVIEW_REQUEST,
     /** Your post under review was approved or rejected */
     POST_REVIEWED,
     /** A subscribed post received a new comment */

--- a/src/main/java/com/openisle/model/Tag.java
+++ b/src/main/java/com/openisle/model/Tag.java
@@ -26,4 +26,7 @@ public class Tag {
 
     @Column(name = "description", nullable = false)
     private String description;
+
+    @Column(nullable = false)
+    private boolean approved = true;
 }

--- a/src/main/java/com/openisle/repository/TagRepository.java
+++ b/src/main/java/com/openisle/repository/TagRepository.java
@@ -7,4 +7,7 @@ import java.util.List;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
     List<Tag> findByNameContainingIgnoreCase(String keyword);
+    List<Tag> findByApproved(boolean approved);
+    List<Tag> findByApprovedTrue();
+    List<Tag> findByNameContainingIgnoreCaseAndApprovedTrue(String keyword);
 }

--- a/src/main/java/com/openisle/repository/UserRepository.java
+++ b/src/main/java/com/openisle/repository/UserRepository.java
@@ -8,4 +8,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUsername(String username);
     Optional<User> findByEmail(String email);
     java.util.List<User> findByUsernameContainingIgnoreCase(String keyword);
+    java.util.List<User> findByRole(com.openisle.model.Role role);
 }

--- a/src/main/java/com/openisle/service/TagService.java
+++ b/src/main/java/com/openisle/service/TagService.java
@@ -13,14 +13,19 @@ public class TagService {
     private final TagRepository tagRepository;
     private final TagValidator tagValidator;
 
-    public Tag createTag(String name, String description, String icon, String smallIcon) {
+    public Tag createTag(String name, String description, String icon, String smallIcon, boolean approved) {
         tagValidator.validate(name);
         Tag tag = new Tag();
         tag.setName(name);
         tag.setDescription(description);
         tag.setIcon(icon);
         tag.setSmallIcon(smallIcon);
+        tag.setApproved(approved);
         return tagRepository.save(tag);
+    }
+
+    public Tag createTag(String name, String description, String icon, String smallIcon) {
+        return createTag(name, description, icon, smallIcon, true);
     }
 
     public Tag updateTag(Long id, String name, String description, String icon, String smallIcon) {
@@ -46,19 +51,30 @@ public class TagService {
         tagRepository.deleteById(id);
     }
 
+    public Tag approveTag(Long id) {
+        Tag tag = tagRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Tag not found"));
+        tag.setApproved(true);
+        return tagRepository.save(tag);
+    }
+
+    public List<Tag> listPendingTags() {
+        return tagRepository.findByApproved(false);
+    }
+
     public Tag getTag(Long id) {
         return tagRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Tag not found"));
     }
 
     public List<Tag> listTags() {
-        return tagRepository.findAll();
+        return tagRepository.findByApprovedTrue();
     }
 
     public List<Tag> searchTags(String keyword) {
         if (keyword == null || keyword.isBlank()) {
-            return tagRepository.findAll();
+            return tagRepository.findByApprovedTrue();
         }
-        return tagRepository.findByNameContainingIgnoreCase(keyword);
+        return tagRepository.findByNameContainingIgnoreCaseAndApprovedTrue(keyword);
     }
 }


### PR DESCRIPTION
## Summary
- support POST_REVIEW_REQUEST notifications for admins
- allow admins and authors to view pending/rejected posts
- notify admins when a post awaits review
- add `approved` field to tags and admin endpoints to approve
- show post status and review actions on frontend
- keep user role in auth state

## Testing
- `npm test` *(fails: Missing script)*
- `mvn -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870a67b7b48832b9cd92ebd9fb89920