### PR TITLE
Add global popups component

### DIFF
--- a/open-isle-cli/src/App.vue
+++ b/open-isle-cli/src/App.vue
@@ -14,29 +14,21 @@
         <router-view />
       </div>
     </div>
-    <ActivityPopup
-      :visible="showMilkTeaPopup"
-      :icon="milkTeaIcon"
-      text="建站送奶茶活动火热进行中，快来参与吧！"
-      @close="closeMilkTeaPopup"
-    />
+    <GlobalPopups />
   </div>
 </template>
 
 <script>
 import HeaderComponent from './components/HeaderComponent.vue'
 import MenuComponent from './components/MenuComponent.vue'
-import ActivityPopup from './components/ActivityPopup.vue'
-import { API_BASE_URL } from './main'
+import GlobalPopups from './components/GlobalPopups.vue'
 
 export default {
   name: 'App',
-  components: { HeaderComponent, MenuComponent, ActivityPopup },
+  components: { HeaderComponent, MenuComponent, GlobalPopups },
   data() {
     return {
-      menuVisible: window.innerWidth > 768,
-      showMilkTeaPopup: false,
-      milkTeaIcon: ''
+      menuVisible: window.innerWidth > 768
     }
   },
   computed: {
@@ -45,30 +37,9 @@ export default {
     }
   },
   async mounted() {
-    await this.checkMilkTeaActivity()
+    // placeholder for future global initializations
   },
-  methods: {
-    async checkMilkTeaActivity() {
-      if (localStorage.getItem('milkTeaActivityPopupShown')) return
-      try {
-        const res = await fetch(`${API_BASE_URL}/api/activities`)
-        if (res.ok) {
-          const list = await res.json()
-          const a = list.find(i => i.type === 'MILK_TEA' && !i.ended)
-          if (a) {
-            this.milkTeaIcon = a.icon
-            this.showMilkTeaPopup = true
-          }
-        }
-      } catch (e) {
-        // ignore network errors
-      }
-    },
-    closeMilkTeaPopup() {
-      localStorage.setItem('milkTeaActivityPopupShown', 'true')
-      this.showMilkTeaPopup = false
-    }
-  }
+  methods: {}
 }
 </script>
 

--- a/open-isle-cli/src/components/GlobalPopups.vue
+++ b/open-isle-cli/src/components/GlobalPopups.vue
@@ -1,0 +1,51 @@
+<template>
+  <div>
+    <ActivityPopup
+      :visible="showMilkTeaPopup"
+      :icon="milkTeaIcon"
+      text="建站送奶茶活动火热进行中，快来参与吧！"
+      @close="closeMilkTeaPopup"
+    />
+  </div>
+</template>
+
+<script>
+import ActivityPopup from './ActivityPopup.vue'
+import { API_BASE_URL } from '../main'
+
+export default {
+  name: 'GlobalPopups',
+  components: { ActivityPopup },
+  data () {
+    return {
+      showMilkTeaPopup: false,
+      milkTeaIcon: ''
+    }
+  },
+  async mounted () {
+    await this.checkMilkTeaActivity()
+  },
+  methods: {
+    async checkMilkTeaActivity () {
+      if (localStorage.getItem('milkTeaActivityPopupShown')) return
+      try {
+        const res = await fetch(`${API_BASE_URL}/api/activities`)
+        if (res.ok) {
+          const list = await res.json()
+          const a = list.find(i => i.type === 'MILK_TEA' && !i.ended)
+          if (a) {
+            this.milkTeaIcon = a.icon
+            this.showMilkTeaPopup = true
+          }
+        }
+      } catch (e) {
+        // ignore network errors
+      }
+    },
+    closeMilkTeaPopup () {
+      localStorage.setItem('milkTeaActivityPopupShown', 'true')
+      this.showMilkTeaPopup = false
+    }
+  }
+}
+</script>


### PR DESCRIPTION
## Summary
- create `GlobalPopups.vue` to handle activity popups
- use the new component in `App.vue`
- remove milk tea popup logic from `App.vue`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68889dce48608327a3bedde54b92e499