### PR TITLE
Fix Twitter OAuth login

### DIFF
--- a/src/main/java/com/openisle/controller/AuthController.java
+++ b/src/main/java/com/openisle/controller/AuthController.java
@@ -233,7 +233,11 @@ public class AuthController {
       
     @PostMapping("/twitter")
     public ResponseEntity<?> loginWithTwitter(@RequestBody TwitterLoginRequest req) {
-        Optional<User> user = twitterAuthService.authenticate(req.getCode(), registerModeService.getRegisterMode(), req.getRedirectUri());
+        Optional<User> user = twitterAuthService.authenticate(
+                req.getCode(),
+                req.getCodeVerifier(),
+                registerModeService.getRegisterMode(),
+                req.getRedirectUri());
         if (user.isPresent()) {
             if (RegisterMode.DIRECT.equals(registerModeService.getRegisterMode())) {
                 return ResponseEntity.ok(Map.of("token", jwtService.generateToken(user.get().getUsername())));
@@ -302,6 +306,7 @@ public class AuthController {
     private static class TwitterLoginRequest {
         private String code;
         private String redirectUri;
+        private String codeVerifier;
     }
 
     @Data


### PR DESCRIPTION
## Summary
- implement PKCE flow in Twitter login utils
- adjust AuthController to pass `codeVerifier`
- update TwitterAuthService to send required fields

## Testing
- `npm run lint` *(fails: Parsing error in SignupPageView.vue)*
- `mvn -q test` *(fails: could not download parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68777a405e9c83278947033111428088