### PR TITLE
Add audio conversion script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,26 @@ mvn spring-boot:run
 - 需要认证的接口示例：`GET /api/hello`（需 `Authorization` 头）
 - 管理员接口示例：`GET /api/admin/hello`
 
+## 🎵 音频处理
+
+为保证平台中音频文件的一致性，所有本地音乐或合成语音上传前都需转为如下规格：
+
+- **采样率**：44100 Hz
+- **声道数**：2（立体声）
+- **平均码率**：192 kbps
+
+项目根目录新增的 `scripts/convert_audio.sh` 脚本提供了批量转换与静音片段生成能力：
+
+```bash
+# 转换音频文件
+./scripts/convert_audio.sh input.mp3 output.mp3
+
+# 生成指定时长的静音 mp3（默认 1 秒）
+./scripts/convert_audio.sh --silent silence.mp3 1
+```
+
+除了 `tts` 与 `sounds_effect` 类型外，现新增 `silent` 类型，可通过 `direction` 属性指示静音位置或时长。播放流程要求在播报标题后先停顿 1 秒，再开始播报摘要内容，可利用上述脚本生成的静音文件进行拼接。
+
 ## 🏘️ 社区
 
 欢迎通过 [Issues](https://github.com/nagisa77/OpenIsle/issues) 交流反馈。

--- a/scripts/convert_audio.sh
+++ b/scripts/convert_audio.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -e
+
+# Converts input audio file to specified format or generates silence.
+# Usage:
+#   ./convert_audio.sh input.mp3 output.mp3
+#   ./convert_audio.sh --silent output.mp3 [duration]
+# Where duration is in seconds (default 1).
+
+TARGET_RATE=44100
+TARGET_CH=2
+BITRATE=192k
+
+if [ "$1" == "--silent" ]; then
+  out="$2"
+  duration="${3:-1}"
+  ffmpeg -y -f lavfi -i anullsrc=r=$TARGET_RATE:cl=stereo -t "$duration" -ac $TARGET_CH -b:a $BITRATE "$out"
+else
+  in="$1"
+  out="$2"
+  ffmpeg -y -i "$in" -ar $TARGET_RATE -ac $TARGET_CH -b:a $BITRATE "$out"
+fi


### PR DESCRIPTION
## Summary
- add `scripts/convert_audio.sh` for converting audio or generating silent segments
- document audio specs and new `silent` type in README

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68773f233a4083279dc09a632061d960