### PR TITLE
feat: count nested replies in post lists and comments

### DIFF
--- a/open-isle-cli/src/components/CommentItem.vue
+++ b/open-isle-cli/src/components/CommentItem.vue
@@ -35,10 +35,10 @@
       <div class="comment-editor-wrapper">
         <CommentEditor v-if="showEditor" @submit="submitReply" :loading="isWaitingForReply" :disabled="!loggedIn" :show-login-overlay="!loggedIn" />
       </div>
-      <div v-if="comment.reply && comment.reply.length" class="reply-toggle" @click="toggleReplies">
+      <div v-if="replyCount" class="reply-toggle" @click="toggleReplies">
         <i v-if="showReplies" class="fas fa-chevron-up reply-toggle-icon"></i>
         <i v-else class="fas fa-chevron-down reply-toggle-icon"></i>
-        {{ comment.reply.length }}条回复
+        {{ replyCount }}条回复
       </div>
       <div v-if="showReplies" class="reply-list">
         <BaseTimeline :items="comment.reply">
@@ -110,6 +110,8 @@ const CommentItem = {
     const lightboxIndex = ref(0)
     const lightboxImgs = ref([])
     const loggedIn = computed(() => authState.loggedIn)
+    const countReplies = (list) => list.reduce((sum, r) => sum + 1 + countReplies(r.reply || []), 0)
+    const replyCount = computed(() => countReplies(props.comment.reply || []))
     const toggleReplies = () => {
       showReplies.value = !showReplies.value
     }
@@ -206,7 +208,7 @@ const CommentItem = {
         lightboxVisible.value = true
       }
     }
-    return { showReplies, toggleReplies, showEditor, toggleEditor, submitReply, copyCommentLink, renderMarkdown, isWaitingForReply, commentMenuItems, deleteComment, lightboxVisible, lightboxIndex, lightboxImgs, handleContentClick, loggedIn }
+    return { showReplies, toggleReplies, showEditor, toggleEditor, submitReply, copyCommentLink, renderMarkdown, isWaitingForReply, commentMenuItems, deleteComment, lightboxVisible, lightboxIndex, lightboxImgs, handleContentClick, loggedIn, replyCount }
   }
 }
 

--- a/open-isle-cli/src/views/HomePageView.vue
+++ b/open-isle-cli/src/views/HomePageView.vue
@@ -165,6 +165,9 @@ export default {
     const pageSize = 10
     const allLoaded = ref(false)
 
+    const countComments = (list) =>
+      list.reduce((sum, c) => sum + 1 + countComments(c.replies || []), 0)
+
     const loadOptions = async () => {
       if (selectedCategory.value && !isNaN(selectedCategory.value)) {
         try {
@@ -254,7 +257,7 @@ export default {
             category: p.category,
             tags: p.tags || [],
             members: (p.participants || []).map(m => ({ id: m.id, avatar: m.avatar })),
-            comments: (p.comments || []).length,
+            comments: countComments(p.comments || []),
             views: p.views,
             time: TimeManager.format(p.createdAt),
             pinned: !!p.pinnedAt
@@ -291,7 +294,7 @@ export default {
             category: p.category,
             tags: p.tags || [],
             members: (p.participants || []).map(m => ({ id: m.id, avatar: m.avatar })),
-            comments: (p.comments || []).length,
+            comments: countComments(p.comments || []),
             views: p.views,
             time: TimeManager.format(p.createdAt),
             pinned: !!p.pinnedAt
@@ -328,7 +331,7 @@ export default {
             category: p.category,
             tags: p.tags || [],
             members: (p.participants || []).map(m => ({ id: m.id, avatar: m.avatar })),
-            comments: (p.comments || []).length,
+            comments: countComments(p.comments || []),
             views: p.views,
             time: TimeManager.format(p.lastReplyAt || p.createdAt),
             pinned: !!p.pinnedAt


### PR DESCRIPTION
## Summary
- display nested reply counts for comments using a computed total
- show total comment counts on post listings by summing nested replies

## Testing
- `npm --prefix open-isle-cli test` *(fails: Missing script "test")*
- `npm --prefix open-isle-cli run lint`
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688e458709a883278d958ceeeabef98b