### PR TITLE
Fix paste upload in custom Vditor handler

### DIFF
--- a/open-isle-cli/src/utils/vditor.js
+++ b/open-isle-cli/src/utils/vditor.js
@@ -81,17 +81,42 @@ export function createVditor(editorId, options = {}) {
       multiple: false,
       handler: async (files) => {
         const file = files[0]
-        const res = await fetch(`${API_BASE_URL}/api/upload/presign?filename=${encodeURIComponent(file.name)}`, {
-          headers: { Authorization: `Bearer ${getToken()}` }
-        })
-        if (!res.ok) return '获取上传地址失败'
+        vditor.tip.show('图片上传中', 0)
+        vditor.disabled()
+        const res = await fetch(
+          `${API_BASE_URL}/api/upload/presign?filename=${encodeURIComponent(file.name)}`,
+          { headers: { Authorization: `Bearer ${getToken()}` } }
+        )
+        if (!res.ok) {
+          vditor.enable()
+          vditor.tip.hide()
+          return '获取上传地址失败'
+        }
         const info = await res.json()
         const put = await fetch(info.uploadUrl, { method: 'PUT', body: file })
-        if (!put.ok) return '上传失败'
+        if (!put.ok) {
+          vditor.enable()
+          vditor.tip.hide()
+          return '上传失败'
+        }
 
         const ext = file.name.split('.').pop().toLowerCase()
-        const imageExts = ['apng','bmp','gif','ico','cur','jpg','jpeg','jfif','pjp','pjpeg','png','svg','webp']
-        const audioExts = ['wav','mp3','ogg']
+        const imageExts = [
+          'apng',
+          'bmp',
+          'gif',
+          'ico',
+          'cur',
+          'jpg',
+          'jpeg',
+          'jfif',
+          'pjp',
+          'pjpeg',
+          'png',
+          'svg',
+          'webp'
+        ]
+        const audioExts = ['wav', 'mp3', 'ogg']
         let md
         if (imageExts.includes(ext)) {
           md = `![${file.name}](${info.fileUrl})`
@@ -101,6 +126,8 @@ export function createVditor(editorId, options = {}) {
           md = `[${file.name}](${info.fileUrl})`
         }
         vditor.insertValue(md + '\n')
+        vditor.enable()
+        vditor.tip.hide()
         return null
       }
     },


### PR DESCRIPTION
## Summary
- improve custom upload handler to show tip and disable editor

## Testing
- `npm run lint`
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.1.1)*

------
https://chatgpt.com/codex/tasks/task_e_688b9d989f908327965b3ed46efaff5f