### PR TITLE
Fix alt attributes for SEO

### DIFF
--- a/open-isle-cli/src/components/ActivityPopup.vue
+++ b/open-isle-cli/src/components/ActivityPopup.vue
@@ -1,7 +1,7 @@
 <template>
   <BasePopup :visible="visible" @close="close">
     <div class="activity-popup">
-      <img v-if="icon" :src="icon" class="activity-popup-icon" />
+      <img v-if="icon" :src="icon" class="activity-popup-icon" alt="activity icon" />
       <div class="activity-popup-text">{{ text }}</div>
       <div class="activity-popup-actions">
         <div class="activity-popup-button" @click="gotoActivity">立即前往</div>

--- a/open-isle-cli/src/components/BaseTimeline.vue
+++ b/open-isle-cli/src/components/BaseTimeline.vue
@@ -6,7 +6,7 @@
         :class="{ clickable: !!item.iconClick }"
         @click="item.iconClick && item.iconClick()"
       >
-        <img v-if="item.src" :src="item.src" class="timeline-img" />
+        <img v-if="item.src" :src="item.src" class="timeline-img" alt="timeline item" />
         <i v-else-if="item.icon" :class="item.icon"></i>
         <span v-else-if="item.emoji" class="timeline-emoji">{{ item.emoji }}</span>
       </div>

--- a/open-isle-cli/src/components/CategorySelect.vue
+++ b/open-isle-cli/src/components/CategorySelect.vue
@@ -4,7 +4,7 @@
       <div class="option-container">
         <div class="option-main">
           <template v-if="option.icon">
-            <img v-if="isImageIcon(option.icon)" :src="option.icon" class="option-icon" />
+            <img v-if="isImageIcon(option.icon)" :src="option.icon" class="option-icon" :alt="option.name" />
             <i v-else :class="['option-icon', option.icon]"></i>
           </template>
           <span>{{ option.name }}</span>

--- a/open-isle-cli/src/components/Dropdown.vue
+++ b/open-isle-cli/src/components/Dropdown.vue
@@ -7,7 +7,7 @@
             <template v-for="(label, idx) in selectedLabels" :key="label.id">
               <div class="selected-label">
                 <template v-if="label.icon">
-                  <img v-if="isImageIcon(label.icon)" :src="label.icon" class="option-icon" />
+                    <img v-if="isImageIcon(label.icon)" :src="label.icon" class="option-icon" :alt="label.name" />
                   <i v-else :class="['option-icon', label.icon]"></i>
                 </template>
                 <span>{{ label.name }}</span>
@@ -21,7 +21,7 @@
           <span v-if="selectedLabels.length">
             <div class="selected-label">
               <template v-if="selectedLabels[0].icon">
-                <img v-if="isImageIcon(selectedLabels[0].icon)" :src="selectedLabels[0].icon" class="option-icon" />
+                  <img v-if="isImageIcon(selectedLabels[0].icon)" :src="selectedLabels[0].icon" class="option-icon" :alt="selectedLabels[0].name" />
                 <i v-else :class="['option-icon', selectedLabels[0].icon]"></i>
               </template>
               <span>{{ selectedLabels[0].name }}</span>
@@ -45,7 +45,7 @@
           :class="['dropdown-option', optionClass, { 'selected': isSelected(o.id) }]">
           <slot name="option" :option="o" :isSelected="isSelected(o.id)">
             <template v-if="o.icon">
-              <img v-if="isImageIcon(o.icon)" :src="o.icon" class="option-icon" />
+                <img v-if="isImageIcon(o.icon)" :src="o.icon" class="option-icon" :alt="o.name" />
               <i v-else :class="['option-icon', o.icon]"></i>
             </template>
             <span>{{ o.name }}</span>
@@ -72,7 +72,7 @@
               :class="['dropdown-option', optionClass, { 'selected': isSelected(o.id) }]">
               <slot name="option" :option="o" :isSelected="isSelected(o.id)">
                 <template v-if="o.icon">
-                  <img v-if="isImageIcon(o.icon)" :src="o.icon" class="option-icon" />
+                  <img v-if="isImageIcon(o.icon)" :src="o.icon" class="option-icon" :alt="o.name" />
                   <i v-else :class="['option-icon', o.icon]"></i>
                 </template>
                 <span>{{ o.name }}</span>

--- a/open-isle-cli/src/components/MenuComponent.vue
+++ b/open-isle-cli/src/components/MenuComponent.vue
@@ -73,7 +73,7 @@
           </div>
           <div v-else v-for="c in categories" :key="c.id" class="section-item" @click="gotoCategory(c)">
             <template v-if="c.smallIcon || c.icon">
-              <img v-if="isImageIcon(c.smallIcon || c.icon)" :src="c.smallIcon || c.icon" class="section-item-icon" />
+              <img v-if="isImageIcon(c.smallIcon || c.icon)" :src="c.smallIcon || c.icon" class="section-item-icon" :alt="c.name" />
               <i v-else :class="['section-item-icon', c.smallIcon || c.icon]"></i>
             </template>
             <span class="section-item-text">{{ c.name }}</span>
@@ -91,7 +91,7 @@
             <l-hatch size="28" stroke="4" speed="3.5" color="var(--primary-color)"></l-hatch>
           </div>
           <div v-else v-for="t in tags" :key="t.id" class="section-item" @click="gotoTag(t)">
-            <img v-if="isImageIcon(t.smallIcon || t.icon)" :src="t.smallIcon || t.icon" class="section-item-icon" />
+            <img v-if="isImageIcon(t.smallIcon || t.icon)" :src="t.smallIcon || t.icon" class="section-item-icon" :alt="t.name" />
             <i v-else class="section-item-icon fas fa-hashtag"></i>
             <span class="section-item-text">{{ t.name }} <span class="section-item-text-count">x {{ t.count
                 }}</span></span>

--- a/open-isle-cli/src/components/TagSelect.vue
+++ b/open-isle-cli/src/components/TagSelect.vue
@@ -5,7 +5,7 @@
       <div class="option-container">
         <div class="option-main">
           <template v-if="option.icon">
-            <img v-if="isImageIcon(option.icon)" :src="option.icon" class="option-icon" />
+            <img v-if="isImageIcon(option.icon)" :src="option.icon" class="option-icon" :alt="option.name" />
             <i v-else :class="['option-icon', option.icon]"></i>
           </template>
           <span>{{ option.name }}</span>

--- a/open-isle-cli/src/views/SettingsPageView.vue
+++ b/open-isle-cli/src/views/SettingsPageView.vue
@@ -9,7 +9,7 @@
         <div class="avatar-row">
           <!-- label 充当点击区域，内部隐藏 input -->
           <label class="avatar-container">
-            <img :src="avatar" class="avatar-preview" />
+            <img :src="avatar" class="avatar-preview" alt="avatar" />
             <!-- 半透明蒙层：hover 时出现 -->
             <div class="avatar-overlay">更换头像</div>
             <input type="file" class="avatar-input" accept="image/*" @change="onAvatarChange" />


### PR DESCRIPTION
## Summary
- add missing alt text to category and tag icons in `MenuComponent`
- set alt text for avatar preview in Settings page
- provide alt text for dropdown options and selected labels
- include alt text in other components such as timeline and popup

## Testing
- `npm install` in `open-isle-cli`
- `npm run lint`
- `mvn -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688a084876808327860a6dff07d13b5c