### PR TITLE
fix: support iOS safe area for header

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -6,7 +6,7 @@
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0,viewport-fit=cover">
   <link rel="icon" href="<%= BASE_URL %>favicon.ico?v=20250712">
   <title>
     OpenIsle - 全面开源的自由技术社区

--- a/frontend/src/assets/global.css
+++ b/frontend/src/assets/global.css
@@ -2,7 +2,9 @@
   --primary-color-hover: rgb(9, 95, 105);
   --primary-color: rgb(10, 110, 120);
   --primary-color-disabled: rgba(93, 152, 156, 0.5);
-  --header-height: 60px;
+  --safe-area-inset-top: constant(safe-area-inset-top);
+  --safe-area-inset-top: env(safe-area-inset-top);
+  --header-height: calc(60px + var(--safe-area-inset-top));
   --header-background-color: white;
   --header-border-color: lightgray;
   --header-text-color: black;

--- a/frontend/src/components/HeaderComponent.vue
+++ b/frontend/src/components/HeaderComponent.vue
@@ -173,6 +173,8 @@ export default {
   justify-content: space-between;
   align-items: center;
   height: var(--header-height);
+  padding-top: var(--safe-area-inset-top);
+  box-sizing: border-box;
   background-color: var(--background-color-blur);
   backdrop-filter: blur(10px);
   color: var(--header-text-color);


### PR DESCRIPTION
## Summary
- support iOS safe-area by updating viewport meta and CSS variables
- add padding-top for header using safe-area inset

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `mvn -q test` *(fails: Could not resolve parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68915f5e302c8327bcb3f5a8972ee2d0