### PR TITLE
Use dynamic_assert directory for COS uploads

### DIFF
--- a/src/main/java/com/openisle/service/CosImageUploader.java
+++ b/src/main/java/com/openisle/service/CosImageUploader.java
@@ -28,6 +28,7 @@ public class CosImageUploader extends ImageUploader {
     private final COSClient cosClient;
     private final String bucketName;
     private final String baseUrl;
+    private static final String UPLOAD_DIR = "dynamic_assert/";
     private static final Logger logger = LoggerFactory.getLogger(CosImageUploader.class);
     private final ExecutorService executor = Executors.newFixedThreadPool(2,
             new CustomizableThreadFactory("cos-upload-"));
@@ -71,18 +72,19 @@ public class CosImageUploader extends ImageUploader {
                 ext = filename.substring(dot);
             }
             String randomName = UUID.randomUUID().toString().replace("-", "") + ext;
-            logger.debug("Generated object key {}", randomName);
+            String objectKey = UPLOAD_DIR + randomName;
+            logger.debug("Generated object key {}", objectKey);
 
             ObjectMetadata meta = new ObjectMetadata();
             meta.setContentLength(data.length);
             PutObjectRequest req = new PutObjectRequest(
                     bucketName,
-                    randomName,
+                    objectKey,
                     new ByteArrayInputStream(data),
                     meta);
             logger.debug("Sending PutObject request to bucket {}", bucketName);
             cosClient.putObject(req);
-            String url = baseUrl + "/" + randomName;
+            String url = baseUrl + "/" + objectKey;
             logger.debug("Upload successful, accessible at {}", url);
             return url;
         }, executor);

--- a/src/test/java/com/openisle/service/CosImageUploaderTest.java
+++ b/src/test/java/com/openisle/service/CosImageUploaderTest.java
@@ -18,6 +18,6 @@ class CosImageUploaderTest {
         String url = uploader.upload("data".getBytes(), "img.png").join();
 
         verify(client).putObject(any(PutObjectRequest.class));
-        assertTrue(url.matches("http://cos.example.com/[a-f0-9]{32}\\.png"));
+        assertTrue(url.matches("http://cos.example.com/dynamic_assert/[a-f0-9]{32}\\.png"));
     }
 }


### PR DESCRIPTION
## Summary
- ensure Tencent COS uploads go into `dynamic_assert/` folder
- update unit test to match new path

## Testing
- `mvn test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6881f3b9d9ac8327886a02a03d1381fd