### PR TITLE
Add COS image reference tracking

### DIFF
--- a/src/main/java/com/openisle/model/Image.java
+++ b/src/main/java/com/openisle/model/Image.java
@@ -1,0 +1,26 @@
+package com.openisle.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Image entity tracking COS image reference counts.
+ */
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@Table(name = "images")
+public class Image {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 512)
+    private String url;
+
+    @Column(nullable = false)
+    private long refCount = 0;
+}

--- a/src/main/java/com/openisle/repository/ImageRepository.java
+++ b/src/main/java/com/openisle/repository/ImageRepository.java
@@ -1,0 +1,13 @@
+package com.openisle.repository;
+
+import com.openisle.model.Image;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+/**
+ * Repository for images stored on COS.
+ */
+public interface ImageRepository extends JpaRepository<Image, Long> {
+    Optional<Image> findByUrl(String url);
+}

--- a/src/main/java/com/openisle/service/CommentService.java
+++ b/src/main/java/com/openisle/service/CommentService.java
@@ -31,6 +31,7 @@ public class CommentService {
     private final ReactionRepository reactionRepository;
     private final CommentSubscriptionRepository commentSubscriptionRepository;
     private final NotificationRepository notificationRepository;
+    private final ImageUploader imageUploader;
 
     public Comment addComment(String username, Long postId, String content) {
         User author = userRepository.findByUsername(username)
@@ -42,6 +43,7 @@ public class CommentService {
         comment.setPost(post);
         comment.setContent(content);
         comment = commentRepository.save(comment);
+        imageUploader.addReferences(imageUploader.extractUrls(content));
         if (!author.getId().equals(post.getAuthor().getId())) {
             notificationService.createNotification(post.getAuthor(), NotificationType.COMMENT_REPLY, post, comment, null, null, null, null);
         }
@@ -69,6 +71,7 @@ public class CommentService {
         comment.setParent(parent);
         comment.setContent(content);
         comment = commentRepository.save(comment);
+        imageUploader.addReferences(imageUploader.extractUrls(content));
         if (!author.getId().equals(parent.getAuthor().getId())) {
             notificationService.createNotification(parent.getAuthor(), NotificationType.COMMENT_REPLY, parent.getPost(), comment, null, null, null, null);
         }
@@ -150,6 +153,7 @@ public class CommentService {
         reactionRepository.findByComment(comment).forEach(reactionRepository::delete);
         commentSubscriptionRepository.findByComment(comment).forEach(commentSubscriptionRepository::delete);
         notificationRepository.deleteAll(notificationRepository.findByComment(comment));
+        imageUploader.removeReferences(imageUploader.extractUrls(comment.getContent()));
         commentRepository.delete(comment);
     }
 }

--- a/src/main/java/com/openisle/service/ImageUploader.java
+++ b/src/main/java/com/openisle/service/ImageUploader.java
@@ -31,10 +31,7 @@ public abstract class ImageUploader {
      * Upload an image asynchronously and return a future of its accessible URL.
      */
     public CompletableFuture<String> upload(byte[] data, String filename) {
-        return doUpload(data, filename).thenApply(url -> {
-            addReference(url);
-            return url;
-        });
+        return doUpload(data, filename).thenApply(url -> url);
     }
 
     protected abstract CompletableFuture<String> doUpload(byte[] data, String filename);

--- a/src/main/java/com/openisle/service/ImageUploader.java
+++ b/src/main/java/com/openisle/service/ImageUploader.java
@@ -1,19 +1,101 @@
 package com.openisle.service;
 
+import com.openisle.model.Image;
+import com.openisle.repository.ImageRepository;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 /**
- * Abstract service for uploading images.
+ * Abstract service for uploading images and tracking their references.
  */
 public abstract class ImageUploader {
-    /**
-     * Upload an image and return its accessible URL.
-     * @param data image binary data
-     * @param filename name of the file
-     * @return accessible URL of the uploaded file
-     */
+    private final ImageRepository imageRepository;
+    private final String baseUrl;
+    private final Pattern urlPattern;
+
+    protected ImageUploader(ImageRepository imageRepository, String baseUrl) {
+        this.imageRepository = imageRepository;
+        if (baseUrl.endsWith("/")) {
+            this.baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+        } else {
+            this.baseUrl = baseUrl;
+        }
+        this.urlPattern = Pattern.compile(Pattern.quote(this.baseUrl) + "/[^\\s)]+");
+    }
+
     /**
      * Upload an image asynchronously and return a future of its accessible URL.
-     * Implementations should complete the future exceptionally on failures so
-     * callers can react accordingly.
      */
-    public abstract java.util.concurrent.CompletableFuture<String> upload(byte[] data, String filename);
+    public CompletableFuture<String> upload(byte[] data, String filename) {
+        return doUpload(data, filename).thenApply(url -> {
+            addReference(url);
+            return url;
+        });
+    }
+
+    protected abstract CompletableFuture<String> doUpload(byte[] data, String filename);
+
+    protected abstract void deleteFromStore(String key);
+
+    /** Extract COS URLs from text. */
+    public Set<String> extractUrls(String text) {
+        Set<String> set = new HashSet<>();
+        if (text == null) return set;
+        Matcher m = urlPattern.matcher(text);
+        while (m.find()) {
+            set.add(m.group());
+        }
+        return set;
+    }
+
+    public void addReferences(Set<String> urls) {
+        for (String u : urls) addReference(u);
+    }
+
+    public void removeReferences(Set<String> urls) {
+        for (String u : urls) removeReference(u);
+    }
+
+    public void adjustReferences(String oldText, String newText) {
+        Set<String> oldUrls = extractUrls(oldText);
+        Set<String> newUrls = extractUrls(newText);
+        for (String u : newUrls) {
+            if (!oldUrls.contains(u)) addReference(u);
+        }
+        for (String u : oldUrls) {
+            if (!newUrls.contains(u)) removeReference(u);
+        }
+    }
+
+    private void addReference(String url) {
+        if (!url.startsWith(baseUrl)) return;
+        imageRepository.findByUrl(url).ifPresentOrElse(img -> {
+            img.setRefCount(img.getRefCount() + 1);
+            imageRepository.save(img);
+        }, () -> {
+            Image img = new Image();
+            img.setUrl(url);
+            img.setRefCount(1);
+            imageRepository.save(img);
+        });
+    }
+
+    private void removeReference(String url) {
+        if (!url.startsWith(baseUrl)) return;
+        imageRepository.findByUrl(url).ifPresent(img -> {
+            long count = img.getRefCount() - 1;
+            if (count <= 0) {
+                imageRepository.delete(img);
+                String key = url.substring(baseUrl.length() + 1);
+                deleteFromStore(key);
+            } else {
+                img.setRefCount(count);
+                imageRepository.save(img);
+            }
+        });
+    }
 }

--- a/src/test/java/com/openisle/service/CosImageUploaderTest.java
+++ b/src/test/java/com/openisle/service/CosImageUploaderTest.java
@@ -2,6 +2,7 @@ package com.openisle.service;
 
 import com.qcloud.cos.COSClient;
 import com.qcloud.cos.model.PutObjectRequest;
+import com.openisle.repository.ImageRepository;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -11,7 +12,8 @@ class CosImageUploaderTest {
     @Test
     void uploadReturnsUrl() {
         COSClient client = mock(COSClient.class);
-        CosImageUploader uploader = new CosImageUploader(client, "bucket", "http://cos.example.com");
+        ImageRepository repo = mock(ImageRepository.class);
+        CosImageUploader uploader = new CosImageUploader(client, repo, "bucket", "http://cos.example.com");
 
         String url = uploader.upload("data".getBytes(), "img.png").join();
 

--- a/src/test/java/com/openisle/service/PostServiceTest.java
+++ b/src/test/java/com/openisle/service/PostServiceTest.java
@@ -24,11 +24,12 @@ class PostServiceTest {
         PostSubscriptionRepository subRepo = mock(PostSubscriptionRepository.class);
         NotificationRepository notificationRepo = mock(NotificationRepository.class);
         PostReadService postReadService = mock(PostReadService.class);
+        ImageUploader imageUploader = mock(ImageUploader.class);
 
         PostService service = new PostService(postRepo, userRepo, catRepo, tagRepo,
                 notifService, subService, commentService, commentRepo,
                 reactionRepo, subRepo, notificationRepo, postReadService,
-                PublishMode.DIRECT);
+                imageUploader, PublishMode.DIRECT);
 
         Post post = new Post();
         post.setId(1L);


### PR DESCRIPTION
## Summary
- track COS image usage in new `images` table
- manage reference counts in `ImageUploader`
- delete COS objects when unused
- adjust counts on posts, comments and avatars
- update tests for new constructors

## Testing
- `mvn test` *(fails: Could not resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6881c4e052a08327b7d6d83ef024d44a