### PR TITLE
Fix Twitter OAuth debug logs

### DIFF
--- a/src/main/java/com/openisle/service/TwitterAuthService.java
+++ b/src/main/java/com/openisle/service/TwitterAuthService.java
@@ -63,7 +63,7 @@ public class TwitterAuthService {
             tokenRes = restTemplate.postForEntity(tokenUrl, new HttpEntity<>(body, headers), JsonNode.class);
             logger.debug("Token response: {}", tokenRes.getBody());
         } catch (HttpClientErrorException e) {
-            logger.debug("Token request failed", e);
+            logger.warn("Token request failed with status {} and body {}", e.getStatusCode(), e.getResponseBodyAsString());
             return Optional.empty();
         }
 


### PR DESCRIPTION
## Summary
- enhance TwitterAuthService error logging with status and body

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_6877923d68348327a48175779af4ed5c