### PR TITLE
Fix register request notifications duplication

### DIFF
--- a/src/main/java/com/openisle/controller/AuthController.java
+++ b/src/main/java/com/openisle/controller/AuthController.java
@@ -9,7 +9,6 @@ import com.openisle.service.GoogleAuthService;
 import com.openisle.service.RegisterModeService;
 import com.openisle.service.NotificationService;
 import com.openisle.model.RegisterMode;
-import com.openisle.model.NotificationType;
 import com.openisle.repository.UserRepository;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
@@ -50,10 +49,7 @@ public class AuthController {
                 req.getUsername(), req.getEmail(), req.getPassword(), req.getReason(), registerModeService.getRegisterMode());
         emailService.sendEmail(user.getEmail(), "Verification Code", "Your verification code is " + user.getVerificationCode());
         if (!user.isApproved()) {
-            for (User admin : userRepository.findByRole(com.openisle.model.Role.ADMIN)) {
-                notificationService.createNotification(admin, NotificationType.REGISTER_REQUEST, null, null,
-                        null, user, null, user.getRegisterReason());
-            }
+            notificationService.createRegisterRequestNotifications(user, user.getRegisterReason());
         }
         return ResponseEntity.ok(Map.of("message", "Verification code sent"));
     }
@@ -98,11 +94,8 @@ public class AuthController {
         if (user.isPresent()) {
             if (!user.get().isApproved()) {
                 if (req.getReason() != null && !req.getReason().isEmpty()) {
-                    // do not send empty notifition (while try login)
-                    for (User admin : userRepository.findByRole(com.openisle.model.Role.ADMIN)) {
-                        notificationService.createNotification(admin, NotificationType.REGISTER_REQUEST, null, null,
-                                null, user.get(), null, req.getReason());
-                    }
+                    // do not send empty notification (while try login)
+                    notificationService.createRegisterRequestNotifications(user.get(), req.getReason());
                 }
                 return ResponseEntity.badRequest().body(Map.of(
                         "error", "Account awaiting approval",

--- a/src/main/java/com/openisle/repository/NotificationRepository.java
+++ b/src/main/java/com/openisle/repository/NotificationRepository.java
@@ -4,6 +4,7 @@ import com.openisle.model.Notification;
 import com.openisle.model.User;
 import com.openisle.model.Post;
 import com.openisle.model.Comment;
+import com.openisle.model.NotificationType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -15,4 +16,6 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     long countByUserAndRead(User user, boolean read);
     List<Notification> findByPost(Post post);
     List<Notification> findByComment(Comment comment);
+
+    void deleteByTypeAndFromUser(NotificationType type, User fromUser);
 }

--- a/src/main/java/com/openisle/service/NotificationService.java
+++ b/src/main/java/com/openisle/service/NotificationService.java
@@ -33,6 +33,18 @@ public class NotificationService {
         return notificationRepository.save(n);
     }
 
+    /**
+     * Create notifications for all admins when a user submits a register request.
+     * Old register request notifications from the same applicant are removed first.
+     */
+    public void createRegisterRequestNotifications(User applicant, String reason) {
+        notificationRepository.deleteByTypeAndFromUser(NotificationType.REGISTER_REQUEST, applicant);
+        for (User admin : userRepository.findByRole(Role.ADMIN)) {
+            createNotification(admin, NotificationType.REGISTER_REQUEST, null, null,
+                    null, applicant, null, reason);
+        }
+    }
+
     public List<Notification> listNotifications(String username, Boolean read) {
         User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> new com.openisle.exception.NotFoundException("User not found"));

--- a/src/test/java/com/openisle/service/NotificationServiceTest.java
+++ b/src/test/java/com/openisle/service/NotificationServiceTest.java
@@ -1,7 +1,6 @@
 package com.openisle.service;
 
-import com.openisle.model.Notification;
-import com.openisle.model.User;
+import com.openisle.model.*;
 import com.openisle.repository.NotificationRepository;
 import com.openisle.repository.UserRepository;
 import org.junit.jupiter.api.Test;
@@ -77,5 +76,24 @@ class NotificationServiceTest {
 
         assertEquals(5L, count);
         verify(nRepo).countByUserAndRead(user, false);
+    }
+
+    @Test
+    void createRegisterRequestNotificationsDeletesOldOnes() {
+        NotificationRepository nRepo = mock(NotificationRepository.class);
+        UserRepository uRepo = mock(UserRepository.class);
+        NotificationService service = new NotificationService(nRepo, uRepo);
+
+        User admin = new User();
+        admin.setId(10L);
+        User applicant = new User();
+        applicant.setId(20L);
+
+        when(uRepo.findByRole(Role.ADMIN)).thenReturn(List.of(admin));
+
+        service.createRegisterRequestNotifications(applicant, "reason");
+
+        verify(nRepo).deleteByTypeAndFromUser(NotificationType.REGISTER_REQUEST, applicant);
+        verify(nRepo).save(any(Notification.class));
     }
 }


### PR DESCRIPTION
## Summary
- delete previous REGISTER_REQUEST notifications when a user applies again
- send register request notifications through a new helper method
- test removal of old register request notifications

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6875d05cf4dc83278102ed7bfc31db88