### PR TITLE
Fix homepage reply count display

### DIFF
--- a/backend/src/main/java/com/openisle/dto/PostSummaryDto.java
+++ b/backend/src/main/java/com/openisle/dto/PostSummaryDto.java
@@ -19,6 +19,7 @@ public class PostSummaryDto {
     private CategoryDto category;
     private List<TagDto> tags;
     private long views;
+    private long commentCount;
     private PostStatus status;
     private LocalDateTime pinnedAt;
     private LocalDateTime lastReplyAt;

--- a/backend/src/main/java/com/openisle/mapper/PostMapper.java
+++ b/backend/src/main/java/com/openisle/mapper/PostMapper.java
@@ -58,6 +58,7 @@ public class PostMapper {
         dto.setCategory(categoryMapper.toDto(post.getCategory()));
         dto.setTags(post.getTags().stream().map(tagMapper::toDto).collect(Collectors.toList()));
         dto.setViews(post.getViews());
+        dto.setCommentCount(commentService.countComments(post.getId()));
         dto.setStatus(post.getStatus());
         dto.setPinnedAt(post.getPinnedAt());
 

--- a/backend/src/main/java/com/openisle/repository/CommentRepository.java
+++ b/backend/src/main/java/com/openisle/repository/CommentRepository.java
@@ -27,4 +27,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @org.springframework.data.jpa.repository.Query("SELECT MAX(c.createdAt) FROM Comment c WHERE c.author.id = :userId")
     java.time.LocalDateTime findLastCommentTimeOfUserByUserId(@org.springframework.data.repository.query.Param("userId") Long userId);
 
+    @org.springframework.data.jpa.repository.Query("SELECT COUNT(c) FROM Comment c WHERE c.post.id = :postId")
+    long countByPostId(@org.springframework.data.repository.query.Param("postId") Long postId);
+
 }

--- a/backend/src/main/java/com/openisle/service/CommentService.java
+++ b/backend/src/main/java/com/openisle/service/CommentService.java
@@ -186,6 +186,13 @@ public class CommentService {
         return time;
     }
 
+    public long countComments(Long postId) {
+        log.debug("countComments called for post {}", postId);
+        long count = commentRepository.countByPostId(postId);
+        log.debug("countComments for post {} is {}", postId, count);
+        return count;
+    }
+
     @Transactional
     public void deleteComment(String username, Long id) {
         log.debug("deleteComment called by user {} for comment {}", username, id);

--- a/frontend/src/views/HomePageView.vue
+++ b/frontend/src/views/HomePageView.vue
@@ -175,8 +175,7 @@ export default {
       })
     })
 
-    const countComments = (list) =>
-      list.reduce((sum, c) => sum + 1 + countComments(c.replies || []), 0)
+    // Backend now returns comment counts directly
 
     const loadOptions = async () => {
       if (selectedCategory.value && !isNaN(selectedCategory.value)) {
@@ -267,7 +266,7 @@ export default {
             category: p.category,
             tags: p.tags || [],
             members: (p.participants || []).map(m => ({ id: m.id, avatar: m.avatar })),
-            comments: countComments(p.comments || []),
+            comments: p.commentCount,
             views: p.views,
             time: TimeManager.format(p.createdAt),
             pinned: !!p.pinnedAt
@@ -304,7 +303,7 @@ export default {
             category: p.category,
             tags: p.tags || [],
             members: (p.participants || []).map(m => ({ id: m.id, avatar: m.avatar })),
-            comments: countComments(p.comments || []),
+            comments: p.commentCount,
             views: p.views,
             time: TimeManager.format(p.createdAt),
             pinned: !!p.pinnedAt
@@ -341,7 +340,7 @@ export default {
             category: p.category,
             tags: p.tags || [],
             members: (p.participants || []).map(m => ({ id: m.id, avatar: m.avatar })),
-            comments: countComments(p.comments || []),
+            comments: p.commentCount,
             views: p.views,
             time: TimeManager.format(p.lastReplyAt || p.createdAt),
             pinned: !!p.pinnedAt


### PR DESCRIPTION
## Summary
- track number of comments per post on the backend via `commentCount`
- serve the comment count and map it into post summaries
- use the new count in `HomePageView` so reply numbers render correctly

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_689189e2e8e483278c0bc761c6ada8df