### PR TITLE
Add website URL property for tests

### DIFF
--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -22,3 +22,6 @@ app.jwt.expiration=3600000
 
 # Default publish mode for tests
 app.post.publish-mode=DIRECT
+
+# Base website URL used in tests
+app.website-url=http://localhost


### PR DESCRIPTION
## Summary
- add `app.website-url` to test `application.properties` to satisfy `@Value` injection during integration tests

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6890b6aa5da08327805879621c93e5cb