### PR TITLE
feat: preserve home page when navigating back

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -9,7 +9,11 @@
         <MenuComponent :visible="!hideMenu && menuVisible" @item-click="menuVisible = false" />
       </div>
       <div class="content" :class="{ 'menu-open': menuVisible && !hideMenu }">
-        <router-view />
+        <router-view v-slot="{ Component }">
+          <keep-alive include="HomePageView">
+            <component :is="Component" />
+          </keep-alive>
+        </router-view>
       </div>
     </div>
     <GlobalPopups />


### PR DESCRIPTION
## Summary
- keep home page state across navigation by caching router-view with `<keep-alive>`

## Testing
- `cd frontend && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890c8863ff08327ab885b2f84692184