### PR TITLE
Add char count for signup reason input

### DIFF
--- a/open-isle-cli/src/views/SignupReasonPageView.vue
+++ b/open-isle-cli/src/views/SignupReasonPageView.vue
@@ -6,6 +6,7 @@
         为了我们社区的良性发展，请填写注册理由，我们将根据你的理由审核你的注册, 谢谢!
       </div>
       <BaseInput textarea rows="4" v-model="reason" placeholder="20个字以上" />
+      <div class="char-count">{{ reason.length }} 字</div>
       <div v-if="error" class="error-message">{{ error }}</div>
       <div v-if="!isWaitingForRegister" class="signup-page-button-primary" @click="submit">提交</div>
       <div v-else class="signup-page-button-primary disabled">提交中...</div>
@@ -114,6 +115,13 @@ export default {
   flex-direction: column;
   gap: 20px;
   width: 400px;
+}
+
+.char-count {
+  font-size: 12px;
+  color: #888;
+  width: 100%;
+  text-align: right;
 }
 
 .error-message {


### PR DESCRIPTION
## Summary
- show user how many characters they have entered in signup reason

## Testing
- `npm run lint`
- `CI=true npm run build`
- `mvn -q test` *(fails: Could not resolve Spring Boot parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6875f964a6908327bd03c3b796e9fcd8