### PR TITLE
Fix Twitter OAuth token request

### DIFF
--- a/src/main/java/com/openisle/service/TwitterAuthService.java
+++ b/src/main/java/com/openisle/service/TwitterAuthService.java
@@ -28,6 +28,9 @@ public class TwitterAuthService {
     @Value("${twitter.client-id:}")
     private String clientId;
 
+    @Value("${twitter.client-secret:}")
+    private String clientSecret;
+
     public Optional<User> authenticate(
             String code,
             String codeVerifier,
@@ -50,7 +53,9 @@ public class TwitterAuthService {
         body.add("code_verifier", codeVerifier);
         body.add("redirect_uri", redirectUri);      // 一律必填
         // 如果你的 app 属于机密客户端，必须带 client_secret
-        // body.add("client_secret", clientSecret);
+        if (clientSecret != null && !clientSecret.isBlank()) {
+            body.add("client_secret", clientSecret);
+        }
 
         ResponseEntity<JsonNode> tokenRes;
         try {


### PR DESCRIPTION
## Summary
- add `twitter.client-secret` property usage
- include client secret when requesting a token

## Testing
- `npm test` *(fails: Missing script)*
- `mvn -q test` *(fails: Non-resolvable parent POM - network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68778f4ba2cc8327b991f0a38dacd23a