### PR TITLE
Implement user visit tracking on post list

### DIFF
--- a/open-isle-cli/src/views/ProfileView.vue
+++ b/open-isle-cli/src/views/ProfileView.vue
@@ -64,19 +64,19 @@
             <div class="total-summary-content">
               <div class="total-summary-item">
                 <div class="total-summary-item-label">访问天数</div>
-                <div class="total-summary-item-value">0</div>
+                <div class="total-summary-item-value">{{ user.visitedDays }}</div>
               </div>
               <div class="total-summary-item">
                 <div class="total-summary-item-label">已读帖子</div>
-                <div class="total-summary-item-value">165k</div>
+                <div class="total-summary-item-value">{{ user.readPosts }}</div>
               </div>
               <div class="total-summary-item">
-                <div class="total-summary-item-label">已送出的💗/div>
-                <div class="total-summary-item-value">165k</div>
+                <div class="total-summary-item-label">已送出的💗</div>
+                <div class="total-summary-item-value">{{ user.likesSent }}</div>
               </div>
               <div class="total-summary-item">
                 <div class="total-summary-item-label">已收到的💗</div>
-                <div class="total-summary-item-value">165k</div>
+                <div class="total-summary-item-value">{{ user.likesReceived }}</div>
               </div>
             </div>
           </div>

--- a/src/main/java/com/openisle/controller/PostController.java
+++ b/src/main/java/com/openisle/controller/PostController.java
@@ -9,6 +9,7 @@ import com.openisle.service.ReactionService;
 import com.openisle.service.CaptchaService;
 import com.openisle.service.DraftService;
 import com.openisle.service.SubscriptionService;
