### PR TITLE
Add categories/tags to search

### DIFF
--- a/open-isle-cli/src/components/SearchDropdown.vue
+++ b/open-isle-cli/src/components/SearchDropdown.vue
@@ -74,7 +74,9 @@ export default {
     const iconMap = {
       user: 'fas fa-user',
       post: 'fas fa-file-alt',
-      comment: 'fas fa-comment'
+      comment: 'fas fa-comment',
+      category: 'fas fa-folder',
+      tag: 'fas fa-hashtag'
     }
 
     watch(selected, val => {
@@ -89,6 +91,10 @@ export default {
         if (opt.postId) {
           router.push(`/posts/${opt.postId}#comment-${opt.id}`)
         }
+      } else if (opt.type === 'category') {
+        router.push({ path: '/', query: { category: opt.id } })
+      } else if (opt.type === 'tag') {
+        router.push({ path: '/', query: { tags: opt.id } })
       }
       selected.value = null
       keyword.value = ''

--- a/src/main/java/com/openisle/repository/CategoryRepository.java
+++ b/src/main/java/com/openisle/repository/CategoryRepository.java
@@ -3,5 +3,8 @@ package com.openisle.repository;
 import com.openisle.model.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CategoryRepository extends JpaRepository<Category, Long> {
+    List<Category> findByNameContainingIgnoreCase(String keyword);
 }

--- a/src/test/java/com/openisle/integration/SearchIntegrationTest.java
+++ b/src/test/java/com/openisle/integration/SearchIntegrationTest.java
@@ -61,10 +61,10 @@ class SearchIntegrationTest {
         String admin = registerAndLoginAsAdmin("admin1", "a@a.com");
         String user = registerAndLogin("bob_nice", "b@b.com");
 
-        ResponseEntity<Map> catResp = postJson("/api/categories", Map.of("name", "misc", "description", "d", "icon", "i"), admin);
+        ResponseEntity<Map> catResp = postJson("/api/categories", Map.of("name", "nic-cat", "description", "d", "icon", "i"), admin);
         Long catId = ((Number)catResp.getBody().get("id")).longValue();
 
-        ResponseEntity<Map> tagResp = postJson("/api/tags", Map.of("name", "misc", "description", "d", "icon", "i"), admin);
+        ResponseEntity<Map> tagResp = postJson("/api/tags", Map.of("name", "nic-tag", "description", "d", "icon", "i"), admin);
         Long tagId = ((Number)tagResp.getBody().get("id")).longValue();
 
         ResponseEntity<Map> postResp = postJson("/api/posts",
@@ -76,9 +76,11 @@ class SearchIntegrationTest {
                 Map.of("content", "Nice article"), admin);
 
         List<Map<String, Object>> results = rest.getForObject("/api/search/global?keyword=nic", List.class);
-        assertEquals(3, results.size());
+        assertEquals(5, results.size());
         assertTrue(results.stream().anyMatch(m -> "user".equals(m.get("type"))));
         assertTrue(results.stream().anyMatch(m -> "post".equals(m.get("type"))));
         assertTrue(results.stream().anyMatch(m -> "comment".equals(m.get("type"))));
+        assertTrue(results.stream().anyMatch(m -> "category".equals(m.get("type"))));
+        assertTrue(results.stream().anyMatch(m -> "tag".equals(m.get("type"))));
     }
 }


### PR DESCRIPTION
## Summary
- allow searching categories via `CategoryRepository`
- extend `SearchService` to return categories and tags
- update search dropdown icons and routing for new types
- check for new results in integration test

## Testing
- `mvn test` *(fails: unable to resolve dependencies)*
- `npm run lint` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_688af563d65083278f27cc112b3a63bd