### PR TITLE
fix: handle iOS Safari keyboard scroll offset

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -12,6 +12,7 @@ import { checkToken, clearToken, isLogin } from './utils/auth'
 import { loginWithGoogle } from './utils/google'
 import { initTheme } from './utils/theme'
 import { clearVditorStorage } from './utils/clearVditorStorage'
+import { initIOSKeyboardFix } from './utils/iosKeyboardFix'
 
 // 采用本地开发环境
 // export const API_DOMAIN = 'http://127.0.0.1'
@@ -34,6 +35,7 @@ export const toast = useToast()
 
 initTheme()
 clearVditorStorage()
+initIOSKeyboardFix()
 
 const app = createApp(App)
 app.use(router)

--- a/frontend/src/utils/iosKeyboardFix.js
+++ b/frontend/src/utils/iosKeyboardFix.js
@@ -1,0 +1,23 @@
+export function initIOSKeyboardFix() {
+  if (typeof window === 'undefined' || !window.visualViewport) return;
+
+  const ua = navigator.userAgent || '';
+  const isIOS = /iP(ad|hone|od)/.test(ua);
+  if (!isIOS) return;
+
+  const viewport = window.visualViewport;
+  const adjustScroll = () => {
+    window.scrollTo(0, viewport.offsetTop);
+  };
+
+  viewport.addEventListener('resize', adjustScroll);
+  viewport.addEventListener('scroll', adjustScroll);
+
+  let lastScrollY = 0;
+  document.addEventListener('focusin', () => {
+    lastScrollY = window.scrollY;
+  });
+  document.addEventListener('focusout', () => {
+    window.scrollTo(0, lastScrollY);
+  });
+}


### PR DESCRIPTION
## Summary
- add utility to reset scroll and restore position when the iOS Safari keyboard toggles
- wire up the keyboard fix during app bootstrap

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6891aacc05808327b7c18bbcc90f0868