### PR TITLE
fix: guard against null exception messages

### DIFF
--- a/backend/src/main/java/com/openisle/controller/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/openisle/controller/GlobalExceptionHandler.java
@@ -7,30 +7,40 @@ import com.openisle.exception.FieldException;
 import com.openisle.exception.NotFoundException;
 import com.openisle.exception.RateLimitException;
 
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(FieldException.class)
     public ResponseEntity<?> handleFieldException(FieldException ex) {
-        return ResponseEntity.badRequest()
-                .body(Map.of("error", ex.getMessage(), "field", ex.getField()));
+        Map<String, Object> body = new HashMap<>();
+        body.put("error", Objects.toString(ex.getMessage(), null));
+        body.put("field", ex.getField());
+        return ResponseEntity.badRequest().body(body);
     }
 
     @ExceptionHandler(NotFoundException.class)
     public ResponseEntity<?> handleNotFoundException(NotFoundException ex) {
-        return ResponseEntity.status(404).body(Map.of("error", ex.getMessage()));
+        Map<String, Object> body = new HashMap<>();
+        body.put("error", Objects.toString(ex.getMessage(), null));
+        return ResponseEntity.status(404).body(body);
     }
 
     @ExceptionHandler(RateLimitException.class)
     public ResponseEntity<?> handleRateLimitException(RateLimitException ex) {
-        return ResponseEntity.status(429).body(Map.of("error", ex.getMessage()));
+        Map<String, Object> body = new HashMap<>();
+        body.put("error", Objects.toString(ex.getMessage(), null));
+        return ResponseEntity.status(429).body(body);
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<?> handleException(Exception ex) {
-        return ResponseEntity.badRequest().body(Map.of("error", ex.getMessage()));
+        Map<String, Object> body = new HashMap<>();
+        body.put("error", Objects.toString(ex.getMessage(), null));
+        return ResponseEntity.badRequest().body(body);
     }
 }
 


### PR DESCRIPTION
## Summary
- avoid Map.of null pointer in exception handling

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.openisle:openisle:0.0.1-SNAPSHOT: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.1.1)*

------
https://chatgpt.com/codex/tasks/task_e_689050ec07cc8327b2a9222289cc9d5f