### PR TITLE
Add comment sorting by date and interactions

### DIFF
--- a/src/main/java/com/openisle/controller/CommentController.java
+++ b/src/main/java/com/openisle/controller/CommentController.java
@@ -4,6 +4,7 @@ import com.openisle.model.Comment;
 import com.openisle.service.CommentService;
 import com.openisle.service.CaptchaService;
 import com.openisle.service.LevelService;
+import com.openisle.model.CommentSort;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -56,8 +57,9 @@ public class CommentController {
     }
 
     @GetMapping("/posts/{postId}/comments")
-    public List<CommentDto> listComments(@PathVariable Long postId) {
-        return commentService.getCommentsForPost(postId).stream()
+    public List<CommentDto> listComments(@PathVariable Long postId,
+                                         @RequestParam(value = "sort", required = false, defaultValue = "OLDEST") CommentSort sort) {
+        return commentService.getCommentsForPost(postId, sort).stream()
                 .map(this::toDtoWithReplies)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/openisle/controller/PostController.java
+++ b/src/main/java/com/openisle/controller/PostController.java
@@ -4,6 +4,7 @@ import com.openisle.model.Comment;
 import com.openisle.model.Post;
 import com.openisle.model.Reaction;
 import com.openisle.service.CommentService;
+import com.openisle.model.CommentSort;
 import com.openisle.service.PostService;
 import com.openisle.service.ReactionService;
 import com.openisle.service.CaptchaService;
@@ -180,7 +181,7 @@ public class PostController {
                 .collect(Collectors.toList());
         dto.setReactions(reactions);
 
-        List<CommentDto> comments = commentService.getCommentsForPost(post.getId())
+        List<CommentDto> comments = commentService.getCommentsForPost(post.getId(), CommentSort.OLDEST)
                 .stream()
                 .map(this::toCommentDtoWithReplies)
                 .collect(Collectors.toList());

--- a/src/main/java/com/openisle/model/CommentSort.java
+++ b/src/main/java/com/openisle/model/CommentSort.java
@@ -1,0 +1,10 @@
+package com.openisle.model;
+
+/**
+ * Sort options for comments.
+ */
+public enum CommentSort {
+    NEWEST,
+    OLDEST,
+    MOST_INTERACTIONS
+}

--- a/src/test/java/com/openisle/controller/CommentControllerTest.java
+++ b/src/test/java/com/openisle/controller/CommentControllerTest.java
@@ -19,6 +19,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.any;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -53,7 +54,7 @@ class CommentControllerTest {
     void createAndListComments() throws Exception {
         Comment comment = createComment(1L, "hi", "bob");
         Mockito.when(commentService.addComment(eq("bob"), eq(1L), eq("hi"))).thenReturn(comment);
-        Mockito.when(commentService.getCommentsForPost(1L)).thenReturn(List.of(comment));
+        Mockito.when(commentService.getCommentsForPost(eq(1L), any())).thenReturn(List.of(comment));
         Mockito.when(commentService.getReplies(1L)).thenReturn(List.of());
 
         mockMvc.perform(post("/api/posts/1/comments")

--- a/src/test/java/com/openisle/controller/PostControllerTest.java
+++ b/src/test/java/com/openisle/controller/PostControllerTest.java
@@ -184,7 +184,7 @@ class PostControllerTest {
         cr.setType(com.openisle.model.ReactionType.LIKE);
 
         Mockito.when(postService.viewPost(eq(1L), Mockito.isNull())).thenReturn(post);
-        Mockito.when(commentService.getCommentsForPost(1L)).thenReturn(List.of(comment));
+        Mockito.when(commentService.getCommentsForPost(eq(1L), any())).thenReturn(List.of(comment));
         Mockito.when(commentService.getReplies(2L)).thenReturn(List.of(reply));
         Mockito.when(commentService.getReplies(3L)).thenReturn(List.of());
         Mockito.when(commentService.getParticipants(Mockito.anyLong(), Mockito.anyInt())).thenReturn(java.util.List.of());


### PR DESCRIPTION
## Summary
- allow sorting comments by newest, oldest or most interactions
- implement dropdown on post page to choose comment order
- update controllers and service for new enum `CommentSort`
- adjust tests for new parameter

## Testing
- `mvn -q test` *(fails: Could not resolve dependencies)*
- `npm run lint` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888cbc06e44832792b38d105dc49e10