### PR TITLE
Add experience info tooltip

### DIFF
--- a/open-isle-cli/src/views/ProfileView.vue
+++ b/open-isle-cli/src/views/ProfileView.vue
@@ -28,7 +28,13 @@
             <div class="profile-level-exp">
               {{ levelInfo.exp }} / {{ levelInfo.nextExp }}
             </div>
-            <div class="profile-level-target">目标 Lv.{{ levelInfo.currentLevel + 1 }}</div>
+            <div class="profile-level-target">
+              目标 Lv.{{ levelInfo.currentLevel + 1 }}
+              <i
+                class="fas fa-info-circle profile-exp-info"
+                title="经验值可通过发帖、评论等操作获得，达到目标后即可提升等级，解锁更多功能。"
+              ></i>
+            </div>
           </div>
         </div>
       </div>
@@ -582,6 +588,12 @@ export default {
 .profile-level-target {
   font-size: 12px;
   opacity: 0.8;
+}
+
+.profile-exp-info {
+  margin-left: 4px;
+  opacity: 0.5;
+  cursor: pointer;
 }
 
 .profile-info {


### PR DESCRIPTION
## Summary
- add info icon to profile level section and show tooltip

## Testing
- `npm run lint`
- `CI=true npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68870cd7086c8327a0bd7d4093193e6a