### PR TITLE
fix: mark admin register requests read once processed

### DIFF
--- a/backend/src/main/java/com/openisle/controller/AdminUserController.java
+++ b/backend/src/main/java/com/openisle/controller/AdminUserController.java
@@ -1,7 +1,10 @@
 package com.openisle.controller;
 
+import com.openisle.model.Notification;
+import com.openisle.model.NotificationType;
 import com.openisle.model.User;
 import com.openisle.service.EmailSender;
+import com.openisle.repository.NotificationRepository;
 import com.openisle.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -13,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class AdminUserController {
     private final UserRepository userRepository;
+    private final NotificationRepository notificationRepository;
     private final EmailSender emailSender;
     @Value("${app.website-url:https://www.open-isle.com}")
     private String websiteUrl;
@@ -22,6 +26,7 @@ public class AdminUserController {
         User user = userRepository.findById(id).orElseThrow();
         user.setApproved(true);
         userRepository.save(user);
+        markRegisterRequestNotificationsRead(user);
         emailSender.sendEmail(user.getEmail(), "您的注册已审核通过",
                 "🎉您的注册已经审核通过, 点击以访问网站: " + websiteUrl);
         return ResponseEntity.ok().build();
@@ -32,8 +37,18 @@ public class AdminUserController {
         User user = userRepository.findById(id).orElseThrow();
         user.setApproved(false);
         userRepository.save(user);
+        markRegisterRequestNotificationsRead(user);
         emailSender.sendEmail(user.getEmail(), "您的注册已被管理员拒绝",
                 "您的注册被管理员拒绝, 点击链接可以重新填写理由申请: " + websiteUrl);
         return ResponseEntity.ok().build();
+    }
+
+    private void markRegisterRequestNotificationsRead(User applicant) {
+        java.util.List<Notification> notifs =
+                notificationRepository.findByTypeAndFromUser(NotificationType.REGISTER_REQUEST, applicant);
+        for (Notification n : notifs) {
+            n.setRead(true);
+        }
+        notificationRepository.saveAll(notifs);
     }
 }

--- a/backend/src/main/java/com/openisle/repository/NotificationRepository.java
+++ b/backend/src/main/java/com/openisle/repository/NotificationRepository.java
@@ -19,5 +19,7 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
     void deleteByTypeAndFromUser(NotificationType type, User fromUser);
 
+    List<Notification> findByTypeAndFromUser(NotificationType type, User fromUser);
+
     void deleteByTypeAndFromUserAndPost(NotificationType type, User fromUser, Post post);
 }

--- a/backend/src/test/java/com/openisle/controller/AdminUserControllerTest.java
+++ b/backend/src/test/java/com/openisle/controller/AdminUserControllerTest.java
@@ -1,0 +1,76 @@
+package com.openisle.controller;
+
+import com.openisle.model.Notification;
+import com.openisle.model.NotificationType;
+import com.openisle.model.User;
+import com.openisle.repository.NotificationRepository;
+import com.openisle.repository.UserRepository;
+import com.openisle.service.EmailSender;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AdminUserController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class AdminUserControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserRepository userRepository;
+    @MockBean
+    private NotificationRepository notificationRepository;
+    @MockBean
+    private EmailSender emailSender;
+
+    @Test
+    void approveMarksNotificationsRead() throws Exception {
+        User u = new User();
+        u.setId(1L);
+        u.setEmail("a@a.com");
+        when(userRepository.findById(1L)).thenReturn(Optional.of(u));
+
+        Notification n = new Notification();
+        n.setId(2L);
+        n.setRead(false);
+        when(notificationRepository.findByTypeAndFromUser(NotificationType.REGISTER_REQUEST, u))
+                .thenReturn(List.of(n));
+
+        mockMvc.perform(post("/api/admin/users/1/approve"))
+                .andExpect(status().isOk());
+
+        assertTrue(n.isRead());
+        verify(notificationRepository).saveAll(List.of(n));
+    }
+
+    @Test
+    void rejectMarksNotificationsRead() throws Exception {
+        User u = new User();
+        u.setId(1L);
+        u.setEmail("a@a.com");
+        when(userRepository.findById(1L)).thenReturn(Optional.of(u));
+
+        Notification n = new Notification();
+        n.setId(2L);
+        n.setRead(false);
+        when(notificationRepository.findByTypeAndFromUser(NotificationType.REGISTER_REQUEST, u))
+                .thenReturn(List.of(n));
+
+        mockMvc.perform(post("/api/admin/users/1/reject"))
+                .andExpect(status().isOk());
+
+        assertTrue(n.isRead());
+        verify(notificationRepository).saveAll(List.of(n));
+    }
+}


### PR DESCRIPTION
## Summary
- mark register request notifications read for all admins after one approves or rejects
- add repository helper and unit tests

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM ... network is unreachable)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_6892e15cd9e48327b3409ae4e4f41232