### PR TITLE
Enable asynchronous notification sending

### DIFF
--- a/src/main/java/com/openisle/config/AsyncConfig.java
+++ b/src/main/java/com/openisle/config/AsyncConfig.java
@@ -1,0 +1,23 @@
+package com.openisle.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+    @Bean(name = "notificationExecutor")
+    public Executor notificationExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("notification-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/openisle/service/ResendEmailSender.java
+++ b/src/main/java/com/openisle/service/ResendEmailSender.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.HashMap;
@@ -20,6 +21,7 @@ public class ResendEmailSender extends EmailSender {
     private final RestTemplate restTemplate = new RestTemplate();
 
     @Override
+    @Async("notificationExecutor")
     public void sendEmail(String to, String subject, String text) {
         String url = "https://api.resend.com/emails"; // hypothetical endpoint
 

--- a/src/test/java/com/openisle/service/NotificationServiceTest.java
+++ b/src/test/java/com/openisle/service/NotificationServiceTest.java
@@ -4,6 +4,8 @@ import com.openisle.model.*;
 import com.openisle.repository.NotificationRepository;
 import com.openisle.repository.UserRepository;
 import com.openisle.service.PushNotificationService;
+import com.openisle.repository.ReactionRepository;
+import java.util.concurrent.Executor;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -21,7 +23,9 @@ class NotificationServiceTest {
         UserRepository uRepo = mock(UserRepository.class);
         EmailSender email = mock(EmailSender.class);
         PushNotificationService push = mock(PushNotificationService.class);
-        NotificationService service = new NotificationService(nRepo, uRepo, email, push);
+        ReactionRepository rRepo = mock(ReactionRepository.class);
+        Executor executor = Runnable::run;
+        NotificationService service = new NotificationService(nRepo, uRepo, email, push, rRepo, executor);
         org.springframework.test.util.ReflectionTestUtils.setField(service, "websiteUrl", "https://ex.com");
 
         User user = new User();
@@ -50,7 +54,9 @@ class NotificationServiceTest {
         UserRepository uRepo = mock(UserRepository.class);
         EmailSender email = mock(EmailSender.class);
         PushNotificationService push = mock(PushNotificationService.class);
-        NotificationService service = new NotificationService(nRepo, uRepo, email, push);
+        ReactionRepository rRepo = mock(ReactionRepository.class);
+        Executor executor = Runnable::run;
+        NotificationService service = new NotificationService(nRepo, uRepo, email, push, rRepo, executor);
         org.springframework.test.util.ReflectionTestUtils.setField(service, "websiteUrl", "https://ex.com");
 
         User user = new User();
@@ -73,7 +79,9 @@ class NotificationServiceTest {
         UserRepository uRepo = mock(UserRepository.class);
         EmailSender email = mock(EmailSender.class);
         PushNotificationService push = mock(PushNotificationService.class);
-        NotificationService service = new NotificationService(nRepo, uRepo, email, push);
+        ReactionRepository rRepo = mock(ReactionRepository.class);
+        Executor executor = Runnable::run;
+        NotificationService service = new NotificationService(nRepo, uRepo, email, push, rRepo, executor);
         org.springframework.test.util.ReflectionTestUtils.setField(service, "websiteUrl", "https://ex.com");
 
         User user = new User();
@@ -94,7 +102,9 @@ class NotificationServiceTest {
         UserRepository uRepo = mock(UserRepository.class);
         EmailSender email = mock(EmailSender.class);
         PushNotificationService push = mock(PushNotificationService.class);
-        NotificationService service = new NotificationService(nRepo, uRepo, email, push);
+        ReactionRepository rRepo = mock(ReactionRepository.class);
+        Executor executor = Runnable::run;
+        NotificationService service = new NotificationService(nRepo, uRepo, email, push, rRepo, executor);
         org.springframework.test.util.ReflectionTestUtils.setField(service, "websiteUrl", "https://ex.com");
 
         User admin = new User();
@@ -116,7 +126,9 @@ class NotificationServiceTest {
         UserRepository uRepo = mock(UserRepository.class);
         EmailSender email = mock(EmailSender.class);
         PushNotificationService push = mock(PushNotificationService.class);
-        NotificationService service = new NotificationService(nRepo, uRepo, email, push);
+        ReactionRepository rRepo = mock(ReactionRepository.class);
+        Executor executor = Runnable::run;
+        NotificationService service = new NotificationService(nRepo, uRepo, email, push, rRepo, executor);
         org.springframework.test.util.ReflectionTestUtils.setField(service, "websiteUrl", "https://ex.com");
 
         User admin = new User();
@@ -138,7 +150,9 @@ class NotificationServiceTest {
         UserRepository uRepo = mock(UserRepository.class);
         EmailSender email = mock(EmailSender.class);
         PushNotificationService push = mock(PushNotificationService.class);
-        NotificationService service = new NotificationService(nRepo, uRepo, email, push);
+        ReactionRepository rRepo = mock(ReactionRepository.class);
+        Executor executor = Runnable::run;
+        NotificationService service = new NotificationService(nRepo, uRepo, email, push, rRepo, executor);
         org.springframework.test.util.ReflectionTestUtils.setField(service, "websiteUrl", "https://ex.com");
 
         User user = new User();


### PR DESCRIPTION
## Summary
- add AsyncConfig with thread pool executor
- run notification side effects on a background executor
- inject executor in NotificationService tests
- make ResendEmailSender execute asynchronously

## Testing
- `mvn -q -DskipTests compile` *(fails: Non-resolvable parent POM)*
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68899d71df6c8327be050f76d1fd57ef