### PR TITLE
Add mobile-friendly dropdown and search

### DIFF
--- a/open-isle-cli/src/components/Dropdown.vue
+++ b/open-isle-cli/src/components/Dropdown.vue
@@ -32,7 +32,7 @@
         <i class="fas fa-caret-down dropdown-caret"></i>
       </slot>
     </div>
-    <div v-if="open && (loading || filteredOptions.length > 0 || showSearch)" :class="['dropdown-menu', menuClass]">
+    <div v-if="open && !isMobile && (loading || filteredOptions.length > 0 || showSearch)" :class="['dropdown-menu', menuClass]">
       <div v-if="showSearch" class="dropdown-search">
         <i class="fas fa-search search-icon"></i>
         <input type="text" v-model="search" placeholder="搜索" />
@@ -53,12 +53,40 @@
         </div>
       </template>
     </div>
+    <div v-if="open && isMobile" class="dropdown-mobile-page">
+      <div class="dropdown-mobile-header">
+        <i class="fas fa-arrow-left" @click="close"></i>
+        <span class="mobile-title">{{ placeholder }}</span>
+      </div>
+      <div class="dropdown-mobile-menu">
+        <div v-if="showSearch" class="dropdown-search">
+          <i class="fas fa-search search-icon"></i>
+          <input type="text" v-model="search" placeholder="搜索" />
+        </div>
+        <div v-if="loading" class="dropdown-loading">
+          <l-hatch size="20" stroke="4" speed="3.5" color="var(--primary-color)"></l-hatch>
+        </div>
+        <template v-else>
+          <div v-for="o in filteredOptions" :key="o.id" @click="select(o.id)"
+            :class="['dropdown-option', optionClass, { 'selected': isSelected(o.id) }]">
+            <slot name="option" :option="o" :isSelected="isSelected(o.id)">
+              <template v-if="o.icon">
+                <img v-if="isImageIcon(o.icon)" :src="o.icon" class="option-icon" />
+                <i v-else :class="['option-icon', o.icon]"></i>
+              </template>
+              <span>{{ o.name }}</span>
+            </slot>
+          </div>
+        </template>
+      </div>
+    </div>
   </div>
 </template>
 
 <script>
 import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue'
 import { hatch } from 'ldrs'
+import { isMobile } from '../utils/screen'
 hatch.register()
 
 export default {
@@ -74,8 +102,8 @@ export default {
     showSearch: { type: Boolean, default: true },
     initialOptions: { type: Array, default: () => [] }
   },
-  emits: ['update:modelValue'],
-  setup(props, { emit }) {
+  emits: ['update:modelValue', 'update:search', 'close'],
+  setup(props, { emit, expose }) {
     const open = ref(false)
     const search = ref('')
     const setSearch = (val) => {
@@ -88,10 +116,12 @@ export default {
 
     const toggle = () => {
       open.value = !open.value
+      if (!open.value) emit('close')
     }
 
     const close = () => {
       open.value = false
+      emit('close')
     }
 
     const select = id => {
@@ -157,6 +187,7 @@ export default {
     })
 
     watch(search, async val => {
+      emit('update:search', val)
       if (props.remote && open.value) {
         await loadOptions(val)
       }
@@ -190,9 +221,12 @@ export default {
       return /^https?:\/\//.test(icon) || icon.startsWith('/')
     }
 
+    expose({ toggle, close })
+
     return {
       open,
       toggle,
+      close,
       select,
       search,
       filteredOptions,
@@ -201,7 +235,8 @@ export default {
       isSelected,
       loading,
       isImageIcon,
-      setSearch
+      setSearch,
+      isMobile
     }
   }
 }
@@ -291,5 +326,30 @@ export default {
   display: flex;
   justify-content: center;
   padding: 10px 0;
+}
+
+.dropdown-mobile-page {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: var(--menu-background-color);
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+}
+
+.dropdown-mobile-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px;
+  border-bottom: 1px solid var(--normal-border-color);
+}
+
+.dropdown-mobile-menu {
+  flex: 1;
+  overflow-y: auto;
 }
 </style>

--- a/open-isle-cli/src/components/HeaderComponent.vue
+++ b/open-isle-cli/src/components/HeaderComponent.vue
@@ -13,6 +13,9 @@
       </div>
 
       <div v-if="isLogin" class="header-content-right">
+        <div v-if="isMobile" class="search-icon" @click="showSearch = true">
+          <i class="fas fa-search"></i>
+        </div>
         <DropdownMenu ref="userMenu" :items="headerMenuItems">
           <template #trigger>
             <div class="avatar-container">
@@ -24,21 +27,27 @@
       </div>
 
       <div v-else class="header-content-right">
+        <div v-if="isMobile" class="search-icon" @click="showSearch = true">
+          <i class="fas fa-search"></i>
+        </div>
         <div class="header-content-item-main" @click="goToLogin">登录</div>
         <div class="header-content-item-secondary" @click="goToSignup">注册</div>
       </div>
     </div>
   </header>
+  <SearchDropdown v-if="isMobile && showSearch" @close="showSearch = false" />
 </template>
 
 <script>
 import { authState, clearToken, loadCurrentUser } from '../utils/auth'
 import { watch } from 'vue'
 import DropdownMenu from './DropdownMenu.vue'
+import SearchDropdown from './SearchDropdown.vue'
+import { isMobile } from '../utils/screen'
 
 export default {
   name: 'HeaderComponent',
-  components: { DropdownMenu },
+  components: { DropdownMenu, SearchDropdown },
   props: {
     showMenuBtn: {
       type: Boolean,
@@ -47,12 +56,16 @@ export default {
   },
   data() {
     return {
-      avatar: ''
+      avatar: '',
+      showSearch: false
     }
   },
   computed: {
     isLogin() {
       return authState.loggedIn
+    },
+    isMobile() {
+      return isMobile.value
     },
     headerMenuItems() {
       return [
@@ -80,6 +93,7 @@ export default {
 
     watch(() => this.$route.fullPath, () => {
       if (this.$refs.userMenu) this.$refs.userMenu.close()
+      this.showSearch = false
     })
   },
 
@@ -225,6 +239,11 @@ export default {
 
 .dropdown-item:hover {
   background-color: var(--menu-selected-background-color);
+}
+
+.search-icon {
+  font-size: 18px;
+  cursor: pointer;
 }
 
 @media (max-width: 1200px) {


### PR DESCRIPTION
## Summary
- optimize `Dropdown` for mobile with full-screen options list
- adapt `SearchDropdown` to mobile and expose close event
- show search icon on mobile header and display mobile search overlay

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687db2f992a48327894cfcd3fe0e15ae