### PR TITLE
chore: clear stale vditor caches

### DIFF
--- a/frontend/src/components/CommentEditor.vue
+++ b/frontend/src/components/CommentEditor.vue
@@ -18,7 +18,7 @@
 </template>
 
 <script>
-import { ref, onMounted, computed, watch } from 'vue'
+import { ref, onMounted, computed, watch, onUnmounted } from 'vue'
 import { themeState } from '../utils/theme'
 import {
   createVditor,
@@ -26,6 +26,7 @@ import {
   getPreviewTheme as getPreviewThemeUtil
 } from '../utils/vditor'
 import LoginOverlay from './LoginOverlay.vue'
+import { clearVditorStorage } from '../utils/clearVditorStorage'
 
 export default {
   name: 'CommentEditor',
@@ -88,6 +89,10 @@ export default {
         }
       })
       // applyTheme()
+    })
+
+    onUnmounted(() => {
+      clearVditorStorage()
     })
 
     watch(

--- a/frontend/src/components/PostEditor.vue
+++ b/frontend/src/components/PostEditor.vue
@@ -8,13 +8,14 @@
 </template>
 
 <script>
-import { ref, onMounted, watch } from 'vue'
+import { ref, onMounted, watch, onUnmounted } from 'vue'
 import { themeState } from '../utils/theme'
 import {
   createVditor,
   getEditorTheme as getEditorThemeUtil,
   getPreviewTheme as getPreviewThemeUtil
 } from '../utils/vditor'
+import { clearVditorStorage } from '../utils/clearVditorStorage'
 import { hatch } from 'ldrs'
 hatch.register()
 
@@ -104,6 +105,10 @@ export default {
         }
       })
       // applyTheme()
+    })
+
+    onUnmounted(() => {
+      clearVditorStorage()
     })
 
     return {}

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -11,6 +11,7 @@ import { useToast } from 'vue-toastification'
 import { checkToken, clearToken, isLogin } from './utils/auth'
 import { initTheme } from './utils/theme'
 import { loginWithGoogle } from './utils/google'
+import { clearVditorStorage } from './utils/clearVditorStorage'
 
 // Configurable API domain and port
 // export const API_DOMAIN = 'http://127.0.0.1'
@@ -28,6 +29,7 @@ export const TWITTER_CLIENT_ID = 'ZTRTU05KSk9KTTJrTTdrVC1tc1E6MTpjaQ'
 export const toast = useToast()
 
 initTheme()
+clearVditorStorage()
 
 const app = createApp(App)
 app.use(router)

--- a/frontend/src/utils/clearVditorStorage.js
+++ b/frontend/src/utils/clearVditorStorage.js
@@ -1,0 +1,7 @@
+export function clearVditorStorage() {
+  Object.keys(localStorage).forEach(key => {
+    if (key.startsWith('vditoreditor-') || key === 'vditor') {
+      localStorage.removeItem(key)
+    }
+  })
+}


### PR DESCRIPTION
## Summary
- purge stale `vditor` localStorage entries on startup
- remove `vditor` caches when editors unmount

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f222d159483278ec8f6974977dc57