### PR TITLE
Fix notification deletion without transaction

### DIFF
--- a/src/main/java/com/openisle/service/NotificationService.java
+++ b/src/main/java/com/openisle/service/NotificationService.java
@@ -37,6 +37,7 @@ public class NotificationService {
      * Create notifications for all admins when a user submits a register request.
      * Old register request notifications from the same applicant are removed first.
      */
+    @org.springframework.transaction.annotation.Transactional
     public void createRegisterRequestNotifications(User applicant, String reason) {
         notificationRepository.deleteByTypeAndFromUser(NotificationType.REGISTER_REQUEST, applicant);
         for (User admin : userRepository.findByRole(Role.ADMIN)) {


### PR DESCRIPTION
## Summary
- wrap `createRegisterRequestNotifications` in a transaction so deleting old requests won't fail when no notification exists

## Testing
- `mvn -q test` *(fails: could not resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687730d5d4a08327a4a0fa3b3a98201b