### PR TITLE
Allow admin delete on FE

### DIFF
--- a/open-isle-cli/src/components/CommentItem.vue
+++ b/open-isle-cli/src/components/CommentItem.vue
@@ -103,8 +103,9 @@ const CommentItem = {
       showEditor.value = !showEditor.value
     }
     const isAuthor = computed(() => authState.username === props.comment.userName)
+    const isAdmin = computed(() => authState.role === 'ADMIN')
     const commentMenuItems = computed(() =>
-      isAuthor.value ? [{ text: '删除评论', color: 'red', onClick: () => deleteComment() }] : []
+      (isAuthor.value || isAdmin.value) ? [{ text: '删除评论', color: 'red', onClick: () => deleteComment() }] : []
     )
     const deleteComment = async () => {
       const token = getToken()

--- a/open-isle-cli/src/views/PostPageView.vue
+++ b/open-isle-cli/src/views/PostPageView.vue
@@ -140,7 +140,7 @@ export default {
     const isAuthor = computed(() => authState.username === author.value.username)
     const articleMenuItems = computed(() => {
       const items = []
-      if (isAuthor.value) {
+      if (isAuthor.value || isAdmin.value) {
         items.push({ text: '删除文章', color: 'red', onClick: () => deletePost() })
       }
       if (isAdmin.value && status.value === 'PENDING') {


### PR DESCRIPTION
## Summary
- permit admins delete any posts
- allow admins delete comments

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_6873e0cb0d2883279a6bf94c82631d50