### PR TITLE
Centralize open-isle domain

### DIFF
--- a/open-isle-cli/src/constants.js
+++ b/open-isle-cli/src/constants.js
@@ -1,0 +1,1 @@
+export const WEBSITE_BASE_URL = 'https://www.open-isle.com'

--- a/open-isle-cli/src/utils/discord.js
+++ b/open-isle-cli/src/utils/discord.js
@@ -1,4 +1,5 @@
 import { API_BASE_URL, DISCORD_CLIENT_ID, toast } from '../main'
+import { WEBSITE_BASE_URL } from '../constants'
 import { setToken, loadCurrentUser } from './auth'
 
 export function discordAuthorize(state = '') {
@@ -6,7 +7,7 @@ export function discordAuthorize(state = '') {
     toast.error('Discord 登录不可用')
     return
   }
-  const redirectUri = `https://www.open-isle.com/discord-callback`
+  const redirectUri = `${WEBSITE_BASE_URL}/discord-callback`
   const url = `https://discord.com/api/oauth2/authorize?client_id=${DISCORD_CLIENT_ID}&redirect_uri=${encodeURIComponent(redirectUri)}&response_type=code&scope=identify%20email&state=${state}`
   window.location.href = url
 }

--- a/open-isle-cli/src/utils/github.js
+++ b/open-isle-cli/src/utils/github.js
@@ -1,12 +1,13 @@
 import { API_BASE_URL, GITHUB_CLIENT_ID, toast } from '../main'
 import { setToken, loadCurrentUser } from './auth'
+import { WEBSITE_BASE_URL } from '../constants'
 
 export function githubAuthorize(state = '') {
   if (!GITHUB_CLIENT_ID) {
     toast.error('GitHub 登录不可用')
     return
   }
-  const redirectUri = `https://www.open-isle.com/github-callback`
+  const redirectUri = `${WEBSITE_BASE_URL}/github-callback`
   const url = `https://github.com/login/oauth/authorize?client_id=${GITHUB_CLIENT_ID}&redirect_uri=${encodeURIComponent(redirectUri)}&scope=user:email&state=${state}`
   window.location.href = url
 }

--- a/open-isle-cli/src/utils/twitter.js
+++ b/open-isle-cli/src/utils/twitter.js
@@ -1,4 +1,5 @@
 import { API_BASE_URL, TWITTER_CLIENT_ID, toast } from '../main'
+import { WEBSITE_BASE_URL } from '../constants'
 import { setToken, loadCurrentUser } from './auth'
 
 function generateCodeVerifier() {
@@ -27,7 +28,7 @@ export async function twitterAuthorize(state = '') {
   if (state === '') {
     state = Math.random().toString(36).substring(2, 15)
   }
-  const redirectUri = `https://www.open-isle.com/twitter-callback`
+  const redirectUri = `${WEBSITE_BASE_URL}/twitter-callback`
   const codeVerifier = generateCodeVerifier()
   sessionStorage.setItem('twitter_code_verifier', codeVerifier)
   const codeChallenge = await generateCodeChallenge(codeVerifier)

--- a/src/main/java/com/openisle/config/SecurityConfig.java
+++ b/src/main/java/com/openisle/config/SecurityConfig.java
@@ -25,6 +25,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.beans.factory.annotation.Value;
 import java.util.List;
 
 import jakarta.servlet.FilterChain;
@@ -40,6 +41,8 @@ public class SecurityConfig {
     private final UserRepository userRepository;
     private final AccessDeniedHandler customAccessDeniedHandler;
     private final UserVisitService userVisitService;
+    @Value("${app.website-url}")
+    private String websiteUrl;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -70,14 +73,14 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration cfg = new CorsConfiguration();
         cfg.setAllowedOrigins(List.of(
-                "http://127.0.0.1:8080",        
-                "http://127.0.0.1",           
-                "http://localhost:8080",          
-                "http://localhost",           
-                "http://30.211.97.200:8080",          
-                "http://30.211.97.200",     
-                "https://www.open-isle.com",   
-                "https://open-isle.com"
+                "http://127.0.0.1:8080",
+                "http://127.0.0.1",
+                "http://localhost:8080",
+                "http://localhost",
+                "http://30.211.97.200:8080",
+                "http://30.211.97.200",
+                websiteUrl,
+                websiteUrl.replace("://www.", "://")
         ));
         cfg.setAllowedMethods(List.of("GET","POST","PUT","DELETE","OPTIONS"));
         cfg.setAllowedHeaders(List.of("*"));

--- a/src/main/java/com/openisle/controller/AdminUserController.java
+++ b/src/main/java/com/openisle/controller/AdminUserController.java
@@ -4,6 +4,7 @@ import com.openisle.model.User;
 import com.openisle.service.EmailSender;
 import com.openisle.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -13,6 +14,8 @@ import org.springframework.web.bind.annotation.*;
 public class AdminUserController {
     private final UserRepository userRepository;
     private final EmailSender emailSender;
+    @Value("${app.website-url}")
+    private String websiteUrl;
 
     @PostMapping("/{id}/approve")
     public ResponseEntity<?> approve(@PathVariable Long id) {
@@ -20,7 +23,7 @@ public class AdminUserController {
         user.setApproved(true);
         userRepository.save(user);
         emailSender.sendEmail(user.getEmail(), "Registration Approved",
-                "Your account has been approved. Visit: https://www.open-isle.com");
+                "Your account has been approved. Visit: " + websiteUrl);
         return ResponseEntity.ok().build();
     }
 
@@ -30,7 +33,7 @@ public class AdminUserController {
         user.setApproved(false);
         userRepository.save(user);
         emailSender.sendEmail(user.getEmail(), "Registration Rejected",
-                "Your account request was rejected. Visit: https://www.open-isle.com");
+                "Your account request was rejected. Visit: " + websiteUrl);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -65,3 +65,6 @@ openai.api-key=${OPENAI_API_KEY:}
 openai.model=${OPENAI_MODEL:gpt-4o}
 # AI markdown format usage limit per user per day (-1 for unlimited)
 app.ai.format-limit=${AI_FORMAT_LIMIT:3}
+
+# Website URL for emails and redirects
+app.website-url=${WEBSITE_URL:https://www.open-isle.com}


### PR DESCRIPTION
## Summary
- add `app.website-url` property
- use property in `AdminUserController` and `SecurityConfig`
- centralize front-end URLs in new `constants.js`
- update OAuth helpers to import and use the constant

## Testing
- `npm run build --silent`
- `mvn -q test` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_687a1be831dc8327bda1011e272a7e42