### PR TITLE
test: include mapper deps in PostControllerTest

### DIFF
--- a/backend/src/test/java/com/openisle/controller/PostControllerTest.java
+++ b/backend/src/test/java/com/openisle/controller/PostControllerTest.java
@@ -1,6 +1,11 @@
 package com.openisle.controller;
 
+import com.openisle.mapper.CategoryMapper;
+import com.openisle.mapper.CommentMapper;
 import com.openisle.mapper.PostMapper;
+import com.openisle.mapper.ReactionMapper;
+import com.openisle.mapper.TagMapper;
+import com.openisle.mapper.UserMapper;
 import com.openisle.model.*;
 import com.openisle.service.*;
 import org.junit.jupiter.api.Test;
@@ -24,7 +29,8 @@ import static org.mockito.Mockito.*;
 
 @WebMvcTest(PostController.class)
 @AutoConfigureMockMvc(addFilters = false)
-@Import(PostMapper.class)
+@Import({PostMapper.class, CommentMapper.class, ReactionMapper.class,
+        UserMapper.class, TagMapper.class, CategoryMapper.class})
 class PostControllerTest {
     @Autowired
     private MockMvc mockMvc;
@@ -47,6 +53,8 @@ class PostControllerTest {
     private SubscriptionService subscriptionService;
     @MockBean
     private UserVisitService userVisitService;
+    @MockBean
+    private PostReadService postReadService;
 
     @Test
     void createAndGetPost() throws Exception {


### PR DESCRIPTION
## Summary
- ensure `PostControllerTest` imports all mapper beans and mocks `PostReadService`

## Testing
- `mvn -q -U test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.1.1)*

------
https://chatgpt.com/codex/tasks/task_e_6890b3bc400483278251c111e0c9d33d