### PR TITLE
Allow login with email fallback

### DIFF
--- a/src/main/java/com/openisle/controller/AuthController.java
+++ b/src/main/java/com/openisle/controller/AuthController.java
@@ -69,6 +69,9 @@ public class AuthController {
             return ResponseEntity.badRequest().body(Map.of("error", "Invalid captcha"));
         }
         Optional<User> userOpt = userService.findByUsername(req.getUsernameOrEmail());
+        if (userOpt.isEmpty()) {
+            userOpt = userService.findByEmail(req.getUsernameOrEmail());
+        }
         if (userOpt.isEmpty() || !userService.matchesPassword(userOpt.get(), req.getPassword())) {
             return ResponseEntity.badRequest().body(Map.of(
                     "error", "Invalid credentials",

--- a/src/main/java/com/openisle/service/UserService.java
+++ b/src/main/java/com/openisle/service/UserService.java
@@ -102,6 +102,10 @@ public class UserService {
         return userRepository.findByUsername(username);
     }
 
+    public Optional<User> findByEmail(String email) {
+        return userRepository.findByEmail(email);
+    }
+
     public Optional<User> findById(Long id) {
         return userRepository.findById(id);
     }


### PR DESCRIPTION
## Summary
- support login with either username or email
- expose UserService.findByEmail helper

## Testing
- `mvn -q test` *(fails: could not resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6875e10ddc5483278fa83d9e16adc424