### PR TITLE
Add latest reply tab support

### DIFF
--- a/src/main/java/com/openisle/repository/CommentRepository.java
+++ b/src/main/java/com/openisle/repository/CommentRepository.java
@@ -16,4 +16,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     @org.springframework.data.jpa.repository.Query("SELECT DISTINCT c.author FROM Comment c WHERE c.post = :post")
     java.util.List<User> findDistinctAuthorsByPost(@org.springframework.data.repository.query.Param("post") Post post);
+
+    @org.springframework.data.jpa.repository.Query("SELECT MAX(c.createdAt) FROM Comment c WHERE c.post = :post")
+    java.time.LocalDateTime findLastCommentTime(@org.springframework.data.repository.query.Param("post") Post post);
 }

--- a/src/main/java/com/openisle/service/CommentService.java
+++ b/src/main/java/com/openisle/service/CommentService.java
@@ -123,6 +123,12 @@ public class CommentService {
         return commentRepository.findAllById(ids);
     }
 
+    public java.time.LocalDateTime getLastCommentTime(Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new com.openisle.exception.NotFoundException("Post not found"));
+        return commentRepository.findLastCommentTime(post);
+    }
+
     @org.springframework.transaction.annotation.Transactional
     public void deleteComment(String username, Long id) {
         User user = userRepository.findByUsername(username)


### PR DESCRIPTION
## Summary
- extend repository/service/controller to handle latest reply queries
- add last reply time to post DTO
- include latest reply tab on homepage

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688042f549688327ae6c8f6ff932ea0b