### PR TITLE
Fix SearchServiceTest constructor

### DIFF
--- a/src/test/java/com/openisle/service/SearchServiceTest.java
+++ b/src/test/java/com/openisle/service/SearchServiceTest.java
@@ -5,6 +5,8 @@ import com.openisle.model.PostStatus;
 import com.openisle.repository.CommentRepository;
 import com.openisle.repository.PostRepository;
 import com.openisle.repository.UserRepository;
+import com.openisle.repository.CategoryRepository;
+import com.openisle.repository.TagRepository;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -19,7 +21,9 @@ class SearchServiceTest {
         UserRepository userRepo = Mockito.mock(UserRepository.class);
         PostRepository postRepo = Mockito.mock(PostRepository.class);
         CommentRepository commentRepo = Mockito.mock(CommentRepository.class);
-        SearchService service = new SearchService(userRepo, postRepo, commentRepo);
+        CategoryRepository categoryRepo = Mockito.mock(CategoryRepository.class);
+        TagRepository tagRepo = Mockito.mock(TagRepository.class);
+        SearchService service = new SearchService(userRepo, postRepo, commentRepo, categoryRepo, tagRepo);
 
         Post post1 = new Post();
         post1.setId(1L);


### PR DESCRIPTION
## Summary
- update SearchServiceTest to reflect new SearchService constructor requiring CategoryRepository and TagRepository

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688afd8375f48327b02c319e19cb441e