### PR TITLE
Add DAU stats filter and endpoint

### DIFF
--- a/src/main/java/com/openisle/controller/StatController.java
+++ b/src/main/java/com/openisle/controller/StatController.java
@@ -1,0 +1,26 @@
+package com.openisle.controller;
+
+import com.openisle.service.UserVisitService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/stats")
+@RequiredArgsConstructor
+public class StatController {
+    private final UserVisitService userVisitService;
+
+    @GetMapping("/dau")
+    public Map<String, Long> dau(@RequestParam(value = "date", required = false)
+                                 @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+        long count = userVisitService.countDau(date);
+        return Map.of("dau", count);
+    }
+}

--- a/src/main/java/com/openisle/repository/UserVisitRepository.java
+++ b/src/main/java/com/openisle/repository/UserVisitRepository.java
@@ -10,4 +10,5 @@ import java.util.Optional;
 public interface UserVisitRepository extends JpaRepository<UserVisit, Long> {
     Optional<UserVisit> findByUserAndVisitDate(User user, LocalDate visitDate);
     long countByUser(User user);
+    long countByVisitDate(LocalDate visitDate);
 }

--- a/src/main/java/com/openisle/service/UserVisitService.java
+++ b/src/main/java/com/openisle/service/UserVisitService.java
@@ -32,4 +32,9 @@ public class UserVisitService {
                 .orElseThrow(() -> new com.openisle.exception.NotFoundException("User not found"));
         return userVisitRepository.countByUser(user);
     }
+
+    public long countDau(LocalDate date) {
+        LocalDate d = date != null ? date : LocalDate.now();
+        return userVisitRepository.countByVisitDate(d);
+    }
 }

--- a/src/test/java/com/openisle/controller/AdminControllerTest.java
+++ b/src/test/java/com/openisle/controller/AdminControllerTest.java
@@ -11,6 +11,7 @@ import com.openisle.config.CustomAccessDeniedHandler;
 import com.openisle.config.SecurityConfig;
 import com.openisle.service.JwtService;
 import com.openisle.repository.UserRepository;
+import com.openisle.service.UserVisitService;
 import com.openisle.model.Role;
 import com.openisle.model.User;
 import java.util.Optional;
@@ -31,6 +32,8 @@ class AdminControllerTest {
     private JwtService jwtService;
     @MockBean
     private UserRepository userRepository;
+    @MockBean
+    private UserVisitService userVisitService;
 
     @Test
     void adminHelloReturnsMessage() throws Exception {

--- a/src/test/java/com/openisle/controller/HelloControllerTest.java
+++ b/src/test/java/com/openisle/controller/HelloControllerTest.java
@@ -11,6 +11,7 @@ import com.openisle.config.CustomAccessDeniedHandler;
 import com.openisle.config.SecurityConfig;
 import com.openisle.service.JwtService;
 import com.openisle.repository.UserRepository;
+import com.openisle.service.UserVisitService;
 import com.openisle.model.Role;
 import com.openisle.model.User;
 import java.util.Optional;
@@ -31,6 +32,8 @@ class HelloControllerTest {
     private JwtService jwtService;
     @MockBean
     private UserRepository userRepository;
+    @MockBean
+    private UserVisitService userVisitService;
 
     @Test
     void helloReturnsMessage() throws Exception {

--- a/src/test/java/com/openisle/controller/StatControllerTest.java
+++ b/src/test/java/com/openisle/controller/StatControllerTest.java
@@ -1,0 +1,54 @@
+package com.openisle.controller;
+
+import com.openisle.config.CustomAccessDeniedHandler;
+import com.openisle.config.SecurityConfig;
+import com.openisle.service.JwtService;
+import com.openisle.repository.UserRepository;
+import com.openisle.service.UserVisitService;
+import com.openisle.model.Role;
+import com.openisle.model.User;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Optional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(StatController.class)
+@AutoConfigureMockMvc
+@Import({SecurityConfig.class, CustomAccessDeniedHandler.class})
+class StatControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private JwtService jwtService;
+    @MockBean
+    private UserRepository userRepository;
+    @MockBean
+    private UserVisitService userVisitService;
+
+    @Test
+    void dauReturnsCount() throws Exception {
+        Mockito.when(jwtService.validateAndGetSubject("token")).thenReturn("user");
+        User user = new User();
+        user.setUsername("user");
+        user.setPassword("p");
+        user.setEmail("u@example.com");
+        user.setRole(Role.USER);
+        Mockito.when(userRepository.findByUsername("user")).thenReturn(Optional.of(user));
+        Mockito.when(userVisitService.countDau(Mockito.any())).thenReturn(3L);
+
+        mockMvc.perform(get("/api/stats/dau").header("Authorization", "Bearer token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.dau").value(3));
+    }
+}


### PR DESCRIPTION
## Summary
- record user visits for every authenticated request
- expose `/api/stats/dau` endpoint to query daily active users
- adjust security config to register the new filter
- update tests to include the new dependency

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: transfer failed)*

------
https://chatgpt.com/codex/tasks/task_e_687501b2e4dc832792c1efb923d4a5b2