### PR TITLE
修复收到的点赞计数错误问题

### DIFF
--- a/backend/src/main/java/com/openisle/repository/ReactionRepository.java
+++ b/backend/src/main/java/com/openisle/repository/ReactionRepository.java
@@ -31,12 +31,17 @@ public interface ReactionRepository extends JpaRepository<Reaction, Long> {
     long countByUserAfter(@Param("username") String username, @Param("start") java.time.LocalDateTime start);
 
     @Query("""
-            SELECT COUNT(r) FROM Reaction r
-            LEFT JOIN r.post p
+            SELECT COUNT(DISTINCT r.id)
+            FROM Reaction r
+            LEFT JOIN r.post    p
+            LEFT JOIN p.author  pa
             LEFT JOIN r.comment c
-            WHERE r.type = com.openisle.model.ReactionType.LIKE AND
-                  ((p IS NOT NULL AND p.author.username = :username) OR
-                   (c IS NOT NULL AND c.author.username = :username))
+            LEFT JOIN c.author  ca
+            WHERE r.type = com.openisle.model.ReactionType.LIKE
+              AND (
+                   (r.post    IS NOT NULL AND pa.username = :username)
+                OR (r.comment IS NOT NULL AND ca.username = :username)
+              )
             """)
     long countLikesReceived(@Param("username") String username);
 


### PR DESCRIPTION
主要的问题出在
```    
@Query("""
            SELECT COUNT(r) FROM Reaction r
            LEFT JOIN r.post p
            LEFT JOIN r.comment c
            WHERE r.type = com.openisle.model.ReactionType.LIKE AND
                  ((p IS NOT NULL AND p.author.username = :username) OR
                   (c IS NOT NULL AND c.author.username = :username))
            """)
long countLikesReceived(@Param("username") String username);
```
JPA 展开后变成
```
LEFT JOIN posts p        ON p.id = r.post_id
JOIN users pa            ON pa.id = p.author_id          -- 这里是 INNER JOIN
LEFT JOIN comments c     ON c.id = r.comment_id
JOIN users ca            ON ca.id = c.author_id          -- 这里是 INNER JOIN
WHERE r.type='LIKE'
  AND ((r.post_id IS NOT NULL AND pa.username=?)
    OR (r.comment_id IS NOT NULL AND ca.username=?))
```

导致最后结果为0

现已改成
```
SELECT COUNT(DISTINCT r.id)
FROM Reaction r
LEFT JOIN r.post    p
LEFT JOIN p.author  pa
LEFT JOIN r.comment c
LEFT JOIN c.author  ca
WHERE r.type = com.openisle.model.ReactionType.LIKE
    AND (
    (r.post    IS NOT NULL AND pa.username = :username)
    OR (r.comment IS NOT NULL AND ca.username = :username)
)
```

使之强行变成 LEFT JOIN 而非默认展开的 INNER JOIN

参考 [mysql使用left join where右表条件无效，变成inner join 或 单表查询效果
](https://blog.csdn.net/github_39325328/article/details/88668888)