### PR TITLE
Improve push notifications

### DIFF
--- a/open-isle-cli/public/notifications-sw.js
+++ b/open-isle-cli/public/notifications-sw.js
@@ -1,9 +1,23 @@
 self.addEventListener('push', function(event) {
-  const data = event.data ? event.data.text() : 'New notification';
+  let payload = { body: 'New notification', url: '/' }
+  try {
+    if (event.data) payload = JSON.parse(event.data.text())
+  } catch (e) {
+    if (event.data) payload.body = event.data.text()
+  }
   event.waitUntil(
     self.registration.showNotification('OpenIsle', {
-      body: data,
-      icon: '/favicon.ico'
+      body: payload.body,
+      icon: '/favicon.ico',
+      data: { url: payload.url }
     })
-  );
-});
+  )
+})
+
+self.addEventListener('notificationclick', function(event) {
+  const url = event.notification.data && event.notification.data.url
+  event.notification.close()
+  if (url) {
+    event.waitUntil(clients.openWindow(url))
+  }
+})

--- a/src/main/java/com/openisle/service/ReactionService.java
+++ b/src/main/java/com/openisle/service/ReactionService.java
@@ -48,9 +48,12 @@ public class ReactionService {
         if (!user.getId().equals(post.getAuthor().getId())) {
             notificationService.createNotification(post.getAuthor(), NotificationType.REACTION, post, null, null, user, type, null);
             long count = reactionRepository.countReceived(post.getAuthor().getUsername());
-            if (count % 5 == 0 && post.getAuthor().getEmail() != null) {
+            if (count % 5 == 0) {
                 String url = websiteUrl + "/messages";
-                emailSender.sendEmail(post.getAuthor().getEmail(), "【OpenIsle】你有新的互动", url);
+                notificationService.sendCustomPush(post.getAuthor(), "你有新的互动", url);
+                if (post.getAuthor().getEmail() != null) {
+                    emailSender.sendEmail(post.getAuthor().getEmail(), "【OpenIsle】你有新的互动", url);
+                }
             }
         }
         return reaction;
@@ -76,9 +79,12 @@ public class ReactionService {
         if (!user.getId().equals(comment.getAuthor().getId())) {
             notificationService.createNotification(comment.getAuthor(), NotificationType.REACTION, comment.getPost(), comment, null, user, type, null);
             long count = reactionRepository.countReceived(comment.getAuthor().getUsername());
-            if (count % 5 == 0 && comment.getAuthor().getEmail() != null) {
+            if (count % 5 == 0) {
                 String url = websiteUrl + "/messages";
-                emailSender.sendEmail(comment.getAuthor().getEmail(), "【OpenIsle】你有新的互动", url);
+                notificationService.sendCustomPush(comment.getAuthor(), "你有新的互动", url);
+                if (comment.getAuthor().getEmail() != null) {
+                    emailSender.sendEmail(comment.getAuthor().getEmail(), "【OpenIsle】你有新的互动", url);
+                }
             }
         }
         return reaction;

--- a/src/test/java/com/openisle/service/NotificationServiceTest.java
+++ b/src/test/java/com/openisle/service/NotificationServiceTest.java
@@ -3,6 +3,7 @@ package com.openisle.service;
 import com.openisle.model.*;
 import com.openisle.repository.NotificationRepository;
 import com.openisle.repository.UserRepository;
+import com.openisle.service.PushNotificationService;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -19,7 +20,8 @@ class NotificationServiceTest {
         NotificationRepository nRepo = mock(NotificationRepository.class);
         UserRepository uRepo = mock(UserRepository.class);
         EmailSender email = mock(EmailSender.class);
-        NotificationService service = new NotificationService(nRepo, uRepo, email);
+        PushNotificationService push = mock(PushNotificationService.class);
+        NotificationService service = new NotificationService(nRepo, uRepo, email, push);
         org.springframework.test.util.ReflectionTestUtils.setField(service, "websiteUrl", "https://ex.com");
 
         User user = new User();
@@ -47,7 +49,8 @@ class NotificationServiceTest {
         NotificationRepository nRepo = mock(NotificationRepository.class);
         UserRepository uRepo = mock(UserRepository.class);
         EmailSender email = mock(EmailSender.class);
-        NotificationService service = new NotificationService(nRepo, uRepo, email);
+        PushNotificationService push = mock(PushNotificationService.class);
+        NotificationService service = new NotificationService(nRepo, uRepo, email, push);
         org.springframework.test.util.ReflectionTestUtils.setField(service, "websiteUrl", "https://ex.com");
 
         User user = new User();
@@ -69,7 +72,8 @@ class NotificationServiceTest {
         NotificationRepository nRepo = mock(NotificationRepository.class);
         UserRepository uRepo = mock(UserRepository.class);
         EmailSender email = mock(EmailSender.class);
-        NotificationService service = new NotificationService(nRepo, uRepo, email);
+        PushNotificationService push = mock(PushNotificationService.class);
+        NotificationService service = new NotificationService(nRepo, uRepo, email, push);
         org.springframework.test.util.ReflectionTestUtils.setField(service, "websiteUrl", "https://ex.com");
 
         User user = new User();
@@ -89,7 +93,8 @@ class NotificationServiceTest {
         NotificationRepository nRepo = mock(NotificationRepository.class);
         UserRepository uRepo = mock(UserRepository.class);
         EmailSender email = mock(EmailSender.class);
-        NotificationService service = new NotificationService(nRepo, uRepo, email);
+        PushNotificationService push = mock(PushNotificationService.class);
+        NotificationService service = new NotificationService(nRepo, uRepo, email, push);
         org.springframework.test.util.ReflectionTestUtils.setField(service, "websiteUrl", "https://ex.com");
 
         User admin = new User();
@@ -110,7 +115,8 @@ class NotificationServiceTest {
         NotificationRepository nRepo = mock(NotificationRepository.class);
         UserRepository uRepo = mock(UserRepository.class);
         EmailSender email = mock(EmailSender.class);
-        NotificationService service = new NotificationService(nRepo, uRepo, email);
+        PushNotificationService push = mock(PushNotificationService.class);
+        NotificationService service = new NotificationService(nRepo, uRepo, email, push);
         org.springframework.test.util.ReflectionTestUtils.setField(service, "websiteUrl", "https://ex.com");
 
         User admin = new User();
@@ -131,7 +137,8 @@ class NotificationServiceTest {
         NotificationRepository nRepo = mock(NotificationRepository.class);
         UserRepository uRepo = mock(UserRepository.class);
         EmailSender email = mock(EmailSender.class);
-        NotificationService service = new NotificationService(nRepo, uRepo, email);
+        PushNotificationService push = mock(PushNotificationService.class);
+        NotificationService service = new NotificationService(nRepo, uRepo, email, push);
         org.springframework.test.util.ReflectionTestUtils.setField(service, "websiteUrl", "https://ex.com");
 
         User user = new User();
@@ -145,5 +152,6 @@ class NotificationServiceTest {
         service.createNotification(user, NotificationType.COMMENT_REPLY, post, comment, null, null, null, null);
 
         verify(email).sendEmail("a@a.com", "【OpenIsle】有人回复了你", "https://ex.com/posts/1#comment-2");
+        verify(push).sendNotification(eq(user), contains("/posts/1#comment-2"));
     }
 }

--- a/src/test/java/com/openisle/service/ReactionServiceTest.java
+++ b/src/test/java/com/openisle/service/ReactionServiceTest.java
@@ -39,5 +39,6 @@ class ReactionServiceTest {
         service.reactToPost("bob", 3L, ReactionType.LIKE);
 
         verify(email).sendEmail("a@a.com", "【OpenIsle】你有新的互动", "https://ex.com/messages");
+        verify(notif).sendCustomPush(author, "你有新的互动", "https://ex.com/messages");
     }
 }


### PR DESCRIPTION
## Summary
- enhance push notifications to include message and URL info
- send tailored push for comment replies and reaction milestones
- open clicked notifications at the right page
- adjust tests for push logic

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688995b54aa883278d20ea6974b58bda