### PR TITLE
Implement comment and post rate limits

### DIFF
--- a/src/main/java/com/openisle/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/openisle/controller/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import com.openisle.exception.FieldException;
 import com.openisle.exception.NotFoundException;
+import com.openisle.exception.RateLimitException;
 
 import java.util.Map;
 
@@ -20,6 +21,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(NotFoundException.class)
     public ResponseEntity<?> handleNotFoundException(NotFoundException ex) {
         return ResponseEntity.status(404).body(Map.of("error", ex.getMessage()));
+    }
+
+    @ExceptionHandler(RateLimitException.class)
+    public ResponseEntity<?> handleRateLimitException(RateLimitException ex) {
+        return ResponseEntity.status(429).body(Map.of("error", ex.getMessage()));
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/openisle/exception/RateLimitException.java
+++ b/src/main/java/com/openisle/exception/RateLimitException.java
@@ -1,0 +1,10 @@
+package com.openisle.exception;
+
+/**
+ * Exception thrown when a user exceeds allowed action rate.
+ */
+public class RateLimitException extends RuntimeException {
+    public RateLimitException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/openisle/service/PostService.java
+++ b/src/main/java/com/openisle/service/PostService.java
@@ -18,6 +18,7 @@ import com.openisle.repository.ReactionRepository;
 import com.openisle.repository.PostSubscriptionRepository;
 import com.openisle.repository.NotificationRepository;
 import com.openisle.model.Role;
+import com.openisle.exception.RateLimitException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -87,6 +88,11 @@ public class PostService {
                            String title,
                            String content,
                            java.util.List<Long> tagIds) {
+        long recent = postRepository.countByAuthorAfter(username,
+                java.time.LocalDateTime.now().minusMinutes(5));
+        if (recent >= 1) {
+            throw new RateLimitException("Too many posts");
+        }
         if (tagIds == null || tagIds.isEmpty()) {
             throw new IllegalArgumentException("At least one tag required");
         }

--- a/src/test/java/com/openisle/service/CommentServiceTest.java
+++ b/src/test/java/com/openisle/service/CommentServiceTest.java
@@ -1,0 +1,37 @@
+package com.openisle.service;
+
+import com.openisle.repository.CommentRepository;
+import com.openisle.repository.PostRepository;
+import com.openisle.repository.UserRepository;
+import com.openisle.repository.ReactionRepository;
+import com.openisle.repository.CommentSubscriptionRepository;
+import com.openisle.repository.NotificationRepository;
+import com.openisle.exception.RateLimitException;
+import org.junit.jupiter.api.Test;
+
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class CommentServiceTest {
+    @Test
+    void addCommentRespectsRateLimit() {
+        CommentRepository commentRepo = mock(CommentRepository.class);
+        PostRepository postRepo = mock(PostRepository.class);
+        UserRepository userRepo = mock(UserRepository.class);
+        NotificationService notifService = mock(NotificationService.class);
+        SubscriptionService subService = mock(SubscriptionService.class);
+        ReactionRepository reactionRepo = mock(ReactionRepository.class);
+        CommentSubscriptionRepository subRepo = mock(CommentSubscriptionRepository.class);
+        NotificationRepository nRepo = mock(NotificationRepository.class);
+        ImageUploader imageUploader = mock(ImageUploader.class);
+
+        CommentService service = new CommentService(commentRepo, postRepo, userRepo,
+                notifService, subService, reactionRepo, subRepo, nRepo, imageUploader);
+
+        when(commentRepo.countByAuthorAfter(eq("alice"), any())).thenReturn(3L);
+
+        assertThrows(RateLimitException.class,
+                () -> service.addComment("alice", 1L, "hi"));
+    }
+}


### PR DESCRIPTION
## Summary
- add `RateLimitException` and handle it globally with HTTP 429
- enforce comment limit of 3 per minute in `CommentService`
- enforce post limit of 1 per 5 minutes in `PostService`
- test rate limiting in service unit tests

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_6888996c3ee08327a3ae810305d0b008