### PR TITLE
fix: offset vditor toolbar when pinned

### DIFF
--- a/frontend/src/assets/global.css
+++ b/frontend/src/assets/global.css
@@ -65,7 +65,11 @@ body {
  *************************/
 .vditor {
   min-height: 200px;
-} 
+}
+.vditor-toolbar--pin {
+  top: var(--header-height) !important;
+  z-index: 900 !important;
+}
 /* .vditor {
   --textarea-background-color: transparent;
   border: none !important;


### PR DESCRIPTION
## Summary
- ensure vditor toolbar remains visible by offsetting sticky position under global scroll

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892cfec5fe4832792872c19ef6cc66e