### PR TITLE
Fix loginWithGoogle router usage

### DIFF
--- a/open-isle-cli/src/utils/google.js
+++ b/open-isle-cli/src/utils/google.js
@@ -51,10 +51,15 @@ export async function googleSignIn(redirect_success, redirect_not_approved) {
   }
 }
 
+import router from '../router'
+
 export function loginWithGoogle() {
-  googleSignIn(() => {
-      this.$router.push('/')
-    }, (token) => {
-      this.$router.push('/signup-reason?token=' + token)
-    })
+  googleSignIn(
+    () => {
+      router.push('/')
+    },
+    token => {
+      router.push('/signup-reason?token=' + token)
+    }
+  )
 }


### PR DESCRIPTION
## Summary
- import router directly into google util
- use router instance instead of `this.$router`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6883375ba5d48327989c56e8c95ee8ed