### PR TITLE
test: fix auth controller tests

### DIFF
--- a/backend/src/test/java/com/openisle/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/openisle/controller/AuthControllerTest.java
@@ -72,6 +72,7 @@ class AuthControllerTest {
     @Test
     void verifyCodeEndpoint() throws Exception {
         Mockito.when(userService.verifyCode("u", "123")).thenReturn(true);
+        Mockito.when(jwtService.generateReasonToken("u")).thenReturn("reason_token");
 
         mockMvc.perform(post("/api/auth/verify")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -84,6 +85,7 @@ class AuthControllerTest {
     void loginReturnsToken() throws Exception {
         User user = new User();
         user.setUsername("u");
+        user.setVerified(true);
         Mockito.when(userService.findByUsername("u")).thenReturn(Optional.of(user));
         Mockito.when(userService.matchesPassword(user, "p")).thenReturn(true);
         Mockito.when(jwtService.generateToken("u")).thenReturn("token");


### PR DESCRIPTION
## Summary
- Prevent NullPointerException in verify test by mocking JWT token generation
- Ensure login test uses verified user so token flow executes

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: org.springframework.boot:spring-boot-starter-parent:pom:3.1.1 - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6890b6d02d6083279344e040d250493f