### PR TITLE
Adjust message for mark-all-read

### DIFF
--- a/open-isle-cli/src/views/MessagePageView.vue
+++ b/open-isle-cli/src/views/MessagePageView.vue
@@ -333,7 +333,11 @@ export default {
           if (n.type !== 'REGISTER_REQUEST') n.read = true
         })
         await fetchUnreadCount()
-        toast.success('已读所有消息（注册请求除外）')
+        if (authState.role === 'ADMIN') {
+          toast.success('已读所有消息（注册请求除外）')
+        } else {
+          toast.success('已读所有消息')
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- show the full "已读所有消息（注册请求除外）" toast only to admins
- regular members see a simpler toast when marking all notifications as read

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688c440b7cf8832791aeef16c9c2e7da