### PR TITLE
Fix deletion of posts with read records

### DIFF
--- a/src/main/java/com/openisle/repository/PostReadRepository.java
+++ b/src/main/java/com/openisle/repository/PostReadRepository.java
@@ -10,4 +10,5 @@ import java.util.Optional;
 public interface PostReadRepository extends JpaRepository<PostRead, Long> {
     Optional<PostRead> findByUserAndPost(User user, Post post);
     long countByUser(User user);
+    void deleteByPost(Post post);
 }

--- a/src/main/java/com/openisle/service/PostReadService.java
+++ b/src/main/java/com/openisle/service/PostReadService.java
@@ -41,4 +41,9 @@ public class PostReadService {
                 .orElseThrow(() -> new IllegalArgumentException("User not found"));
         return postReadRepository.countByUser(user);
     }
+
+    @org.springframework.transaction.annotation.Transactional
+    public void deleteByPost(Post post) {
+        postReadRepository.deleteByPost(post);
+    }
 }

--- a/src/main/java/com/openisle/service/PostService.java
+++ b/src/main/java/com/openisle/service/PostService.java
@@ -360,6 +360,7 @@ public class PostService {
         reactionRepository.findByPost(post).forEach(reactionRepository::delete);
         postSubscriptionRepository.findByPost(post).forEach(postSubscriptionRepository::delete);
         notificationRepository.deleteAll(notificationRepository.findByPost(post));
+        postReadService.deleteByPost(post);
         postRepository.delete(post);
     }
 

--- a/src/test/java/com/openisle/service/PostServiceTest.java
+++ b/src/test/java/com/openisle/service/PostServiceTest.java
@@ -1,0 +1,52 @@
+package com.openisle.service;
+
+import com.openisle.model.*;
+import com.openisle.repository.*;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+
+class PostServiceTest {
+    @Test
+    void deletePostRemovesReads() {
+        PostRepository postRepo = mock(PostRepository.class);
+        UserRepository userRepo = mock(UserRepository.class);
+        CategoryRepository catRepo = mock(CategoryRepository.class);
+        TagRepository tagRepo = mock(TagRepository.class);
+        NotificationService notifService = mock(NotificationService.class);
+        SubscriptionService subService = mock(SubscriptionService.class);
+        CommentService commentService = mock(CommentService.class);
+        CommentRepository commentRepo = mock(CommentRepository.class);
+        ReactionRepository reactionRepo = mock(ReactionRepository.class);
+        PostSubscriptionRepository subRepo = mock(PostSubscriptionRepository.class);
+        NotificationRepository notificationRepo = mock(NotificationRepository.class);
+        PostReadService postReadService = mock(PostReadService.class);
+
+        PostService service = new PostService(postRepo, userRepo, catRepo, tagRepo,
+                notifService, subService, commentService, commentRepo,
+                reactionRepo, subRepo, notificationRepo, postReadService,
+                PublishMode.DIRECT);
+
+        Post post = new Post();
+        post.setId(1L);
+        User author = new User();
+        author.setId(1L);
+        author.setRole(Role.USER);
+        post.setAuthor(author);
+
+        when(postRepo.findById(1L)).thenReturn(Optional.of(post));
+        when(userRepo.findByUsername("alice")).thenReturn(Optional.of(author));
+        when(commentRepo.findByPostAndParentIsNullOrderByCreatedAtAsc(post)).thenReturn(List.of());
+        when(reactionRepo.findByPost(post)).thenReturn(List.of());
+        when(subRepo.findByPost(post)).thenReturn(List.of());
+        when(notificationRepo.findByPost(post)).thenReturn(List.of());
+
+        service.deletePost(1L, "alice");
+
+        verify(postReadService).deleteByPost(post);
+        verify(postRepo).delete(post);
+    }
+}


### PR DESCRIPTION
## Summary
- delete post read records when removing a post
- expose repository method for deleting by post
- unit test to verify deletion cascades

## Testing
- `mvn -q test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6874cd6b44b0832794cce4edf2028780