### PR TITLE
Improve mobile markdown layout

### DIFF
--- a/open-isle-cli/src/assets/global.css
+++ b/open-isle-cli/src/assets/global.css
@@ -80,6 +80,11 @@ body {
   padding-left: 1.5em;
 }
 
+.info-content-text {
+  word-break: break-word;
+  max-width: 100%;
+}
+
 .info-content-text blockquote {
   margin: 1em 0;
   padding-left: 1em;
@@ -92,6 +97,8 @@ body {
   padding: 8px 12px;
   border-radius: 4px;
   line-height: 1.0;
+  overflow-x: auto;
+  max-width: 100%;
 }
 
 .info-content-text code {
@@ -168,6 +175,9 @@ body {
 }
 
 @media (max-width: 768px) {
+  .info-content-text {
+    font-size: 14px;
+  }
   .info-content-text h1 {
     font-size: 20px;
   }

--- a/open-isle-cli/src/views/PostPageView.vue
+++ b/open-isle-cli/src/views/PostPageView.vue
@@ -818,6 +818,22 @@ export default {
     padding: 10px;
   }
 
+  .article-title {
+    font-size: 22px;
+  }
+
+  .user-name {
+    font-size: 14px;
+  }
+
+  .post-time {
+    font-size: 12px;
+  }
+
+  .reactions-viewer-item {
+    font-size: 14px;
+  }
+
   .post-page-scroller-container {
     display: none;
   }


### PR DESCRIPTION
## Summary
- ensure markdown blocks fit on small screens
- shrink article fonts and metadata for mobile

## Testing
- `npm run lint`
- `mvn test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6879bd62c92c832789102109f789ded4