### PR TITLE
Expand first-level comments by default

### DIFF
--- a/open-isle-cli/src/views/PostPageView.vue
+++ b/open-isle-cli/src/views/PostPageView.vue
@@ -216,15 +216,15 @@ export default {
       }
     }
 
-    const mapComment = c => ({
+    const mapComment = (c, level = 0) => ({
       id: c.id,
       userName: c.author.username,
       time: TimeManager.format(c.createdAt),
       avatar: c.author.avatar,
       text: c.content,
       reactions: c.reactions || [],
-      reply: (c.replies || []).map(mapComment),
-      openReplies: false,
+      reply: (c.replies || []).map(r => mapComment(r, level + 1)),
+      openReplies: level === 0,
       src: c.author.avatar,
       iconClick: () => router.push(`/users/${c.author.id}`)
     })


### PR DESCRIPTION
## Summary
- open replies for top-level comments so they show by default

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688c3c80fcd08327a5606c2680c464cb