### PR TITLE
Count real milk tea redemptions

### DIFF
--- a/open-isle-cli/src/components/MilkTeaActivityComponent.vue
+++ b/open-isle-cli/src/components/MilkTeaActivityComponent.vue
@@ -14,8 +14,8 @@
     <div class="milk-tea-status-container">
     <div class="milk-tea-status">
       <div class="status-title">🔥 已兑换奶茶人数</div>
-      <ProgressBar :value="info.level1Count" :max="50" />
-      <div class="status-text">当前 {{ info.level1Count }} / 50</div>
+      <ProgressBar :value="info.redeemCount" :max="50" />
+      <div class="status-text">当前 {{ info.redeemCount }} / 50</div>
     </div>
       <div v-if="isLoadingUser" class="loading-user">
         <l-hatch size="28" stroke="4" speed="3.5" color="var(--primary-color)"></l-hatch>
@@ -57,7 +57,7 @@ export default {
   components: { ProgressBar, LevelProgress, BaseInput, BasePopup },
   data () {
     return {
-      info: { level1Count: 0, ended: false },
+      info: { redeemCount: 0, ended: false },
       user: null,
       dialogVisible: false,
       contact: '',
@@ -97,7 +97,12 @@ export default {
         body: JSON.stringify({ contact: this.contact })
       })
       if (res.ok) {
-        toast.success('兑换成功！')
+        const data = await res.json()
+        if (data.message === 'updated') {
+          toast.success('您已提交过兑换，本次更新兑换信息')
+        } else {
+          toast.success('兑换成功！')
+        }
         this.dialogVisible = false
         await this.loadInfo()
       } else {

--- a/src/main/java/com/openisle/controller/ActivityController.java
+++ b/src/main/java/com/openisle/controller/ActivityController.java
@@ -27,26 +27,30 @@ public class ActivityController {
     @GetMapping("/milk-tea")
     public MilkTeaInfo milkTea() {
         Activity a = activityService.getByType(ActivityType.MILK_TEA);
-        long count = activityService.countLevel1Users();
-        if (!a.isEnded() && count > 50) {
+        long count = activityService.countParticipants(a);
+        if (!a.isEnded() && count >= 50) {
             activityService.end(a);
         }
         MilkTeaInfo info = new MilkTeaInfo();
-        info.setLevel1Count(count);
+        info.setRedeemCount(count);
         info.setEnded(a.isEnded());
         return info;
     }
 
     @PostMapping("/milk-tea/redeem")
-    public void redeemMilkTea(@RequestBody RedeemRequest req, Authentication auth) {
+    public java.util.Map<String, String> redeemMilkTea(@RequestBody RedeemRequest req, Authentication auth) {
         User user = userService.findByIdentifier(auth.getName()).orElseThrow();
         Activity a = activityService.getByType(ActivityType.MILK_TEA);
-        activityService.redeem(a, user, req.getContact());
+        boolean first = activityService.redeem(a, user, req.getContact());
+        if (first) {
+            return java.util.Map.of("message", "redeemed");
+        }
+        return java.util.Map.of("message", "updated");
     }
 
     @Data
     private static class MilkTeaInfo {
-        private long level1Count;
+        private long redeemCount;
         private boolean ended;
     }
 

--- a/src/main/java/com/openisle/service/ActivityService.java
+++ b/src/main/java/com/openisle/service/ActivityService.java
@@ -37,9 +37,20 @@ public class ActivityService {
         activityRepository.save(activity);
     }
 
-    public void redeem(Activity activity, User user, String contact) {
+    public long countParticipants(Activity activity) {
+        return activity.getParticipants().size();
+    }
+
+    /**
+     * Redeem an activity for the given user.
+     *
+     * @return true if the user redeemed for the first time, false if the
+     *         information was simply updated
+     */
+    public boolean redeem(Activity activity, User user, String contact) {
         notificationService.createActivityRedeemNotifications(user, contact);
-        activity.getParticipants().add(user);
+        boolean added = activity.getParticipants().add(user);
         activityRepository.save(activity);
+        return added;
     }
 }


### PR DESCRIPTION
## Summary
- count the number of users who actually redeemed the milk tea activity
- inform the frontend if the redeem request updates an existing record
- show redeemed count on the milk tea component

## Testing
- `mvn -q test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6889dfb8fe948327af68676dea473552