### PR TITLE
Implement menu caching

### DIFF
--- a/open-isle-cli/src/components/MenuComponent.vue
+++ b/open-isle-cli/src/components/MenuComponent.vue
@@ -172,33 +172,61 @@ export default {
       await updateCount()
     })
 
-    try {
-      this.isLoadingCategory = true
-      fetch(`${API_BASE_URL}/api/categories`).then(
-        res => {
-          if (res.ok) {
-            res.json().then(data => {
-              this.categories = data.slice(0, 10)
-            })
-          }
-          this.isLoadingCategory = false
-        }
-      )
-    } catch { /* ignore */ }
+    const CAT_CACHE_KEY = 'menu-categories'
+    const TAG_CACHE_KEY = 'menu-tags'
 
-    try {
-      this.isLoadingTag = true
-      fetch(`${API_BASE_URL}/api/tags?limit=10`).then(
-        res => {
-          if (res.ok) {
-            res.json().then(data => {
-              this.tags = data
-            })
-          }
-          this.isLoadingTag = false
+    const cachedCategories = localStorage.getItem(CAT_CACHE_KEY)
+    if (cachedCategories) {
+      try {
+        this.categories = JSON.parse(cachedCategories)
+      } catch { /* ignore */ }
+    }
+
+    const cachedTags = localStorage.getItem(TAG_CACHE_KEY)
+    if (cachedTags) {
+      try {
+        this.tags = JSON.parse(cachedTags)
+      } catch { /* ignore */ }
+    }
+
+    const fetchCategories = () => {
+      fetch(`${API_BASE_URL}/api/categories`).then(res => {
+        if (res.ok) {
+          res.json().then(data => {
+            this.categories = data.slice(0, 10)
+            localStorage.setItem(CAT_CACHE_KEY, JSON.stringify(this.categories))
+          })
         }
-      )
-    } catch { /* ignore */ }
+        this.isLoadingCategory = false
+      })
+    }
+
+    const fetchTags = () => {
+      fetch(`${API_BASE_URL}/api/tags?limit=10`).then(res => {
+        if (res.ok) {
+          res.json().then(data => {
+            this.tags = data
+            localStorage.setItem(TAG_CACHE_KEY, JSON.stringify(this.tags))
+          })
+        }
+        this.isLoadingTag = false
+      })
+    }
+
+    this.isLoadingCategory = !cachedCategories
+    this.isLoadingTag = !cachedTags
+
+    if (cachedCategories) {
+      setTimeout(fetchCategories, 1500)
+    } else {
+      fetchCategories()
+    }
+
+    if (cachedTags) {
+      setTimeout(fetchTags, 1500)
+    } else {
+      fetchTags()
+    }
   },
   methods: {
     cycleTheme,

--- a/open-isle-cli/src/components/MenuComponent.vue
+++ b/open-isle-cli/src/components/MenuComponent.vue
@@ -167,7 +167,7 @@ export default {
         notificationState.unreadCount = 0
       }
     }
-    await updateCount()
+    
     watch(() => authState.loggedIn, async () => {
       await updateCount()
     })
@@ -188,6 +188,9 @@ export default {
         this.tags = JSON.parse(cachedTags)
       } catch { /* ignore */ }
     }
+
+    this.isLoadingCategory = !cachedCategories
+    this.isLoadingTag = !cachedTags
 
     const fetchCategories = () => {
       fetch(`${API_BASE_URL}/api/categories`).then(res => {
@@ -213,9 +216,6 @@ export default {
       })
     }
 
-    this.isLoadingCategory = !cachedCategories
-    this.isLoadingTag = !cachedTags
-
     if (cachedCategories) {
       setTimeout(fetchCategories, 1500)
     } else {
@@ -227,6 +227,8 @@ export default {
     } else {
       fetchTags()
     }
+
+    await updateCount()
   },
   methods: {
     cycleTheme,


### PR DESCRIPTION
## Summary
- cache menu categories and tags in localStorage
- avoid loading spinners if cache exists
- refresh cached data asynchronously after a short delay

## Testing
- `npm run lint`
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688c2fa122a88327a3281a06dd53a406