### PR TITLE
Add sugar toast theme

### DIFF
--- a/open-isle-cli/package-lock.json
+++ b/open-isle-cli/package-lock.json
@@ -17,6 +17,7 @@
         "vue-easy-lightbox": "^1.19.0",
         "vue-echarts": "^7.0.3",
         "vue-router": "^4.5.1",
+        "vue-toast-notification": "^3.1.3",
         "vue-toastification": "^2.0.0-rc.5"
       },
       "devDependencies": {
@@ -11601,6 +11602,18 @@
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vue-toast-notification": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/vue-toast-notification/-/vue-toast-notification-3.1.3.tgz",
+      "integrity": "sha512-XNyWqwLIGBFfX5G9sK+clq3N3IPlhDjzNdbZaXkEElcotPlWs0wWZailk1vqhdtLYT/93Y4FHAVuzyatLmPZRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.15.0"
+      },
+      "peerDependencies": {
+        "vue": "^3.0"
+      }
     },
     "node_modules/vue-toastification": {
       "version": "2.0.0-rc.5",

--- a/open-isle-cli/package.json
+++ b/open-isle-cli/package.json
@@ -17,7 +17,8 @@
     "vue-toastification": "^2.0.0-rc.5",
     "vue-easy-lightbox": "^1.19.0",
     "echarts": "^5.6.0",
-    "vue-echarts": "^7.0.3"
+    "vue-echarts": "^7.0.3",
+    "vue-toast-notification": "^3.1.3"
   },
   "devDependencies": {
     "@babel/core": "^7.12.16",

--- a/open-isle-cli/src/main.js
+++ b/open-isle-cli/src/main.js
@@ -4,6 +4,9 @@ import router from './router'
 import './assets/global.css'
 import Toast, { POSITION } from 'vue-toastification'
 import 'vue-toastification/dist/index.css'
+// Use Sugar theme from vue-toast-notification for better toast styling.
+// If you prefer Bootstrap style, replace with theme-bootstrap.css instead.
+import 'vue-toast-notification/dist/theme-sugar.css'
 import { useToast } from 'vue-toastification'
 import { checkToken, clearToken } from './utils/auth'
 import { initTheme } from './utils/theme'


### PR DESCRIPTION
## Summary
- add `vue-toast-notification` dependency
- use its Sugar theme for better toasts

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687e0fd231588327b0df01afa414aeba