### PR TITLE
Add global isMobile computed util

### DIFF
--- a/open-isle-cli/src/utils/screen.js
+++ b/open-isle-cli/src/utils/screen.js
@@ -1,0 +1,12 @@
+import { ref, computed } from 'vue'
+
+// reactive width value to watch window resize events
+const width = ref(window.innerWidth)
+
+// update width on resize
+window.addEventListener('resize', () => {
+  width.value = window.innerWidth
+})
+
+// global computed property
+export const isMobile = computed(() => width.value <= 768)


### PR DESCRIPTION
## Summary
- add a `screen.js` util that exposes a global `isMobile` computed property

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6878a969ce488327a137622a97f24aee