### PR TITLE
Implement deduplication for post view notifications

### DIFF
--- a/src/main/java/com/openisle/repository/NotificationRepository.java
+++ b/src/main/java/com/openisle/repository/NotificationRepository.java
@@ -18,4 +18,6 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     List<Notification> findByComment(Comment comment);
 
     void deleteByTypeAndFromUser(NotificationType type, User fromUser);
+
+    void deleteByUserAndTypeAndPostAndFromUser(User user, NotificationType type, Post post, User fromUser);
 }

--- a/src/main/java/com/openisle/service/NotificationService.java
+++ b/src/main/java/com/openisle/service/NotificationService.java
@@ -58,6 +58,9 @@ public class NotificationService {
 
     public Notification createNotification(User user, NotificationType type, Post post, Comment comment, Boolean approved,
                                            User fromUser, ReactionType reactionType, String content) {
+        if (type == NotificationType.POST_VIEWED && post != null) {
+            notificationRepository.deleteByUserAndTypeAndPostAndFromUser(user, type, post, fromUser);
+        }
         Notification n = new Notification();
         n.setUser(user);
         n.setType(type);

--- a/src/test/java/com/openisle/service/NotificationServiceTest.java
+++ b/src/test/java/com/openisle/service/NotificationServiceTest.java
@@ -168,4 +168,29 @@ class NotificationServiceTest {
         verify(email).sendEmail("a@a.com", "有人回复了你", "https://ex.com/posts/1#comment-2");
         verify(push).sendNotification(eq(user), contains("/posts/1#comment-2"));
     }
+
+    @Test
+    void postViewedDeletesOldNotification() {
+        NotificationRepository nRepo = mock(NotificationRepository.class);
+        UserRepository uRepo = mock(UserRepository.class);
+        ReactionRepository rRepo = mock(ReactionRepository.class);
+        EmailSender email = mock(EmailSender.class);
+        PushNotificationService push = mock(PushNotificationService.class);
+        Executor executor = Runnable::run;
+        NotificationService service = new NotificationService(nRepo, uRepo, email, push, rRepo, executor);
+
+        User author = new User();
+        author.setId(1L);
+        User viewer = new User();
+        viewer.setId(2L);
+        Post post = new Post();
+        post.setId(3L);
+
+        when(nRepo.save(any(Notification.class))).thenAnswer(i -> i.getArgument(0));
+
+        service.createNotification(author, NotificationType.POST_VIEWED, post, null, null, viewer, null, null);
+
+        verify(nRepo).deleteByUserAndTypeAndPostAndFromUser(author, NotificationType.POST_VIEWED, post, viewer);
+        verify(nRepo).save(any(Notification.class));
+    }
 }


### PR DESCRIPTION
## Summary
- deduplicate POST_VIEWED notifications so only the latest remains per post
- add repository method to delete existing POST_VIEWED notifications
- test that POST_VIEWED deduplication deletes old notifications

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688c37c2db288327ae57d402c1619600