### PR TITLE
Improve login error handling and Google whitelist signup

### DIFF
--- a/open-isle-cli/src/utils/google.js
+++ b/open-isle-cli/src/utils/google.js
@@ -1,33 +1,47 @@
 import { API_BASE_URL, GOOGLE_CLIENT_ID, toast } from '../main'
 import { setToken, loadCurrentUser } from './auth'
 
-export function googleSignIn(redirect, reason) {
-  if (!window.google || !GOOGLE_CLIENT_ID) {
-    toast.error('Google 登录不可用')
-    return
-  }
-  window.google.accounts.id.initialize({
-    client_id: GOOGLE_CLIENT_ID,
-    callback: async ({ credential }) => {
-      try {
-        const res = await fetch(`${API_BASE_URL}/api/auth/google`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ idToken: credential, reason })
-        })
-        const data = await res.json()
-        if (res.ok && data.token) {
-          setToken(data.token)
-          await loadCurrentUser()
-          toast.success('登录成功')
-          if (redirect) redirect()
-        } else {
-          toast.error(data.error || '登录失败')
-        }
-      } catch (e) {
-        toast.error('登录失败')
-      }
+export async function googleGetIdToken() {
+  return new Promise((resolve, reject) => {
+    if (!window.google || !GOOGLE_CLIENT_ID) {
+      toast.error('Google 登录不可用')
+      reject()
+      return
     }
+    window.google.accounts.id.initialize({
+      client_id: GOOGLE_CLIENT_ID,
+      callback: ({ credential }) => resolve(credential)
+    })
+    window.google.accounts.id.prompt()
   })
-  window.google.accounts.id.prompt()
+}
+
+export async function googleAuthWithToken(idToken, reason, redirect) {
+  try {
+    const res = await fetch(`${API_BASE_URL}/api/auth/google`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ idToken, reason })
+    })
+    const data = await res.json()
+    if (res.ok && data.token) {
+      setToken(data.token)
+      await loadCurrentUser()
+      toast.success('登录成功')
+      if (redirect) redirect()
+    } else {
+      toast.error(data.error || '登录失败')
+    }
+  } catch (e) {
+    toast.error('登录失败')
+  }
+}
+
+export async function googleSignIn(redirect, reason) {
+  try {
+    const token = await googleGetIdToken()
+    await googleAuthWithToken(token, reason, redirect)
+  } catch {
+    /* ignore */
+  }
 }

--- a/open-isle-cli/src/views/SignupPageView.vue
+++ b/open-isle-cli/src/views/SignupPageView.vue
@@ -82,7 +82,7 @@
 
 <script>
 import { API_BASE_URL, toast } from '../main'
-import { googleSignIn } from '../utils/google'
+import { googleSignIn, googleGetIdToken } from '../utils/google'
 import BaseInput from '../components/BaseInput.vue'
 export default {
   name: 'SignupPageView',
@@ -197,7 +197,10 @@ export default {
     },
     signupWithGoogle() {
       if (this.registerMode === 'WHITELIST') {
-        this.$router.push('/signup-reason?google=1')
+        googleGetIdToken().then(token => {
+          sessionStorage.setItem('google_id_token', token)
+          this.$router.push('/signup-reason?google=1')
+        }).catch(() => {})
       } else {
         googleSignIn(() => {
           this.$router.push('/')

--- a/src/main/java/com/openisle/service/UserService.java
+++ b/src/main/java/com/openisle/service/UserService.java
@@ -94,6 +94,10 @@ public class UserService {
                 .filter(user -> passwordEncoder.matches(password, user.getPassword()));
     }
 
+    public boolean matchesPassword(User user, String rawPassword) {
+        return passwordEncoder.matches(rawPassword, user.getPassword());
+    }
+
     public Optional<User> findByUsername(String username) {
         return userRepository.findByUsername(username);
     }

--- a/src/test/java/com/openisle/controller/AuthControllerTest.java
+++ b/src/test/java/com/openisle/controller/AuthControllerTest.java
@@ -73,7 +73,8 @@ class AuthControllerTest {
     void loginReturnsToken() throws Exception {
         User user = new User();
         user.setUsername("u");
-        Mockito.when(userService.authenticate("u", "p")).thenReturn(Optional.of(user));
+        Mockito.when(userService.findByUsername("u")).thenReturn(Optional.of(user));
+        Mockito.when(userService.matchesPassword(user, "p")).thenReturn(true);
         Mockito.when(jwtService.generateToken("u")).thenReturn("token");
 
         mockMvc.perform(post("/api/auth/login")
@@ -85,12 +86,12 @@ class AuthControllerTest {
 
     @Test
     void loginFails() throws Exception {
-        Mockito.when(userService.authenticate("u", "bad")).thenReturn(Optional.empty());
+        Mockito.when(userService.findByUsername("u")).thenReturn(Optional.empty());
 
         mockMvc.perform(post("/api/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"username\":\"u\",\"password\":\"bad\"}"))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error").value("Invalid credentials or user not verified"));
+                .andExpect(jsonPath("$.reason_code").value("INVALID_CREDENTIALS"));
     }
 }


### PR DESCRIPTION
## Summary
- refine `/api/auth/login` failure responses
- add `matchesPassword` to UserService
- support retrieving Google ID token separately
- revise Google whitelist signup flow to authenticate first
- update tests for new login error handling

## Testing
- `npm run lint`
- `mvn -q -DskipTests=false test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6875c3f43608832789f453c4e3af5bd8