### PR TITLE
Fix not-found responses

### DIFF
--- a/src/main/java/com/openisle/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/openisle/controller/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.openisle.controller;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -14,6 +15,15 @@ public class GlobalExceptionHandler {
     public ResponseEntity<?> handleFieldException(FieldException ex) {
         return ResponseEntity.badRequest()
                 .body(Map.of("error", ex.getMessage(), "field", ex.getField()));
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<?> handleIllegalArgumentException(IllegalArgumentException ex) {
+        String msg = ex.getMessage();
+        if (msg != null && (msg.contains("User not found") || msg.contains("Post not found"))) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("error", msg));
+        }
+        return ResponseEntity.badRequest().body(Map.of("error", msg));
     }
 
     @ExceptionHandler(Exception.class)


### PR DESCRIPTION
## Summary
- return HTTP 404 instead of 400 when a post or user is missing

## Testing
- `mvn -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6874dab101cc8327a71295b6d96abbc3