### PR TITLE
Add missing mocks for AuthControllerTest

### DIFF
--- a/backend/src/test/java/com/openisle/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/openisle/controller/AuthControllerTest.java
@@ -3,6 +3,7 @@ package com.openisle.controller;
 import com.openisle.model.User;
 import com.openisle.service.*;
 import com.openisle.model.RegisterMode;
+import com.openisle.repository.UserRepository;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,6 +40,16 @@ class AuthControllerTest {
     private GoogleAuthService googleAuthService;
     @MockBean
     private RegisterModeService registerModeService;
+    @MockBean
+    private GithubAuthService githubAuthService;
+    @MockBean
+    private DiscordAuthService discordAuthService;
+    @MockBean
+    private TwitterAuthService twitterAuthService;
+    @MockBean
+    private NotificationService notificationService;
+    @MockBean
+    private UserRepository userRepository;
 
     @Test
     void registerSendsEmail() throws Exception {


### PR DESCRIPTION
## Summary
- mock additional AuthController dependencies in test to satisfy Spring context

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6890b4046ba48327816ef2001c44c9bd