### PR TITLE
Handle null exception messages in global handler

### DIFF
--- a/backend/src/main/java/com/openisle/controller/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/openisle/controller/GlobalExceptionHandler.java
@@ -30,7 +30,11 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<?> handleException(Exception ex) {
-        return ResponseEntity.badRequest().body(Map.of("error", ex.getMessage()));
+        String message = ex.getMessage();
+        if (message == null) {
+            message = ex.getClass().getSimpleName();
+        }
+        return ResponseEntity.badRequest().body(Map.of("error", message));
     }
 }
 


### PR DESCRIPTION
## Summary
- avoid NullPointerException when an exception has no message

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689050ec07cc8327b2a9222289cc9d5f