### PR TITLE
fix comment replies expansion

### DIFF
--- a/open-isle-cli/src/components/CommentItem.vue
+++ b/open-isle-cli/src/components/CommentItem.vue
@@ -97,11 +97,11 @@ const CommentItem = {
   },
   setup(props, { emit }) {
     const router = useRouter()
-    const showReplies = ref(props.defaultShowReplies)
+    const showReplies = ref(props.level === 0 ? true : props.defaultShowReplies)
     watch(
       () => props.defaultShowReplies,
       (val) => {
-        showReplies.value = val
+        showReplies.value = props.level === 0 ? true : val
       }
     )
     const showEditor = ref(false)


### PR DESCRIPTION
## Summary
- ensure replies under each top-level comment are expanded by default

## Testing
- `npm run lint` in `open-isle-cli`
- `npm run build` in `open-isle-cli`
- `mvn -q test` *(fails: could not resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688c43b6e0bc8327ba424a67bf42bb98