### PR TITLE
fix: defer notification sending until after commit

### DIFF
--- a/backend/src/main/java/com/openisle/service/NotificationService.java
+++ b/backend/src/main/java/com/openisle/service/NotificationService.java
@@ -10,6 +10,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.util.Map;
 
@@ -71,7 +73,7 @@ public class NotificationService {
         }
         n = notificationRepository.save(n);
 
-        notificationExecutor.execute(() -> {
+        Runnable asyncTask = () -> {
             if (type == NotificationType.COMMENT_REPLY && user.getEmail() != null && post != null && comment != null) {
                 String url = String.format("%s/posts/%d#comment-%d", websiteUrl, post.getId(), comment.getId());
                 emailSender.sendEmail(user.getEmail(), "有人回复了你", url);
@@ -95,7 +97,18 @@ public class NotificationService {
 //                    }
 //                }
             }
-        });
+        };
+
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    notificationExecutor.execute(asyncTask);
+                }
+            });
+        } else {
+            notificationExecutor.execute(asyncTask);
+        }
 
         return n;
     }


### PR DESCRIPTION
## Summary
- defer push/email notifications until after DB commit to avoid session state errors during comment replies

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.1.1)*

------
https://chatgpt.com/codex/tasks/task_e_6892245215ac8327acef637ac459154c