+import com.openisle.service.UserVisitService;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -30,6 +31,7 @@ public class PostController {
     private final SubscriptionService subscriptionService;
     private final CaptchaService captchaService;
     private final DraftService draftService;
+    private final UserVisitService userVisitService;
 
     @Value("${app.captcha.enabled:false}")
     private boolean captchaEnabled;
@@ -66,7 +68,8 @@ public class PostController {
                                    @RequestParam(value = "tagId", required = false) Long tagId,
                                    @RequestParam(value = "tagIds", required = false) List<Long> tagIds,
                                    @RequestParam(value = "page", required = false) Integer page,
-                                   @RequestParam(value = "pageSize", required = false) Integer pageSize) {
+                                   @RequestParam(value = "pageSize", required = false) Integer pageSize,
+                                   Authentication auth) {
         List<Long> ids = categoryIds;
         if (categoryId != null) {
             ids = java.util.List.of(categoryId);
@@ -74,6 +77,10 @@ public class PostController {
         List<Long> tids = tagIds;
         if (tagId != null) {
             tids = java.util.List.of(tagId);
+        }
+
+        if (auth != null) {
+            userVisitService.recordVisit(auth.getName());
         }
 
         boolean hasCategories = ids != null && !ids.isEmpty();
@@ -98,7 +105,8 @@ public class PostController {
                                       @RequestParam(value = "tagId", required = false) Long tagId,
                                       @RequestParam(value = "tagIds", required = false) List<Long> tagIds,
                                       @RequestParam(value = "page", required = false) Integer page,
-                                      @RequestParam(value = "pageSize", required = false) Integer pageSize) {
+                                      @RequestParam(value = "pageSize", required = false) Integer pageSize,
+                                      Authentication auth) {
         List<Long> ids = categoryIds;
         if (categoryId != null) {
             ids = java.util.List.of(categoryId);
@@ -106,6 +114,10 @@ public class PostController {
         List<Long> tids = tagIds;
         if (tagId != null) {
             tids = java.util.List.of(tagId);
+        }
+
+        if (auth != null) {
+            userVisitService.recordVisit(auth.getName());
         }
 
         return postService.listPostsByViews(ids, tids, page, pageSize)

--- a/src/main/java/com/openisle/controller/UserController.java
+++ b/src/main/java/com/openisle/controller/UserController.java
@@ -23,6 +23,8 @@ public class UserController {
     private final CommentService commentService;
     private final ReactionService reactionService;
     private final SubscriptionService subscriptionService;
+    private final PostReadService postReadService;
+    private final UserVisitService userVisitService;
 
     @Value("${app.upload.check-type:true}")
     private boolean checkImageType;
@@ -170,6 +172,10 @@ public class UserController {
         dto.setCreatedAt(user.getCreatedAt());
         dto.setLastPostTime(postService.getLastPostTime(user.getUsername()));
         dto.setTotalViews(postService.getTotalViews(user.getUsername()));
+        dto.setVisitedDays(userVisitService.countVisits(user.getUsername()));
+        dto.setReadPosts(postReadService.countReads(user.getUsername()));
+        dto.setLikesSent(reactionService.countLikesSent(user.getUsername()));
+        dto.setLikesReceived(reactionService.countLikesReceived(user.getUsername()));
         if (viewer != null) {
             dto.setSubscribed(subscriptionService.isSubscribed(viewer.getName(), user.getUsername()));
         } else {
@@ -230,6 +236,10 @@ public class UserController {
         private java.time.LocalDateTime createdAt;
         private java.time.LocalDateTime lastPostTime;
         private long totalViews;
+        private long visitedDays;
+        private long readPosts;
+        private long likesSent;
+        private long likesReceived;
         private boolean subscribed;
     }
 

--- a/src/main/java/com/openisle/model/PostRead.java
+++ b/src/main/java/com/openisle/model/PostRead.java
@@ -1,0 +1,32 @@
+package com.openisle.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+/** Record of a user reading a post. */
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@Table(name = "post_reads",
+       uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "post_id"}))
+public class PostRead {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @Column(name = "last_read_at")
+    private LocalDateTime lastReadAt;
+}

--- a/src/main/java/com/openisle/model/UserVisit.java
+++ b/src/main/java/com/openisle/model/UserVisit.java
@@ -1,0 +1,28 @@
+package com.openisle.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+/** Daily visit record for a user. */
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@Table(name = "user_visits",
+       uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "visit_date"}))
+public class UserVisit {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(name = "visit_date", nullable = false)
+    private LocalDate visitDate;
+}

--- a/src/main/java/com/openisle/repository/PostReadRepository.java
+++ b/src/main/java/com/openisle/repository/PostReadRepository.java
@@ -1,0 +1,13 @@
+package com.openisle.repository;
+
+import com.openisle.model.Post;
+import com.openisle.model.PostRead;
+import com.openisle.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PostReadRepository extends JpaRepository<PostRead, Long> {
+    Optional<PostRead> findByUserAndPost(User user, Post post);
+    long countByUser(User user);
+}

--- a/src/main/java/com/openisle/repository/ReactionRepository.java
+++ b/src/main/java/com/openisle/repository/ReactionRepository.java
@@ -23,4 +23,10 @@ public interface ReactionRepository extends JpaRepository<Reaction, Long> {
 
     @Query("SELECT r.comment.id FROM Reaction r WHERE r.comment IS NOT NULL AND r.comment.author.username = :username AND r.type = com.openisle.model.ReactionType.LIKE GROUP BY r.comment.id ORDER BY COUNT(r.id) DESC")
     List<Long> findTopCommentIds(@Param("username") String username, Pageable pageable);
+
+    @Query("SELECT COUNT(r) FROM Reaction r WHERE r.user.username = :username AND r.type = com.openisle.model.ReactionType.LIKE")
+    long countLikesSent(@Param("username") String username);
+
+    @Query("SELECT COUNT(r) FROM Reaction r WHERE r.type = com.openisle.model.ReactionType.LIKE AND ((r.post IS NOT NULL AND r.post.author.username = :username) OR (r.comment IS NOT NULL AND r.comment.author.username = :username))")
+    long countLikesReceived(@Param("username") String username);
 }

--- a/src/main/java/com/openisle/repository/UserVisitRepository.java
+++ b/src/main/java/com/openisle/repository/UserVisitRepository.java
@@ -1,0 +1,13 @@
+package com.openisle.repository;
+
+import com.openisle.model.User;
+import com.openisle.model.UserVisit;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+public interface UserVisitRepository extends JpaRepository<UserVisit, Long> {
+    Optional<UserVisit> findByUserAndVisitDate(User user, LocalDate visitDate);
+    long countByUser(User user);
+}

--- a/src/main/java/com/openisle/service/PostReadService.java
+++ b/src/main/java/com/openisle/service/PostReadService.java
@@ -1,0 +1,44 @@
+package com.openisle.service;
+
+import com.openisle.model.Post;
+import com.openisle.model.PostRead;
+import com.openisle.model.User;
+import com.openisle.repository.PostReadRepository;
+import com.openisle.repository.PostRepository;
+import com.openisle.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class PostReadService {
+    private final PostReadRepository postReadRepository;
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
+
+    public void recordRead(String username, Long postId) {
+        if (username == null) return;
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("Post not found"));
+        postReadRepository.findByUserAndPost(user, post).ifPresentOrElse(pr -> {
+            pr.setLastReadAt(LocalDateTime.now());
+            postReadRepository.save(pr);
+        }, () -> {
+            PostRead pr = new PostRead();
+            pr.setUser(user);
+            pr.setPost(post);
+            pr.setLastReadAt(LocalDateTime.now());
+            postReadRepository.save(pr);
+        });
+    }
+
+    public long countReads(String username) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+        return postReadRepository.countByUser(user);
+    }
+}

--- a/src/main/java/com/openisle/service/PostService.java
+++ b/src/main/java/com/openisle/service/PostService.java
@@ -39,6 +39,7 @@ public class PostService {
     private final ReactionRepository reactionRepository;
     private final PostSubscriptionRepository postSubscriptionRepository;
     private final NotificationRepository notificationRepository;
+    private final PostReadService postReadService;
 
     @org.springframework.beans.factory.annotation.Autowired
     public PostService(PostRepository postRepository,
@@ -52,6 +53,7 @@ public class PostService {
                        ReactionRepository reactionRepository,
                        PostSubscriptionRepository postSubscriptionRepository,
                        NotificationRepository notificationRepository,
+                       PostReadService postReadService,
                        @Value("${app.post.publish-mode:DIRECT}") PublishMode publishMode) {
         this.postRepository = postRepository;
         this.userRepository = userRepository;
@@ -64,6 +66,7 @@ public class PostService {
         this.reactionRepository = reactionRepository;
         this.postSubscriptionRepository = postSubscriptionRepository;
         this.notificationRepository = notificationRepository;
+        this.postReadService = postReadService;
         this.publishMode = publishMode;
     }
 
@@ -142,6 +145,9 @@ public class PostService {
         }
         post.setViews(post.getViews() + 1);
         post = postRepository.save(post);
+        if (viewer != null) {
+            postReadService.recordRead(viewer, id);
+        }
         if (viewer != null && !viewer.equals(post.getAuthor().getUsername())) {
             User viewerUser = userRepository.findByUsername(viewer).orElse(null);
             if (viewerUser != null) {

--- a/src/main/java/com/openisle/service/ReactionService.java
+++ b/src/main/java/com/openisle/service/ReactionService.java
@@ -87,4 +87,12 @@ public class ReactionService {
     public java.util.List<Long> topCommentIds(String username, int limit) {
         return reactionRepository.findTopCommentIds(username, org.springframework.data.domain.PageRequest.of(0, limit));
     }
+
+    public long countLikesSent(String username) {
+        return reactionRepository.countLikesSent(username);
+    }
+
+    public long countLikesReceived(String username) {
+        return reactionRepository.countLikesReceived(username);
+    }
 }

--- a/src/main/java/com/openisle/service/UserVisitService.java
+++ b/src/main/java/com/openisle/service/UserVisitService.java
@@ -1,0 +1,35 @@
+package com.openisle.service;
+
+import com.openisle.model.User;
+import com.openisle.model.UserVisit;
+import com.openisle.repository.UserRepository;
+import com.openisle.repository.UserVisitRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class UserVisitService {
+    private final UserVisitRepository userVisitRepository;
+    private final UserRepository userRepository;
+
+    public void recordVisit(String username) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+        LocalDate today = LocalDate.now();
+        userVisitRepository.findByUserAndVisitDate(user, today).orElseGet(() -> {
+            UserVisit visit = new UserVisit();
+            visit.setUser(user);
+            visit.setVisitDate(today);
+            return userVisitRepository.save(visit);
+        });
+    }
+
+    public long countVisits(String username) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+        return userVisitRepository.countByUser(user);
+    }
+}


### PR DESCRIPTION
## Summary
- remove visit recording from auth controller
- count a visit whenever an authenticated user lists posts
- track visits on ranking list as well

## Testing
- `npm run lint`
- `mvn -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6874871ce87c832781e7e8182d099533