### PR TITLE
Add counts for categories in menu

### DIFF
--- a/open-isle-cli/src/components/MenuComponent.vue
+++ b/open-isle-cli/src/components/MenuComponent.vue
@@ -76,7 +76,10 @@
               <img v-if="isImageIcon(c.smallIcon || c.icon)" :src="c.smallIcon || c.icon" class="section-item-icon" :alt="c.name" />
               <i v-else :class="['section-item-icon', c.smallIcon || c.icon]"></i>
             </template>
-            <span class="section-item-text">{{ c.name }}</span>
+            <span class="section-item-text">
+              {{ c.name }}
+              <span class="section-item-text-count" v-if="c.count >= 0">x {{ c.count }}</span>
+            </span>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- show the number of posts in each category alongside the category name in the menu

## Testing
- `npm --prefix open-isle-cli install`
- `npm --prefix open-isle-cli run lint`
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688b2c6c986c8327ac73f2f7827d7172