### PR TITLE
feat: add new reaction types

### DIFF
--- a/backend/src/main/java/com/openisle/model/ReactionType.java
+++ b/backend/src/main/java/com/openisle/model/ReactionType.java
@@ -15,5 +15,16 @@ public enum ReactionType {
     MIND_BLOWN,
     POOP,
     CLOWN,
-    SKULL
+    SKULL,
+    FIRE,
+    EYES,
+    FROWN,
+    HOT,
+    EAGLE,
+    SPIDER,
+    BAT,
+    CHINA,
+    USA,
+    JAPAN,
+    KOREA
 }

--- a/frontend/src/components/ReactionsGroup.vue
+++ b/frontend/src/components/ReactionsGroup.vue
@@ -66,7 +66,18 @@ const iconMap = {
   MIND_BLOWN: '🤯',
   POOP: '💩',
   CLOWN: '🤡',
-  SKULL: '☠️'
+  SKULL: '☠️',
+  FIRE: '🔥',
+  EYES: '👀',
+  FROWN: '☹️',
+  HOT: '🥵',
+  EAGLE: '🦅',
+  SPIDER: '🕷️',
+  BAT: '🦇',
+  CHINA: '🇨🇳',
+  USA: '🇺🇸',
+  JAPAN: '🇯🇵',
+  KOREA: '🇰🇷'
 }
 
 export default {

--- a/frontend/src/views/MessagePageView.vue
+++ b/frontend/src/views/MessagePageView.vue
@@ -370,7 +370,18 @@ export default {
       MIND_BLOWN: '🤯',
       POOP: '💩',
       CLOWN: '🤡',
-      SKULL: '☠️'
+      SKULL: '☠️',
+      FIRE: '🔥',
+      EYES: '👀',
+      FROWN: '☹️',
+      HOT: '🥵',
+      EAGLE: '🦅',
+      SPIDER: '🕷️',
+      BAT: '🦇',
+      CHINA: '🇨🇳',
+      USA: '🇺🇸',
+      JAPAN: '🇯🇵',
+      KOREA: '🇰🇷'
     }
 
     const fetchNotifications = async () => {


### PR DESCRIPTION
## Summary
- extend `ReactionType` enum with emojis like fire, eyes, hot face, and country flags
- map new reaction types to emojis in `ReactionsGroup` and notifications

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f0e02695483278e65da359c910fc4