### PR TITLE
Add tag timeline and summary features

### DIFF
--- a/src/main/java/com/openisle/controller/TagController.java
+++ b/src/main/java/com/openisle/controller/TagController.java
@@ -30,7 +30,13 @@ public class TagController {
                 approved = false;
             }
         }
-        Tag tag = tagService.createTag(req.getName(), req.getDescription(), req.getIcon(), req.getSmallIcon(), approved);
+        Tag tag = tagService.createTag(
+                req.getName(),
+                req.getDescription(),
+                req.getIcon(),
+                req.getSmallIcon(),
+                approved,
+                auth != null ? auth.getName() : null);
         long count = postService.countPostsByTag(tag.getId());
         return toDto(tag, count);
     }

--- a/src/main/java/com/openisle/model/Tag.java
+++ b/src/main/java/com/openisle/model/Tag.java
@@ -4,6 +4,10 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
 
 @Entity
 @Getter
@@ -29,4 +33,13 @@ public class Tag {
 
     @Column(nullable = false)
     private boolean approved = true;
+
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false,
+            columnDefinition = "DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6)")
+    private LocalDateTime createdAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "creator_id")
+    private User creator;
 }

--- a/src/main/java/com/openisle/repository/TagRepository.java
+++ b/src/main/java/com/openisle/repository/TagRepository.java
@@ -1,7 +1,9 @@
 package com.openisle.repository;
 
 import com.openisle.model.Tag;
+import com.openisle.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
@@ -10,4 +12,7 @@ public interface TagRepository extends JpaRepository<Tag, Long> {
     List<Tag> findByApproved(boolean approved);
     List<Tag> findByApprovedTrue();
     List<Tag> findByNameContainingIgnoreCaseAndApprovedTrue(String keyword);
+
+    List<Tag> findByCreatorOrderByCreatedAtDesc(User creator, Pageable pageable);
+    List<Tag> findByCreator(User creator);
 }

--- a/src/test/java/com/openisle/controller/TagControllerTest.java
+++ b/src/test/java/com/openisle/controller/TagControllerTest.java
@@ -15,6 +15,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -38,7 +39,7 @@ class TagControllerTest {
         t.setDescription("d");
         t.setIcon("i");
         t.setSmallIcon("s1");
-        Mockito.when(tagService.createTag(eq("java"), eq("d"), eq("i"), eq("s1"))).thenReturn(t);
+        Mockito.when(tagService.createTag(eq("java"), eq("d"), eq("i"), eq("s1"), eq(true), isNull())).thenReturn(t);
         Mockito.when(tagService.getTag(1L)).thenReturn(t);
 
         mockMvc.perform(post("/api/tags")


### PR DESCRIPTION
## Summary
- track tag creator and creation time
- expose user tag APIs including hot-tags
- fetch and display created tags in ProfileView
- update timeline and summary sections for tags
- adjust tests

## Testing
- `mvn -q -DskipTests=false test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6874957e74dc83278453794b35d2ca2d