### PR TITLE
Fix dynamic Google OAuth client config

### DIFF
--- a/open-isle-cli/src/main.js
+++ b/open-isle-cli/src/main.js
@@ -17,7 +17,7 @@ export const API_PORT = 8081
 
 // export const API_BASE_URL = API_PORT ? `${API_DOMAIN}:${API_PORT}` : API_DOMAIN
 export const API_BASE_URL = "";
-export const GOOGLE_CLIENT_ID = '777830451304-nt8afkkap18gui4f9entcha99unal744.apps.googleusercontent.com'
+export const config = { googleClientId: '' }
 export const toast = useToast()
 
 initTheme()
@@ -32,3 +32,10 @@ checkToken().then(valid => {
     clearToken()
   }
 })
+
+fetch(`${API_BASE_URL}/api/config`).then(async res => {
+  if (res.ok) {
+    const data = await res.json()
+    config.googleClientId = data.googleClientId || ''
+  }
+}).catch(() => {/* ignore */})

--- a/open-isle-cli/src/utils/google.js
+++ b/open-isle-cli/src/utils/google.js
@@ -1,17 +1,28 @@
-import { API_BASE_URL, GOOGLE_CLIENT_ID, toast } from '../main'
+import { API_BASE_URL, config, toast } from '../main'
 import { setToken, loadCurrentUser } from './auth'
 
 export async function googleGetIdToken() {
+  if (!config.googleClientId) {
+    try {
+      const res = await fetch(`${API_BASE_URL}/api/config`)
+      if (res.ok) {
+        const data = await res.json()
+        if (data.googleClientId) {
+          config.googleClientId = data.googleClientId
+        }
+      }
+    } catch { /* ignore */ }
+  }
   return new Promise((resolve, reject) => {
-    if (!window.google || !GOOGLE_CLIENT_ID) {
+    if (!window.google || !config.googleClientId) {
       toast.error('Google 登录不可用')
       reject()
       return
     }
     window.google.accounts.id.initialize({
-      client_id: GOOGLE_CLIENT_ID,
+      client_id: config.googleClientId,
       callback: ({ credential }) => resolve(credential),
-      use_fedcm: true 
+      use_fedcm: true
     })
     window.google.accounts.id.prompt()
   })

--- a/src/main/java/com/openisle/controller/ConfigController.java
+++ b/src/main/java/com/openisle/controller/ConfigController.java
@@ -31,6 +31,9 @@ public class ConfigController {
     @Value("${app.ai.format-limit:3}")
     private int aiFormatLimit;
 
+    @Value("${google.client-id:}")
+    private String googleClientId;
+
     private final RegisterModeService registerModeService;
 
     @GetMapping("/config")
@@ -43,6 +46,7 @@ public class ConfigController {
         resp.setCommentCaptchaEnabled(commentCaptchaEnabled);
         resp.setAiFormatLimit(aiFormatLimit);
         resp.setRegisterMode(registerModeService.getRegisterMode());
+        resp.setGoogleClientId(googleClientId);
         return resp;
     }
 
@@ -55,5 +59,6 @@ public class ConfigController {
         private boolean commentCaptchaEnabled;
         private int aiFormatLimit;
         private RegisterMode registerMode;
+        private String googleClientId;
     }
 }


### PR DESCRIPTION
## Summary
- expose `googleClientId` in `/api/config`
- load `googleClientId` dynamically in Vue frontend
- use the loaded ID during Google login

## Testing
- `npm install`
- `npm run lint`
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_687635af30948327a43ddb59a6fde3ef