### PR TITLE
feat: enable avatar cropping before upload

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "core-js": "^3.8.3",
+        "cropperjs": "^2.0.1",
         "echarts": "^5.6.0",
         "ldrs": "^1.1.7",
         "markdown-it": "^14.1.0",
@@ -1782,6 +1783,126 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@cropper/element": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@cropper/element/-/element-2.0.1.tgz",
+      "integrity": "sha512-Jn1hR7XWzWQM/QfXRGMGzdkJ2gG/UcLdQPZQ7OKs0JiFfRzKpzu4u/nYrXHeH3MM2iOslLqh2kqYju6mjZLMJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@cropper/utils": "^2.0.1"
+      }
+    },
+    "node_modules/@cropper/element-canvas": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@cropper/element-canvas/-/element-canvas-2.0.1.tgz",
+      "integrity": "sha512-OKxq/O0HL9W2JegOsc2zh1NRpERZcLM5+M8aQ/eXdmMcfi1lzosPftag3Irp6pTsVpwV6B6ypIxKESzJ4ci9Fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@cropper/element": "^2.0.1",
+        "@cropper/utils": "^2.0.1"
+      }
+    },
+    "node_modules/@cropper/element-crosshair": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@cropper/element-crosshair/-/element-crosshair-2.0.1.tgz",
+      "integrity": "sha512-bS5msU9cTU/jf1/kDw+QJmEM9/rw8IgOdpolR85iMVUCR8sRcLa0wgom42MBHcpBYB6hvL5YfiOeXZ7lHIYMpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@cropper/element": "^2.0.1",
+        "@cropper/utils": "^2.0.1"
+      }
+    },
+    "node_modules/@cropper/element-grid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@cropper/element-grid/-/element-grid-2.0.1.tgz",
+      "integrity": "sha512-ayqCvYQJ+GVT31HhFpttzHabW1T/LsIwLJY5PLTMG0cEZLw/E8ihg8mxctjZbo852D7oEePbz6/2SeuCb1018Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@cropper/element": "^2.0.1",
+        "@cropper/utils": "^2.0.1"
+      }
+    },
+    "node_modules/@cropper/element-handle": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@cropper/element-handle/-/element-handle-2.0.1.tgz",
+      "integrity": "sha512-fdifyyPIaR9S2eQ7qPHuM8fX8uToAfBsi8vQlR9EM+oJkDNil0uO4rWyArLWEtlr0/q7U0OvsufcuJ7ffqfmpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@cropper/element": "^2.0.1",
+        "@cropper/utils": "^2.0.1"
+      }
+    },
+    "node_modules/@cropper/element-image": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@cropper/element-image/-/element-image-2.0.1.tgz",
+      "integrity": "sha512-gPj5Sl2T8Cno198Cz3F3TDfcYoALW3yJ3fV6PHXmhMnX8sBkL7J441do7Vwkg0mEd2CogCtTLAf+p7ljdV0kgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@cropper/element": "^2.0.1",
+        "@cropper/element-canvas": "^2.0.1",
+        "@cropper/utils": "^2.0.1"
+      }
+    },
+    "node_modules/@cropper/element-selection": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@cropper/element-selection/-/element-selection-2.0.1.tgz",
+      "integrity": "sha512-atv+Aeq2N2eWawelIRPGh1kYFdNrpb0QkUPPheGxz1ImfxpLdcHO9gb9T5noQijizUW2G0pNvts4ZaITQ0I71Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@cropper/element": "^2.0.1",
+        "@cropper/element-canvas": "^2.0.1",
+        "@cropper/element-image": "^2.0.1",
+        "@cropper/utils": "^2.0.1"
+      }
+    },
+    "node_modules/@cropper/element-shade": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@cropper/element-shade/-/element-shade-2.0.1.tgz",
+      "integrity": "sha512-YIYgJ690NdFQ6wJLRFh/EySNVxGFKArncQ4FrsJ3yHU+ShgtOKz4FpjFLpqJRJB9swoVbD3WKTimGyzXrwjZrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@cropper/element": "^2.0.1",
+        "@cropper/element-canvas": "^2.0.1",
+        "@cropper/element-selection": "^2.0.1",
+        "@cropper/utils": "^2.0.1"
+      }
+    },
+    "node_modules/@cropper/element-viewer": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@cropper/element-viewer/-/element-viewer-2.0.1.tgz",
+      "integrity": "sha512-HDj25l08pWi/AO6El/OqfQHBpBC4Lh5NEnQN1SOldsmxEwt27Ubv6ndDsF8LkTK7XPwjjZRpyQPyfig4w8L2JQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@cropper/element": "^2.0.1",
+        "@cropper/element-canvas": "^2.0.1",
+        "@cropper/element-image": "^2.0.1",
+        "@cropper/element-selection": "^2.0.1",
+        "@cropper/utils": "^2.0.1"
+      }
+    },
+    "node_modules/@cropper/elements": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@cropper/elements/-/elements-2.0.1.tgz",
+      "integrity": "sha512-paFbBLXTKXNngn1yDi2ZIf+FO1pIEQXyBntmqOjuxqtG73KuEKv633wsJPFpj958bgcfSakgBbF80j+3nHbPug==",
+      "license": "MIT",
+      "dependencies": {
+        "@cropper/element": "^2.0.1",
+        "@cropper/element-canvas": "^2.0.1",
+        "@cropper/element-crosshair": "^2.0.1",
+        "@cropper/element-grid": "^2.0.1",
+        "@cropper/element-handle": "^2.0.1",
+        "@cropper/element-image": "^2.0.1",
+        "@cropper/element-selection": "^2.0.1",
+        "@cropper/element-shade": "^2.0.1",
+        "@cropper/element-viewer": "^2.0.1"
+      }
+    },
+    "node_modules/@cropper/utils": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@cropper/utils/-/utils-2.0.1.tgz",
+      "integrity": "sha512-A9RnAFmgNF5aZk5q2VZnFnHtXWu1kPyEN0LVsX8wJ2LBRu2nyETKwz+ZXVsVWliktToCaYojHKrS+6/HODyEZA==",
+      "license": "MIT"
     },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
@@ -4432,6 +4553,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/cropperjs": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/cropperjs/-/cropperjs-2.0.1.tgz",
+      "integrity": "sha512-hiJwk2SCPZqxMA7aR3byzLpYUqOrQo+ihMk8k/WRm/xe/LX8wNzAIzMwEB/NEGJYA6sbewxW9TUlrRUYi/2Ipg==",
+      "license": "MIT",
+      "dependencies": {
+        "@cropper/elements": "^2.0.1",
+        "@cropper/utils": "^2.0.1"
       }
     },
     "node_modules/cross-spawn": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "core-js": "^3.8.3",
+    "cropperjs": "^2.0.1",
     "echarts": "^5.6.0",
     "ldrs": "^1.1.7",
     "markdown-it": "^14.1.0",


### PR DESCRIPTION
## Summary
- add Cropper.js for client-side avatar cropping
- integrate cropping popup in SettingsPageView to generate 512x512 JPEG before upload

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68901c3cd0f88327a990c299a1b9df3f