### PR TITLE
Adjust username validation and signup UI

### DIFF
--- a/open-isle-cli/src/views/SettingsPageView.vue
+++ b/open-isle-cli/src/views/SettingsPageView.vue
@@ -158,8 +158,6 @@ export default {
         this.usernameError = ''
         if (!this.username) {
           this.usernameError = '用户名不能为空'
-        } else if (this.username.length < 6) {
-          this.usernameError = '用户名至少6位'
         }
         if (this.usernameError) {
           toast.error(this.usernameError)

--- a/open-isle-cli/src/views/SignupPageView.vue
+++ b/open-isle-cli/src/views/SignupPageView.vue
@@ -33,11 +33,6 @@
         />
         <div v-if="passwordError" class="error-message">{{ passwordError }}</div>
 
-        <BaseInput
-          icon="fas fa-user"
-          v-model="nickname"
-          placeholder="昵称 (可选)"
-        />
 
         <div v-if="!isWaitingForEmailSent" class="signup-page-button-primary" @click="sendVerification">
           <div class="signup-page-button-text">验证邮箱</div>
@@ -113,7 +108,6 @@ export default {
       emailError: '',
       usernameError: '',
       passwordError: '',
-      nickname: '',
       code: '',
       isWaitingForEmailSent: false,
       isWaitingForEmailVerified: false
@@ -149,8 +143,6 @@ export default {
       }
       if (!this.username) {
         this.usernameError = '用户名不能为空'
-      } else if (this.username.length < 6) {
-        this.usernameError = '用户名至少6位'
       }
       if (this.emailError || this.passwordError || this.usernameError) {
         return

--- a/src/main/java/com/openisle/service/UsernameValidator.java
+++ b/src/main/java/com/openisle/service/UsernameValidator.java
@@ -14,8 +14,8 @@ public class UsernameValidator {
      * @param username the username to validate
      */
     public void validate(String username) {
-        if (username == null || username.length() < 6) {
-            throw new FieldException("username", "Username must be at least 6 characters long");
+        if (username == null || username.isEmpty()) {
+            throw new FieldException("username", "Username cannot be empty");
         }
     }
 }

--- a/src/test/java/com/openisle/service/UsernameValidatorTest.java
+++ b/src/test/java/com/openisle/service/UsernameValidatorTest.java
@@ -1,0 +1,22 @@
+package com.openisle.service;
+
+import com.openisle.exception.FieldException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UsernameValidatorTest {
+
+    @Test
+    void rejectsEmptyUsername() {
+        UsernameValidator validator = new UsernameValidator();
+        assertThrows(FieldException.class, () -> validator.validate(""));
+        assertThrows(FieldException.class, () -> validator.validate(null));
+    }
+
+    @Test
+    void allowsShortUsername() {
+        UsernameValidator validator = new UsernameValidator();
+        assertDoesNotThrow(() -> validator.validate("a"));
+    }
+}


### PR DESCRIPTION
## Summary
- allow usernames shorter than 6 characters
- remove nickname input from signup page
- adjust settings and signup validation messages
- add unit tests for UsernameValidator

## Testing
- `npm run lint`
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68778fae4be08327a848c1b65fa47741