### PR TITLE
Fix latest posts ordering

### DIFF
--- a/src/main/java/com/openisle/repository/PostRepository.java
+++ b/src/main/java/com/openisle/repository/PostRepository.java
@@ -16,15 +16,23 @@ import org.springframework.data.repository.query.Param;
 public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findByStatus(PostStatus status);
     List<Post> findByStatus(PostStatus status, Pageable pageable);
+    List<Post> findByStatusOrderByCreatedAtDesc(PostStatus status);
+    List<Post> findByStatusOrderByCreatedAtDesc(PostStatus status, Pageable pageable);
     List<Post> findByStatusOrderByViewsDesc(PostStatus status);
     List<Post> findByStatusOrderByViewsDesc(PostStatus status, Pageable pageable);
     List<Post> findByAuthorAndStatusOrderByCreatedAtDesc(User author, PostStatus status, Pageable pageable);
     List<Post> findByCategoryInAndStatus(List<Category> categories, PostStatus status);
     List<Post> findByCategoryInAndStatus(List<Category> categories, PostStatus status, Pageable pageable);
+    List<Post> findByCategoryInAndStatusOrderByCreatedAtDesc(List<Category> categories, PostStatus status);
+    List<Post> findByCategoryInAndStatusOrderByCreatedAtDesc(List<Category> categories, PostStatus status, Pageable pageable);
     List<Post> findDistinctByTagsInAndStatus(List<Tag> tags, PostStatus status);
     List<Post> findDistinctByTagsInAndStatus(List<Tag> tags, PostStatus status, Pageable pageable);
+    List<Post> findDistinctByTagsInAndStatusOrderByCreatedAtDesc(List<Tag> tags, PostStatus status);
+    List<Post> findDistinctByTagsInAndStatusOrderByCreatedAtDesc(List<Tag> tags, PostStatus status, Pageable pageable);
     List<Post> findDistinctByCategoryInAndTagsInAndStatus(List<Category> categories, List<Tag> tags, PostStatus status);
     List<Post> findDistinctByCategoryInAndTagsInAndStatus(List<Category> categories, List<Tag> tags, PostStatus status, Pageable pageable);
+    List<Post> findDistinctByCategoryInAndTagsInAndStatusOrderByCreatedAtDesc(List<Category> categories, List<Tag> tags, PostStatus status);
+    List<Post> findDistinctByCategoryInAndTagsInAndStatusOrderByCreatedAtDesc(List<Category> categories, List<Tag> tags, PostStatus status, Pageable pageable);
 
     // Queries requiring all provided tags to be present
     @Query("SELECT p FROM Post p JOIN p.tags t WHERE t IN :tags AND p.status = :status GROUP BY p.id HAVING COUNT(DISTINCT t.id) = :tagCount")
@@ -32,6 +40,12 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     @Query(value = "SELECT p FROM Post p JOIN p.tags t WHERE t IN :tags AND p.status = :status GROUP BY p.id HAVING COUNT(DISTINCT t.id) = :tagCount")
     List<Post> findByAllTags(@Param("tags") List<Tag> tags, @Param("status") PostStatus status, @Param("tagCount") long tagCount, Pageable pageable);
+
+    @Query("SELECT p FROM Post p JOIN p.tags t WHERE t IN :tags AND p.status = :status GROUP BY p.id HAVING COUNT(DISTINCT t.id) = :tagCount ORDER BY p.createdAt DESC")
+    List<Post> findByAllTagsOrderByCreatedAtDesc(@Param("tags") List<Tag> tags, @Param("status") PostStatus status, @Param("tagCount") long tagCount);
+
+    @Query(value = "SELECT p FROM Post p JOIN p.tags t WHERE t IN :tags AND p.status = :status GROUP BY p.id HAVING COUNT(DISTINCT t.id) = :tagCount ORDER BY p.createdAt DESC")
+    List<Post> findByAllTagsOrderByCreatedAtDesc(@Param("tags") List<Tag> tags, @Param("status") PostStatus status, @Param("tagCount") long tagCount, Pageable pageable);
 
     @Query("SELECT p FROM Post p JOIN p.tags t WHERE t IN :tags AND p.status = :status GROUP BY p.id HAVING COUNT(DISTINCT t.id) = :tagCount ORDER BY p.views DESC")
     List<Post> findByAllTagsOrderByViewsDesc(@Param("tags") List<Tag> tags, @Param("status") PostStatus status, @Param("tagCount") long tagCount);
@@ -50,6 +64,12 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     @Query(value = "SELECT p FROM Post p JOIN p.tags t WHERE p.category IN :categories AND t IN :tags AND p.status = :status GROUP BY p.id HAVING COUNT(DISTINCT t.id) = :tagCount ORDER BY p.views DESC")
     List<Post> findByCategoriesAndAllTagsOrderByViewsDesc(@Param("categories") List<Category> categories, @Param("tags") List<Tag> tags, @Param("status") PostStatus status, @Param("tagCount") long tagCount, Pageable pageable);
