### PR TITLE
fix: add missing highlight.js

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "core-js": "^3.8.3",
     "cropperjs": "^1.6.2",
     "echarts": "^5.6.0",
+    "highlight.js": "^11.11.1",
     "ldrs": "^1.1.7",
     "markdown-it": "^14.1.0",
     "vditor": "^3.11.1",


### PR DESCRIPTION
fixes a phantom dependency on `highlight.js`. 