### PR TITLE
Add website URL property for tests to fix SecurityConfig

### DIFF
--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -22,3 +22,6 @@ app.jwt.expiration=3600000
 
 # Default publish mode for tests
 app.post.publish-mode=DIRECT
+
+# Website URL used in tests for redirects and email links
+app.website-url=http://test.example.com


### PR DESCRIPTION
## Summary
- provide `app.website-url` in test configuration so Spring Security can resolve placeholder during integration tests

## Testing
- `mvn -q -Djava.net.preferIPv4Stack=true test` *(fails: Non-resolvable parent POM for com.openisle:openisle:0.0.1-SNAPSHOT: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.1.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6890b6c2d6608327a73003758956c8e5