### PR TITLE
Fix reaction types access

### DIFF
--- a/src/main/java/com/openisle/config/SecurityConfig.java
+++ b/src/main/java/com/openisle/config/SecurityConfig.java
@@ -98,6 +98,7 @@ public class SecurityConfig {
                     .requestMatchers(HttpMethod.GET, "/api/tags/**").permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/search/**").permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/users/**").permitAll()
+                    .requestMatchers(HttpMethod.GET, "/api/reaction-types").permitAll()
                     .requestMatchers(HttpMethod.POST, "/api/categories/**").hasAuthority("ADMIN")
                     .requestMatchers(HttpMethod.POST, "/api/tags/**").authenticated()
                     .requestMatchers(HttpMethod.DELETE, "/api/categories/**").hasAuthority("ADMIN")
@@ -126,7 +127,8 @@ public class SecurityConfig {
                 boolean publicGet = "GET".equalsIgnoreCase(request.getMethod()) &&
                         (uri.startsWith("/api/posts") || uri.startsWith("/api/comments") ||
                          uri.startsWith("/api/categories") || uri.startsWith("/api/tags") ||
-                         uri.startsWith("/api/search") || uri.startsWith("/api/users"));
+                         uri.startsWith("/api/search") || uri.startsWith("/api/users") ||
+                         uri.startsWith("/api/reaction-types"));
 
                 if (authHeader != null && authHeader.startsWith("Bearer ")) {
                     String token = authHeader.substring(7);


### PR DESCRIPTION
## Summary
- make `/api/reaction-types` publicly accessible

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68750677963083278296ab20caef6f6c