### PR TITLE
Fix draft saving when custom tags present

### DIFF
--- a/open-isle-cli/src/views/NewPostPageView.vue
+++ b/open-isle-cli/src/views/NewPostPageView.vue
@@ -98,6 +98,7 @@ export default {
         return
       }
       try {
+        const tagIds = selectedTags.value.filter(t => typeof t === 'number')
         const res = await fetch(`${API_BASE_URL}/api/drafts`, {
           method: 'POST',
           headers: {
@@ -108,7 +109,7 @@ export default {
             title: title.value,
             content: content.value,
             categoryId: selectedCategory.value || null,
-            tagIds: selectedTags.value
+            tagIds
           })
         })
         if (res.ok) {


### PR DESCRIPTION
## Summary
- ignore custom tags in `saveDraft` request

## Testing
- `npm run lint`
- `mvn -q test` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6874bca7663c8327942b1a0865b466b3