### PR TITLE
Enable presigned URL uploads

### DIFF
--- a/open-isle-cli/src/utils/vditor.js
+++ b/open-isle-cli/src/utils/vditor.js
@@ -162,27 +162,6 @@ export function createVditor(editorId, options = {}) {
     input,
     after
   })
-  const container = document.getElementById(editorId)
-  if (container) {
-    container.addEventListener('paste', async (e) => {
-      const items = e.clipboardData && e.clipboardData.items
-      if (!items) return
-      const files = []
-      for (let i = 0; i < items.length; i++) {
-        const item = items[i]
-        if (item.kind === 'file') {
-          const file = item.getAsFile()
-          if (file) files.push(file)
-        }
-      }
-      if (files.length > 0) {
-        e.preventDefault()
-        const err = await vditor.options.upload.handler(files)
-        if (typeof err === 'string') {
-          vditor.tip(err)
-        }
-      }
-    })
-  }
+
   return vditor
 }

--- a/open-isle-cli/src/utils/vditor.js
+++ b/open-isle-cli/src/utils/vditor.js
@@ -81,7 +81,7 @@ export function createVditor(editorId, options = {}) {
       multiple: false,
       handler: async (files) => {
         const file = files[0]
-        vditor.tip.show('图片上传中', 0)
+        vditor.tip('图片上传中', 0)
         vditor.disabled()
         const res = await fetch(
           `${API_BASE_URL}/api/upload/presign?filename=${encodeURIComponent(file.name)}`,
@@ -89,14 +89,14 @@ export function createVditor(editorId, options = {}) {
         )
         if (!res.ok) {
           vditor.enable()
-          vditor.tip.hide()
+          vditor.tip('获取上传地址失败')
           return '获取上传地址失败'
         }
         const info = await res.json()
         const put = await fetch(info.uploadUrl, { method: 'PUT', body: file })
         if (!put.ok) {
           vditor.enable()
-          vditor.tip.hide()
+          vditor.tip('上传失败')
           return '上传失败'
         }
 
@@ -127,7 +127,7 @@ export function createVditor(editorId, options = {}) {
         }
         vditor.insertValue(md + '\n')
         vditor.enable()
-        vditor.tip.hide()
+        vditor.tip('上传成功')
         return null
       }
     },

--- a/open-isle-cli/src/utils/vditor.js
+++ b/open-isle-cli/src/utils/vditor.js
@@ -162,32 +162,27 @@ export function createVditor(editorId, options = {}) {
     input,
     after
   })
-  const pasteHandler = async (e) => {
-    const items = e.clipboardData && e.clipboardData.items
-    if (!items) return
-    const files = []
-    for (let i = 0; i < items.length; i++) {
-      const item = items[i]
-      if (item.kind === 'file') {
-        const file = item.getAsFile()
-        if (file) files.push(file)
+  const container = document.getElementById(editorId)
+  if (container) {
+    container.addEventListener('paste', async (e) => {
+      const items = e.clipboardData && e.clipboardData.items
+      if (!items) return
+      const files = []
+      for (let i = 0; i < items.length; i++) {
+        const item = items[i]
+        if (item.kind === 'file') {
+          const file = item.getAsFile()
+          if (file) files.push(file)
+        }
       }
-    }
-    if (files.length > 0) {
-      e.preventDefault()
-      const err = await vditor.options.upload.handler(files)
-      if (typeof err === 'string') {
-        vditor.tip(err)
+      if (files.length > 0) {
+        e.preventDefault()
+        const err = await vditor.options.upload.handler(files)
+        if (typeof err === 'string') {
+          vditor.tip(err)
+        }
       }
-    }
+    })
   }
-
-  const elements = []
-  if (vditor.wysiwyg) elements.push(vditor.wysiwyg.element)
-  if (vditor.ir) elements.push(vditor.ir.element)
-  if (vditor.sv) elements.push(vditor.sv.element)
-  elements.forEach(el => {
-    el.addEventListener('paste', pasteHandler)
-  })
   return vditor
 }

--- a/open-isle-cli/src/utils/vditor.js
+++ b/open-isle-cli/src/utils/vditor.js
@@ -94,6 +94,32 @@ export function createVditor(editorId, options = {}) {
         })
       }
     },
+    // upload: {
+    //   fieldName: 'file',
+    //   url: `${API_BASE_URL}/api/upload`,
+    //   accept: 'image/*,video/*',
+    //   multiple: false,
+    //   headers: { Authorization: `Bearer ${getToken()}` },
+    //   format(files, responseText) {
+    //     const res = JSON.parse(responseText)
+    //     if (res.code === 0) {
+    //       return JSON.stringify({
+    //         code: 0,
+    //         msg: '',
+    //         data: {
+    //           errFiles: [],
+    //           succMap: { [files[0].name]: res.data.url }
+    //         }
+    //       })
+    //     } else {
+    //       return JSON.stringify({
+    //         code: 1,
+    //         msg: '上传失败',
+    //         data: { errFiles: files.map(f => f.name), succMap: {} }
+    //       })
+    //     }
+    //   }
+    // },
     toolbarConfig: { pin: true },
     cache: { enable: false },
     input,

--- a/src/main/java/com/openisle/controller/UploadController.java
+++ b/src/main/java/com/openisle/controller/UploadController.java
@@ -74,4 +74,9 @@ public class UploadController {
             return ResponseEntity.internalServerError().body(Map.of("code", 3, "msg", "Upload failed"));
         }
     }
+
+    @GetMapping("/presign")
+    public java.util.Map<String, String> presign(@RequestParam("filename") String filename) {
+        return imageUploader.presignUpload(filename);
+    }
 }

--- a/src/main/java/com/openisle/service/ImageUploader.java
+++ b/src/main/java/com/openisle/service/ImageUploader.java
@@ -38,6 +38,14 @@ public abstract class ImageUploader {
 
     protected abstract void deleteFromStore(String key);
 
+    /**
+     * Generate a presigned PUT URL for direct browser upload.
+     * Default implementation is unsupported.
+     */
+    public java.util.Map<String, String> presignUpload(String filename) {
+        throw new UnsupportedOperationException("presignUpload not supported");
+    }
+
     /** Extract COS URLs from text. */
     public Set<String> extractUrls(String text) {
         Set<String> set = new HashSet<>();


### PR DESCRIPTION
## Summary
- expose an API to generate COS presigned URLs
- add presign logic to COS uploader implementation
- support presign upload requests in the upload controller
- switch the editor upload utility to use the new presign endpoint

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688b718d9ef883278b63d85c87995e64