### PR TITLE
feat: add popup Google login

### DIFF
--- a/frontend/src/utils/google.js
+++ b/frontend/src/utils/google.js
@@ -65,3 +65,16 @@ export function loginWithGoogle() {
     }
   )
 }
+
+export function loginWithGoogleWithNewWindow() {
+  const width = 500
+  const height = 600
+  const left = (window.screen.width - width) / 2
+  const top = (window.screen.height - height) / 2
+  const url = `${window.location.origin}/login?popup=1`
+  window.open(
+    url,
+    'GoogleLoginWindow',
+    `width=${width},height=${height},left=${left},top=${top}`
+  )
+}

--- a/frontend/src/views/LoginPageView.vue
+++ b/frontend/src/views/LoginPageView.vue
@@ -31,7 +31,7 @@
     </div>
 
     <div class="other-login-page-content">
-      <div class="login-page-button" @click="loginWithGoogle">
+      <div class="login-page-button" @click="loginWithGoogleWithNewWindow">
         <img class="login-page-button-icon" src="../assets/icons/google.svg" alt="Google Logo" />
         <div class="login-page-button-text">Google 登录</div>
       </div>
@@ -54,18 +54,39 @@
 <script>
 import { API_BASE_URL, toast } from '../main'
 import { setToken, loadCurrentUser } from '../utils/auth'
-import { loginWithGoogle } from '../utils/google'
+import { loginWithGoogleWithNewWindow, googleSignIn } from '../utils/google'
 import { githubAuthorize } from '../utils/github'
 import { discordAuthorize } from '../utils/discord'
 import { twitterAuthorize } from '../utils/twitter'
 import BaseInput from '../components/BaseInput.vue'
 import { registerPush } from '../utils/push'
+import { useRoute } from 'vue-router'
+import { onMounted } from 'vue'
 export default {
   name: 'LoginPageView',
   components: { BaseInput },
   setup() {
-    return { loginWithGoogle }
-  }, 
+    const route = useRoute()
+    onMounted(() => {
+      if (route.query.popup === '1') {
+        googleSignIn(
+          () => {
+            if (window.opener) {
+              window.opener.location.reload()
+            }
+            window.close()
+          },
+          token => {
+            if (window.opener) {
+              window.opener.location.href = '/signup-reason?token=' + token
+            }
+            window.close()
+          }
+        )
+      }
+    })
+    return { loginWithGoogleWithNewWindow }
+  },
   data() {
     return {
       username: '',

--- a/frontend/src/views/SignupPageView.vue
+++ b/frontend/src/views/SignupPageView.vue
@@ -67,7 +67,7 @@
     </div>
 
     <div class="other-signup-page-content">
-      <div class="signup-page-button" @click="loginWithGoogle">
+      <div class="signup-page-button" @click="loginWithGoogleWithNewWindow">
         <img class="signup-page-button-icon" src="../assets/icons/google.svg" alt="Google Logo" />
         <div class="signup-page-button-text">Google 注册</div>
       </div>
@@ -89,7 +89,7 @@
 
 <script>
 import { API_BASE_URL, toast } from '../main'
-import { loginWithGoogle } from '../utils/google'
+import { loginWithGoogleWithNewWindow } from '../utils/google'
 import { githubAuthorize } from '../utils/github'
 import { discordAuthorize } from '../utils/discord'
 import { twitterAuthorize } from '../utils/twitter'
@@ -98,7 +98,7 @@ export default {
   name: 'SignupPageView',
   components: { BaseInput },
   setup() {
-    return { loginWithGoogle }
+    return { loginWithGoogleWithNewWindow }
   },
   data() {
     return {


### PR DESCRIPTION
## Summary
- support Google sign-in via popup window
- switch login and signup buttons to use popup Google login

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f514bfebc832789170872ccb16947