### PR TITLE
Fix mobile menu display

### DIFF
--- a/open-isle-cli/src/App.vue
+++ b/open-isle-cli/src/App.vue
@@ -25,7 +25,7 @@ export default {
   name: 'App',
   components: { HeaderComponent, MenuComponent },
   data() {
-    return { menuVisible: true }
+    return { menuVisible: window.innerWidth > 768 }
   },
   computed: {
     hideMenu() {


### PR DESCRIPTION
## Summary
- hide menu by default on mobile devices

## Testing
- `npm run lint`
- `mvn -q test` *(fails: Non-resolvable parent POM due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_68789b4457648327bca30e82ee5b13d9