### PR TITLE
Handle missing web push keys to allow tests to run

### DIFF
--- a/backend/src/main/java/com/openisle/service/PushNotificationService.java
+++ b/backend/src/main/java/com/openisle/service/PushNotificationService.java
@@ -23,14 +23,21 @@ public class PushNotificationService {
     private final PushService pushService;
 
     public PushNotificationService(PushSubscriptionRepository subscriptionRepository,
-                                   @Value("${app.webpush.public-key}") String publicKey,
-                                   @Value("${app.webpush.private-key}") String privateKey) throws GeneralSecurityException {
+                                   @Value("${app.webpush.public-key:}") String publicKey,
+                                   @Value("${app.webpush.private-key:}") String privateKey) throws GeneralSecurityException {
         this.subscriptionRepository = subscriptionRepository;
-        Security.addProvider(new BouncyCastleProvider());
-        this.pushService = new PushService(publicKey, privateKey);
+        if (!publicKey.isEmpty() && !privateKey.isEmpty()) {
+            Security.addProvider(new BouncyCastleProvider());
+            this.pushService = new PushService(publicKey, privateKey);
+        } else {
+            this.pushService = null;
+        }
     }
 
     public void sendNotification(User user, String payload) {
+        if (pushService == null) {
+            return;
+        }
         List<PushSubscription> subs = subscriptionRepository.findByUser(user);
         for (PushSubscription sub : subs) {
             try {


### PR DESCRIPTION
## Summary
- Allow `PushNotificationService` to initialize without web push keys
- Skip sending notifications when keys are absent

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6890b89fb2c883279451f2faa6c16221