### PR TITLE
Send email and push notification every five reactions

### DIFF
--- a/backend/src/main/java/com/openisle/service/ReactionService.java
+++ b/backend/src/main/java/com/openisle/service/ReactionService.java
@@ -49,6 +49,15 @@ public class ReactionService {
         reaction = reactionRepository.save(reaction);
         if (!user.getId().equals(post.getAuthor().getId())) {
             notificationService.createNotification(post.getAuthor(), NotificationType.REACTION, post, null, null, user, type, null);
+
+            long count = reactionRepository.countReceived(post.getAuthor().getUsername());
+            if (count % 5 == 0) {
+                String url = websiteUrl + "/messages";
+                notificationService.sendCustomPush(post.getAuthor(), "你有新的互动", url);
+                if (post.getAuthor().getEmail() != null) {
+                    emailSender.sendEmail(post.getAuthor().getEmail(), "你有新的互动", url);
+                }
+            }
         }
         return reaction;
     }
@@ -73,6 +82,15 @@ public class ReactionService {
         reaction = reactionRepository.save(reaction);
         if (!user.getId().equals(comment.getAuthor().getId())) {
             notificationService.createNotification(comment.getAuthor(), NotificationType.REACTION, comment.getPost(), comment, null, user, type, null);
+
+            long count = reactionRepository.countReceived(comment.getAuthor().getUsername());
+            if (count % 5 == 0) {
+                String url = websiteUrl + "/messages";
+                notificationService.sendCustomPush(comment.getAuthor(), "你有新的互动", url);
+                if (comment.getAuthor().getEmail() != null) {
+                    emailSender.sendEmail(comment.getAuthor().getEmail(), "你有新的互动", url);
+                }
+            }
         }
         return reaction;
     }


### PR DESCRIPTION
## Summary
- trigger push and email notifications when authors receive every fifth reaction
- apply the same logic for comment reactions

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.1.1)*

------
https://chatgpt.com/codex/tasks/task_e_6890b3f73f088327a08367d50b02d430