### PR TITLE
Improve dropdown usability on mobile

### DIFF
--- a/open-isle-cli/src/components/Dropdown.vue
+++ b/open-isle-cli/src/components/Dropdown.vue
@@ -32,7 +32,7 @@
         <i class="fas fa-caret-down dropdown-caret"></i>
       </slot>
     </div>
-    <div v-if="open && (loading || filteredOptions.length > 0 || showSearch)" :class="['dropdown-menu', menuClass]">
+    <div v-if="open && (loading || filteredOptions.length > 0 || showSearch) && !isMobile" :class="['dropdown-menu', menuClass]">
       <div v-if="showSearch" class="dropdown-search">
         <i class="fas fa-search search-icon"></i>
         <input type="text" v-model="search" placeholder="搜索" />
@@ -53,12 +53,40 @@
         </div>
       </template>
     </div>
+    <teleport to="body">
+      <div v-if="open && isMobile" class="dropdown-page">
+        <div class="dropdown-page-header">
+          <i class="fas fa-arrow-left back-icon" @click="close"></i>
+        </div>
+        <div class="dropdown-page-content">
+          <div v-if="showSearch" class="dropdown-search">
+            <i class="fas fa-search search-icon"></i>
+            <input type="text" v-model="search" placeholder="搜索" />
+          </div>
+          <div v-if="loading" class="dropdown-loading">
+            <l-hatch size="20" stroke="4" speed="3.5" color="var(--primary-color)"></l-hatch>
+          </div>
+          <template v-else>
+            <div v-for="o in filteredOptions" :key="o.id" @click="select(o.id)" :class="['dropdown-option', optionClass, { 'selected': isSelected(o.id) }]">
+              <slot name="option" :option="o" :isSelected="isSelected(o.id)">
+                <template v-if="o.icon">
+                  <img v-if="isImageIcon(o.icon)" :src="o.icon" class="option-icon" />
+                  <i v-else :class="['option-icon', o.icon]"></i>
+                </template>
+                <span>{{ o.name }}</span>
+              </slot>
+            </div>
+          </template>
+        </div>
+      </div>
+    </teleport>
   </div>
 </template>
 
 <script>
 import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue'
 import { hatch } from 'ldrs'
+import { isMobile } from '../utils/screen'
 hatch.register()
 
 export default {
@@ -201,7 +229,8 @@ export default {
       isSelected,
       loading,
       isImageIcon,
-      setSearch
+      setSearch,
+      isMobile
     }
   }
 }
@@ -291,5 +320,35 @@ export default {
   display: flex;
   justify-content: center;
   padding: 10px 0;
+}
+
+.dropdown-page {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: var(--background-color);
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+}
+
+.dropdown-page-header {
+  height: var(--header-height);
+  display: flex;
+  align-items: center;
+  padding: 0 10px;
+  border-bottom: 1px solid var(--normal-border-color);
+}
+
+.back-icon {
+  font-size: 20px;
+  cursor: pointer;
+}
+
+.dropdown-page-content {
+  flex: 1;
+  overflow-y: auto;
 }
 </style>

--- a/open-isle-cli/src/components/HeaderComponent.vue
+++ b/open-isle-cli/src/components/HeaderComponent.vue
@@ -13,6 +13,7 @@
       </div>
 
       <div v-if="isLogin" class="header-content-right">
+        <i v-if="isMobile" class="fas fa-search mobile-search-icon" @click="showMobileSearch = true"></i>
         <DropdownMenu ref="userMenu" :items="headerMenuItems">
           <template #trigger>
             <div class="avatar-container">
@@ -24,21 +25,35 @@
       </div>
 
       <div v-else class="header-content-right">
+        <i v-if="isMobile" class="fas fa-search mobile-search-icon" @click="showMobileSearch = true"></i>
         <div class="header-content-item-main" @click="goToLogin">登录</div>
         <div class="header-content-item-secondary" @click="goToSignup">注册</div>
       </div>
     </div>
   </header>
+  <teleport to="body">
+    <div v-if="isMobile && showMobileSearch" class="mobile-search-page">
+      <div class="mobile-search-header">
+        <i class="fas fa-arrow-left back-icon" @click="showMobileSearch = false"></i>
+      </div>
+      <SearchDropdown @selected="showMobileSearch = false" />
+    </div>
+  </teleport>
 </template>
 
 <script>
 import { authState, clearToken, loadCurrentUser } from '../utils/auth'
 import { watch } from 'vue'
 import DropdownMenu from './DropdownMenu.vue'
+import SearchDropdown from './SearchDropdown.vue'
+import { isMobile } from '../utils/screen'
 
 export default {
   name: 'HeaderComponent',
-  components: { DropdownMenu },
+  components: { DropdownMenu, SearchDropdown },
+  setup() {
+    return { isMobile }
+  },
   props: {
     showMenuBtn: {
       type: Boolean,
@@ -47,7 +62,8 @@ export default {
   },
   data() {
     return {
-      avatar: ''
+      avatar: '',
+      showMobileSearch: false
     }
   },
   computed: {
@@ -80,6 +96,7 @@ export default {
 
     watch(() => this.$route.fullPath, () => {
       if (this.$refs.userMenu) this.$refs.userMenu.close()
+      this.showMobileSearch = false
     })
   },
 
@@ -225,6 +242,31 @@ export default {
 
 .dropdown-item:hover {
   background-color: var(--menu-selected-background-color);
+}
+
+.mobile-search-icon {
+  font-size: 20px;
+  cursor: pointer;
+}
+
+.mobile-search-page {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: var(--background-color);
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+}
+
+.mobile-search-header {
+  height: var(--header-height);
+  display: flex;
+  align-items: center;
+  padding: 0 10px;
+  border-bottom: 1px solid var(--normal-border-color);
 }
 
 @media (max-width: 1200px) {

--- a/open-isle-cli/src/components/SearchDropdown.vue
+++ b/open-isle-cli/src/components/SearchDropdown.vue
@@ -32,7 +32,8 @@ import { stripMarkdown } from '../utils/markdown'
 export default {
   name: 'SearchDropdown',
   components: { Dropdown },
-  setup() {
+  emits: ['selected'],
+  setup(props, { emit }) {
     const router = useRouter()
     const keyword = ref('')
     const selected = ref(null)
@@ -83,6 +84,7 @@ export default {
       }
       selected.value = null
       keyword.value = ''
+      emit('selected')
     })
 
     return { keyword, selected, fetchResults, highlight, iconMap }
@@ -151,5 +153,18 @@ export default {
 .result-extra {
   font-size: 12px;
   color: #666;
+}
+
+@media (max-width: 768px) {
+  .search-dropdown {
+    width: 100%;
+    margin-top: 0;
+    padding: 10px;
+  }
+
+  .search-menu {
+    max-width: none;
+    width: 100%;
+  }
 }
 </style>


### PR DESCRIPTION
## Summary
- add mobile overlay mode for `Dropdown.vue`
- support emitting selection from `SearchDropdown`
- revamp `HeaderComponent` with mobile search access
- tweak styles for mobile search dropdown

## Testing
- `npm run lint`
- `mvn -q test` *(fails: could not resolve Spring parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_687db2f992a48327894cfcd3fe0e15ae