### PR TITLE
Preserve home page state when navigating back

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -9,7 +9,12 @@
         <MenuComponent :visible="!hideMenu && menuVisible" @item-click="menuVisible = false" />
       </div>
       <div class="content" :class="{ 'menu-open': menuVisible && !hideMenu }">
-        <router-view />
+        <router-view v-slot="{ Component }">
+          <keep-alive>
+            <component :is="Component" v-if="$route.meta.keepAlive" />
+          </keep-alive>
+          <component :is="Component" v-if="!$route.meta.keepAlive" />
+        </router-view>
       </div>
     </div>
     <GlobalPopups />

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -23,7 +23,8 @@ const routes = [
   {
     path: '/',
     name: 'home',
-    component: HomePageView
+    component: HomePageView,
+    meta: { keepAlive: true }
   },
   {
     path: '/message',


### PR DESCRIPTION
## Summary
- cache home route using keep-alive
- render router view with keep-alive wrapper

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890dbb6613c8327bd70b07c7fe48dce