+
+    @Query("SELECT p FROM Post p JOIN p.tags t WHERE p.category IN :categories AND t IN :tags AND p.status = :status GROUP BY p.id HAVING COUNT(DISTINCT t.id) = :tagCount ORDER BY p.createdAt DESC")
+    List<Post> findByCategoriesAndAllTagsOrderByCreatedAtDesc(@Param("categories") List<Category> categories, @Param("tags") List<Tag> tags, @Param("status") PostStatus status, @Param("tagCount") long tagCount);
+
+    @Query(value = "SELECT p FROM Post p JOIN p.tags t WHERE p.category IN :categories AND t IN :tags AND p.status = :status GROUP BY p.id HAVING COUNT(DISTINCT t.id) = :tagCount ORDER BY p.createdAt DESC")
+    List<Post> findByCategoriesAndAllTagsOrderByCreatedAtDesc(@Param("categories") List<Category> categories, @Param("tags") List<Tag> tags, @Param("status") PostStatus status, @Param("tagCount") long tagCount, Pageable pageable);
 
     List<Post> findByCategoryInAndStatusOrderByViewsDesc(List<Category> categories, PostStatus status);
     List<Post> findByCategoryInAndStatusOrderByViewsDesc(List<Category> categories, PostStatus status, Pageable pageable);

--- a/src/main/java/com/openisle/service/PostService.java
+++ b/src/main/java/com/openisle/service/PostService.java
@@ -24,6 +24,7 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 @Service
 public class PostService {
@@ -174,7 +175,7 @@ public class PostService {
                                        Integer pageSize) {
         Pageable pageable = null;
         if (page != null && pageSize != null) {
-            pageable = PageRequest.of(page, pageSize);
+            pageable = PageRequest.of(page, pageSize, Sort.Direction.DESC, "createdAt");
         }
 
         boolean hasCategories = categoryIds != null && !categoryIds.isEmpty();
@@ -225,21 +226,21 @@ public class PostService {
                                             Integer pageSize) {
         Pageable pageable = null;
         if (page != null && pageSize != null) {
-            pageable = PageRequest.of(page, pageSize);
+            pageable = PageRequest.of(page, pageSize, Sort.Direction.DESC, "createdAt");
         }
 
         if (categoryIds == null || categoryIds.isEmpty()) {
             if (pageable != null) {
-                return postRepository.findByStatus(PostStatus.PUBLISHED, pageable);
+                return postRepository.findByStatusOrderByCreatedAtDesc(PostStatus.PUBLISHED, pageable);
             }
-            return postRepository.findByStatus(PostStatus.PUBLISHED);
+            return postRepository.findByStatusOrderByCreatedAtDesc(PostStatus.PUBLISHED);
         }
 
         java.util.List<Category> categories = categoryRepository.findAllById(categoryIds);
         if (pageable != null) {
-            return postRepository.findByCategoryInAndStatus(categories, PostStatus.PUBLISHED, pageable);
+            return postRepository.findByCategoryInAndStatusOrderByCreatedAtDesc(categories, PostStatus.PUBLISHED, pageable);
         }
-        return postRepository.findByCategoryInAndStatus(categories, PostStatus.PUBLISHED);
+        return postRepository.findByCategoryInAndStatusOrderByCreatedAtDesc(categories, PostStatus.PUBLISHED);
     }
 
     public List<Post> getRecentPostsByUser(String username, int limit) {
@@ -267,7 +268,7 @@ public class PostService {
 
         Pageable pageable = null;
         if (page != null && pageSize != null) {
-            pageable = PageRequest.of(page, pageSize);
+            pageable = PageRequest.of(page, pageSize, Sort.Direction.DESC, "createdAt");
         }
 
         java.util.List<com.openisle.model.Tag> tags = tagRepository.findAllById(tagIds);
@@ -276,9 +277,9 @@ public class PostService {
         }
 
         if (pageable != null) {
-            return postRepository.findByAllTags(tags, PostStatus.PUBLISHED, tags.size(), pageable);
+            return postRepository.findByAllTagsOrderByCreatedAtDesc(tags, PostStatus.PUBLISHED, tags.size(), pageable);
         }
-        return postRepository.findByAllTags(tags, PostStatus.PUBLISHED, tags.size());
+        return postRepository.findByAllTagsOrderByCreatedAtDesc(tags, PostStatus.PUBLISHED, tags.size());
     }
 
     public List<Post> listPostsByCategoriesAndTags(java.util.List<Long> categoryIds,
@@ -301,9 +302,9 @@ public class PostService {
         }
 
         if (pageable != null) {
-            return postRepository.findByCategoriesAndAllTags(categories, tags, PostStatus.PUBLISHED, tags.size(), pageable);
+            return postRepository.findByCategoriesAndAllTagsOrderByCreatedAtDesc(categories, tags, PostStatus.PUBLISHED, tags.size(), pageable);
         }
-        return postRepository.findByCategoriesAndAllTags(categories, tags, PostStatus.PUBLISHED, tags.size());
+        return postRepository.findByCategoriesAndAllTagsOrderByCreatedAtDesc(categories, tags, PostStatus.PUBLISHED, tags.size());
     }
 
     public List<Post> listPendingPosts() {


### PR DESCRIPTION
## Summary
- ensure posts are returned newest first for HomePageView
- order post listings by created time descending

## Testing
- `mvn -q -DskipTests compile` *(fails: Could not download dependencies)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68766ded0f1c8327af6dadfbcdc8c4ee