### PR TITLE
test: add missing JWT secrets for tests

### DIFF
--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -16,6 +16,8 @@ app.upload.check-type=true
 app.upload.max-size=1048576
 
 app.jwt.secret=TestSecret
+app.jwt.reason-secret=TestReasonSecret
+app.jwt.reset-secret=TestResetSecret
 app.jwt.expiration=3600000
 
 # Default publish mode for tests


### PR DESCRIPTION
## Summary
- add missing JWT secrets to test application properties so integration tests can start the context

## Testing
- `mvn -q test` *(fails: Could not resolve parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6890b3fe5f208327a7373f507c0e7cc7