### PR TITLE
feat: add hourly rolling logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ openisle.iml
 node_modules
 dist
 open-isle.env
+logs
+*.log

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ OpenIsle 是一个使用 Spring Boot 和 Vue 3 构建的全栈开源社区平台
 2. 执行 `npm install`
 3. `npm run serve`可在本地启动开发服务，产品环境使用 `npm run build`生成 `dist/` 文件，配合线上网站方式部署
 
+### 日志
+
+后端使用 Logback 按小时滚动输出日志，日志文件位于 `backend/logs/`，文件名格式为 `application-YYYY-MM-dd_HH.log.gz`，系统会自动保留最近三天的日志。
+若需要解压最近三天的日志，可在后端目录执行 `./scripts/extract_logs.sh`，脚本会将日志解压到 `scripts/extracted/` 目录或指定的目标目录。
+
 ## ✨ 项目特点
 - JWT 认证以及 Google、GitHub、Discord、Twitter 等多种 OAuth 登录
 - 支持分类、标签的贴文管理以及草稿保存功能

--- a/backend/scripts/extract_logs.sh
+++ b/backend/scripts/extract_logs.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Extract gzipped logs from the last three days into a target directory.
+# Usage: ./extract_logs.sh [output_dir]
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOG_DIR="${SCRIPT_DIR}/../logs"
+OUTPUT_DIR="${1:-${SCRIPT_DIR}/extracted}"
+
+mkdir -p "$OUTPUT_DIR"
+find "$LOG_DIR" -name 'application-*.log.gz' -mtime -3 -print \
+  -exec sh -c 'gzip -dc "$1" > "$2/$(basename "$1" .gz)"' _ {} "$OUTPUT_DIR" \;
+echo "Logs extracted to $OUTPUT_DIR"

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -1,0 +1,25 @@
+<configuration>
+    <property name="LOG_PATH" value="logs"/>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_PATH}/application.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/application-%d{yyyy-MM-dd_HH}.log.gz</fileNamePattern>
+            <maxHistory>72</maxHistory>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="${LOG_LEVEL:-INFO}">
+        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="FILE"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## Summary
- log application logs hourly and keep only the last three days
- add script to extract recent logs
- document log retention and extraction process

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.1.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68903a95aa748327b6b9ed38884b5d9c