### PR TITLE
Fix paste image upload in Vditor

### DIFF
--- a/open-isle-cli/src/utils/vditor.js
+++ b/open-isle-cli/src/utils/vditor.js
@@ -162,5 +162,27 @@ export function createVditor(editorId, options = {}) {
     input,
     after
   })
+  const container = document.getElementById(editorId)
+  if (container) {
+    container.addEventListener('paste', async (e) => {
+      const items = e.clipboardData && e.clipboardData.items
+      if (!items) return
+      const files = []
+      for (let i = 0; i < items.length; i++) {
+        const item = items[i]
+        if (item.kind === 'file') {
+          const file = item.getAsFile()
+          if (file) files.push(file)
+        }
+      }
+      if (files.length > 0) {
+        e.preventDefault()
+        const err = await vditor.options.upload.handler(files)
+        if (typeof err === 'string') {
+          vditor.tip(err)
+        }
+      }
+    })
+  }
   return vditor
 }


### PR DESCRIPTION
## Summary
- handle paste events manually so Command+V uploads images

## Testing
- `npm run lint --silent`
- `CI=true npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_e_688ba01cb2308327acbb83d53318cf71