### PR TITLE
Adjust default topic view to latest reply

### DIFF
--- a/open-isle-cli/src/views/HomePageView.vue
+++ b/open-isle-cli/src/views/HomePageView.vue
@@ -151,13 +151,13 @@ export default {
     const tagOptions = ref([])
     const categoryOptions = ref([])
     const isLoadingPosts = ref(false)
-    const topics = ref(['最新', '最新回复', '排行榜' /*, '热门', '类别'*/])
+    const topics = ref(['最新回复', '最新', '排行榜' /*, '热门', '类别'*/])
     const selectedTopic = ref(
       route.query.view === 'ranking'
         ? '排行榜'
-        : route.query.view === 'latest-reply'
-          ? '最新回复'
-          : '最新'
+        : route.query.view === 'latest'
+          ? '最新'
+          : '最新回复'
     )
 
     const articles = ref([])


### PR DESCRIPTION
## Summary
- reorder topic list to start with latest replies
- set latest reply as default topic

## Testing
- `npm run lint`
- `mvn -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688af4524bf08327a5b5067cadcdebc8