### PR TITLE
test: provide jwt secrets for tests

### DIFF
--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -16,6 +16,8 @@ app.upload.check-type=true
 app.upload.max-size=1048576
 
 app.jwt.secret=TestSecret
+app.jwt.reason-secret=TestReasonSecret
+app.jwt.reset-secret=TestResetSecret
 app.jwt.expiration=3600000
 
 # Default publish mode for tests


### PR DESCRIPTION
## Summary
- provide reason and reset JWT secrets in test properties to satisfy JwtService dependencies

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.openisle:openisle:0.0.1-SNAPSHOT: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.1.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6890b3d079c0832780d49dcedcfb58fc