### PR TITLE
Refine toast style

### DIFF
--- a/open-isle-cli/src/assets/toast.css
+++ b/open-isle-cli/src/assets/toast.css
@@ -1,0 +1,33 @@
+/* Custom styles for vue-toastification */
+.Vue-Toastification__toast--info {
+  background-color: #d0e9ff;
+  color: #1b6ec2;
+}
+.Vue-Toastification__toast--success {
+  background-color: #dff6dd;
+  color: #2b7a2b;
+}
+.Vue-Toastification__toast--error {
+  background-color: #ffe4e4;
+  color: #b73737;
+}
+
+@media (max-width: 600px) {
+  .Vue-Toastification__container {
+    width: auto;
+    max-width: 90vw;
+    right: 0.5em;
+    left: auto;
+  }
+  .Vue-Toastification__toast {
+    padding: 12px 14px;
+  }
+  .Vue-Toastification__toast-body {
+    font-size: 14px;
+    line-height: 20px;
+  }
+  .Vue-Toastification__close-button {
+    font-size: 20px;
+    line-height: 20px;
+  }
+}

--- a/open-isle-cli/src/main.js
+++ b/open-isle-cli/src/main.js
@@ -7,6 +7,7 @@ import 'vue-toastification/dist/index.css'
 // Use Sugar theme from vue-toast-notification for better toast styling.
 // If you prefer Bootstrap style, replace with theme-bootstrap.css instead.
 import 'vue-toast-notification/dist/theme-sugar.css'
+import './assets/toast.css'
 import { useToast } from 'vue-toastification'
 import { checkToken, clearToken } from './utils/auth'
 import { initTheme } from './utils/theme'


### PR DESCRIPTION
## Summary
- tweak vue-toastification styles for a lighter look
- shrink toast size on mobile
- use the new custom styles in the client

## Testing
- `npm run lint`
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e15c6a23483279840329195d93877