### PR TITLE
Fix sitemap lastmod format

### DIFF
--- a/src/main/java/com/openisle/controller/SitemapController.java
+++ b/src/main/java/com/openisle/controller/SitemapController.java
@@ -56,7 +56,7 @@ public class SitemapController {
                 .append(p.getId())
                 .append("</loc>\n")
                 .append("    <lastmod>")
-                .append(p.getCreatedAt())
+                .append(p.getCreatedAt().toLocalDate())
                 .append("</lastmod>\n")
                 .append("  </url>\n");
         }


### PR DESCRIPTION
## Summary
- ensure sitemap `<lastmod>` dates use `yyyy-MM-dd`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688a14fd984483278608c33237c88d71