### PR TITLE
Implement deletion for posts and comments

### DIFF
--- a/open-isle-cli/src/components/CommentItem.vue
+++ b/open-isle-cli/src/components/CommentItem.vue
@@ -70,6 +70,7 @@ import ReactionsGroup from './ReactionsGroup.vue'
 import DropdownMenu from './DropdownMenu.vue'
 const CommentItem = {
   name: 'CommentItem',
+  emits: ['deleted'],
   props: {
     comment: {
       type: Object,
@@ -84,7 +85,7 @@ const CommentItem = {
       default: false
     }
   },
-  setup(props) {
+  setup(props, { emit }) {
     const router = useRouter()
     const showReplies = ref(props.defaultShowReplies)
     watch(
@@ -105,7 +106,22 @@ const CommentItem = {
     const commentMenuItems = computed(() =>
       isAuthor.value ? [{ text: '删除评论', color: 'red', onClick: () => deleteComment() }] : []
     )
-    const deleteComment = () => {
+    const deleteComment = async () => {
+      const token = getToken()
+      if (!token) {
+        toast.error('请先登录')
+        return
+      }
+      const res = await fetch(`${API_BASE_URL}/api/comments/${props.comment.id}`, {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${token}` }
+      })
+      if (res.ok) {
+        toast.success('已删除')
+        emit('deleted', props.comment.id)
+      } else {
+        toast.error('操作失败')
+      }
     }
     const submitReply = async (text) => {
       if (!text.trim()) return

--- a/src/main/java/com/openisle/controller/CommentController.java
+++ b/src/main/java/com/openisle/controller/CommentController.java
@@ -65,6 +65,11 @@ public class CommentController {
         return dto;
     }
 
+    @DeleteMapping("/comments/{id}")
+    public void deleteComment(@PathVariable Long id, Authentication auth) {
+        commentService.deleteComment(auth.getName(), id);
+    }
+
     private CommentDto toDto(Comment comment) {
         CommentDto dto = new CommentDto();
         dto.setId(comment.getId());

--- a/src/main/java/com/openisle/controller/PostController.java
+++ b/src/main/java/com/openisle/controller/PostController.java
@@ -48,6 +48,11 @@ public class PostController {
         return ResponseEntity.ok(toDto(post));
     }
 
+    @DeleteMapping("/{id}")
+    public void deletePost(@PathVariable Long id, Authentication auth) {
+        postService.deletePost(id, auth.getName());
+    }
+
     @GetMapping("/{id}")
     public ResponseEntity<PostDto> getPost(@PathVariable Long id, Authentication auth) {
         String viewer = auth != null ? auth.getName() : null;

--- a/src/main/java/com/openisle/repository/NotificationRepository.java
+++ b/src/main/java/com/openisle/repository/NotificationRepository.java
@@ -2,6 +2,8 @@ package com.openisle.repository;
 
 import com.openisle.model.Notification;
 import com.openisle.model.User;
+import com.openisle.model.Post;
+import com.openisle.model.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -11,4 +13,6 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     List<Notification> findByUserOrderByCreatedAtDesc(User user);
     List<Notification> findByUserAndReadOrderByCreatedAtDesc(User user, boolean read);
     long countByUserAndRead(User user, boolean read);
+    List<Notification> findByPost(Post post);
+    List<Notification> findByComment(Comment comment);
 }


### PR DESCRIPTION
## Summary
- allow deleting posts from backend and UI
- support deleting comments with replies from backend and UI
- update notification repository for query helpers
- cascade delete related reactions and subscriptions

## Testing
- `mvn -q -DskipTests=true package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6870d4842e08832ba543394aedadec88