### PR TITLE
Enable comment image upload

### DIFF
--- a/open-isle-cli/src/components/CommentEditor.vue
+++ b/open-isle-cli/src/components/CommentEditor.vue
@@ -24,6 +24,8 @@ import { themeState } from '../utils/theme'
 import 'vditor/dist/index.css'
 import LoginOverlay from './LoginOverlay.vue'
 import { isMobile } from '../utils/screen'
+import { API_BASE_URL } from '../main'
+import { getToken } from '../utils/auth'
 
 export default {
   name: 'CommentEditor',
@@ -97,10 +99,43 @@ export default {
           'redo',
           '|',
           'link',
+          'upload'
         ],
+        upload: {
+          fieldName: 'file',
+          url: `${API_BASE_URL}/api/upload`,
+          accept: 'image/*,video/*',
+          multiple: false,
+          headers: { Authorization: `Bearer ${getToken()}` },
+          format(files, responseText) {
+            const res = JSON.parse(responseText)
+            if (res.code === 0) {
+              return JSON.stringify({
+                code: 0,
+                msg: '',
+                data: {
+                  errFiles: [],
+                  succMap: { [files[0].name]: res.data.url }
+                }
+              })
+            } else {
+              return JSON.stringify({
+                code: 1,
+                msg: '上传失败',
+                data: { errFiles: files.map(f => f.name), succMap: {} }
+              })
+            }
+          }
+        },
         toolbarConfig: { pin: true },
         input(value) {
           text.value = value
+        },
+        after() {
+          if (props.loading || props.disabled) {
+            vditorInstance.value.disabled()
+          }
+          applyTheme()
         }
       })
       // applyTheme()


### PR DESCRIPTION
## Summary
- allow comment editor to upload images
- update comment editor to match post editor features

## Testing
- `npm --prefix open-isle-cli run lint`
- `mvn -q test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6880434f591c832781515b3a8b441b3b