### PR TITLE
Clean up notifications when posts or comments are removed

### DIFF
--- a/src/main/java/com/openisle/service/CommentService.java
+++ b/src/main/java/com/openisle/service/CommentService.java
@@ -143,7 +143,7 @@ public class CommentService {
         }
         reactionRepository.findByComment(comment).forEach(reactionRepository::delete);
         commentSubscriptionRepository.findByComment(comment).forEach(commentSubscriptionRepository::delete);
-        notificationRepository.findByComment(comment).forEach(n -> { n.setComment(null); notificationRepository.save(n); });
+        notificationRepository.deleteAll(notificationRepository.findByComment(comment));
         commentRepository.delete(comment);
     }
 }

--- a/src/main/java/com/openisle/service/PostService.java
+++ b/src/main/java/com/openisle/service/PostService.java
@@ -353,7 +353,7 @@ public class PostService {
         }
         reactionRepository.findByPost(post).forEach(reactionRepository::delete);
         postSubscriptionRepository.findByPost(post).forEach(postSubscriptionRepository::delete);
-        notificationRepository.findByPost(post).forEach(n -> { n.setPost(null); notificationRepository.save(n); });
+        notificationRepository.deleteAll(notificationRepository.findByPost(post));
         postRepository.delete(post);
     }
 


### PR DESCRIPTION
## Summary
- delete notifications tied to removed comments
- delete notifications tied to removed posts

## Testing
- `mvn -q -DskipTests=false test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6873e485b968832793db5c93e34a94f5