### PR TITLE
refactor: reuse callback page component

### DIFF
--- a/frontend/src/components/CallbackPage.vue
+++ b/frontend/src/components/CallbackPage.vue
@@ -1,0 +1,35 @@
+<template>
+  <div class="callback-page">
+    <l-hatch size="28" stroke="4" speed="3.5" color="var(--primary-color)"></l-hatch>
+    <div class="callback-page-text">Magic is happening...</div>
+  </div>
+</template>
+
+<script>
+import { hatch } from 'ldrs'
+
+hatch.register()
+
+export default {
+  name: 'CallbackPage'
+}
+</script>
+
+<style scoped>
+.callback-page {
+  background-color: var(--background-color);
+  height: calc(100vh - var(--header-height));
+  padding-top: var(--header-height);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.callback-page-text {
+  margin-top: 25px;
+  font-size: 16px;
+  color: var(--primary-color);
+  font-weight: bold;
+}
+</style>

--- a/frontend/src/views/DiscordCallbackPageView.vue
+++ b/frontend/src/views/DiscordCallbackPageView.vue
@@ -1,18 +1,14 @@
 <template>
-  <div class="discord-callback-page">
-    <l-hatch size="28" stroke="4" speed="3.5" color="var(--primary-color)"></l-hatch>
-    <div class="discord-callback-page-text">Magic is happening...</div>
-  </div>
+  <CallbackPage />
 </template>
 
 <script>
+import CallbackPage from '../components/CallbackPage.vue'
 import { discordExchange } from '../utils/discord'
-import { hatch } from 'ldrs'
-
-hatch.register()
 
 export default {
   name: 'DiscordCallbackPageView',
+  components: { CallbackPage },
   async mounted() {
     const url = new URL(window.location.href)
     const code = url.searchParams.get('code')
@@ -28,21 +24,3 @@ export default {
 }
 </script>
 
-<style scoped>
-.discord-callback-page {
-  background-color: var(--background-color);
-  height: calc(100vh - var(--header-height));
-  padding-top: var(--header-height);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-}
-
-.discord-callback-page-text {
-  margin-top: 25px;
-  font-size: 16px;
-  color: var(--primary-color);
-  font-weight: bold;
-}
-</style>

--- a/frontend/src/views/GithubCallbackPageView.vue
+++ b/frontend/src/views/GithubCallbackPageView.vue
@@ -1,18 +1,14 @@
 <template>
-  <div class="github-callback-page">
-    <l-hatch size="28" stroke="4" speed="3.5" color="var(--primary-color)"></l-hatch>
-    <div class="github-callback-page-text">Magic is happening...</div>
-  </div>
+  <CallbackPage />
 </template>
 
 <script>
+import CallbackPage from '../components/CallbackPage.vue'
 import { githubExchange } from '../utils/github'
-import { hatch } from 'ldrs'
-hatch.register()
-
 
 export default {
   name: 'GithubCallbackPageView',
+  components: { CallbackPage },
   async mounted() {
     const url = new URL(window.location.href)
     const code = url.searchParams.get('code')
@@ -28,21 +24,3 @@ export default {
 }
 </script>
 
-<style scoped>
-.github-callback-page {
-  background-color: var(--background-color);
-  height: calc(100vh - var(--header-height));
-  padding-top: var(--header-height);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-}
-
-.github-callback-page-text {
-  margin-top: 25px;
-  font-size: 16px;
-  color: var(--primary-color);
-  font-weight: bold;
-}
-</style>

--- a/frontend/src/views/GoogleCallbackPageView.vue
+++ b/frontend/src/views/GoogleCallbackPageView.vue
@@ -1,17 +1,14 @@
 <template>
-  <div class="google-callback-page">
-    <l-hatch size="28" stroke="4" speed="3.5" color="var(--primary-color)"></l-hatch>
-    <div class="google-callback-page-text">Magic is happening...</div>
-  </div>
+  <CallbackPage />
 </template>
 
 <script>
+import CallbackPage from '../components/CallbackPage.vue'
 import { googleAuthWithToken } from '../utils/google'
-import { hatch } from 'ldrs'
-hatch.register()
 
 export default {
   name: 'GoogleCallbackPageView',
+  components: { CallbackPage },
   async mounted() {
     const hash = new URLSearchParams(window.location.hash.substring(1))
     const idToken = hash.get('id_token')
@@ -28,21 +25,3 @@ export default {
 }
 </script>
 
-<style scoped>
-.google-callback-page {
-  background-color: var(--background-color);
-  height: calc(100vh - var(--header-height));
-  padding-top: var(--header-height);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-}
-
-.google-callback-page-text {
-  margin-top: 25px;
-  font-size: 16px;
-  color: var(--primary-color);
-  font-weight: bold;
-}
-</style>

--- a/frontend/src/views/TwitterCallbackPageView.vue
+++ b/frontend/src/views/TwitterCallbackPageView.vue
@@ -1,17 +1,14 @@
 <template>
-  <div class="twitter-callback-page">
-    <l-hatch size="28" stroke="4" speed="3.5" color="var(--primary-color)"></l-hatch>
-    <div class="twitter-callback-page-text">Magic is happening...</div>
-  </div>
+  <CallbackPage />
 </template>
 
 <script>
+import CallbackPage from '../components/CallbackPage.vue'
 import { twitterExchange } from '../utils/twitter'
-import { hatch } from 'ldrs'
-hatch.register()
 
 export default {
   name: 'TwitterCallbackPageView',
+  components: { CallbackPage },
   async mounted() {
     const url = new URL(window.location.href)
     const code = url.searchParams.get('code')
@@ -27,21 +24,3 @@ export default {
 }
 </script>
 
-<style scoped>
-.twitter-callback-page {
-  background-color: var(--background-color);
-  height: calc(100vh - var(--header-height));
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding-top: var(--header-height);
-}
-
-.twitter-callback-page-text {
-  margin-top: 25px;
-  font-size: 16px;
-  color: var(--primary-color);
-  font-weight: bold;
-}
-</style>


### PR DESCRIPTION
## Summary
- reuse a new `CallbackPage` component for OAuth callbacks
- simplify GitHub, Twitter, Discord, and Google callback views

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f9990d2f88327860c6f1bc3af7996