### PR TITLE
feat: add tieba emoji support

### DIFF
--- a/frontend/src/assets/global.css
+++ b/frontend/src/assets/global.css
@@ -71,6 +71,16 @@ body {
   top: var(--header-height) !important;
 }
 
+.vditor-panel {
+  min-width: 400px;
+}
+
+.emoji {
+  width: 20px;
+  height: 20px;
+  vertical-align: middle;
+}
+
 /* .vditor {
   --textarea-background-color: transparent;
   border: none !important;

--- a/frontend/src/assets/global.css
+++ b/frontend/src/assets/global.css
@@ -255,6 +255,11 @@ body {
     margin-bottom: 3px;
   }
 
+
+  .vditor-toolbar--pin {
+    top: 0 !important;
+  }
+
   .about-content li,
   .info-content-text li {
     font-size: 14px;

--- a/frontend/src/components/PostEditor.vue
+++ b/frontend/src/components/PostEditor.vue
@@ -123,7 +123,6 @@ export default {
 
 <style scoped>
 .post-editor-container {
-  border: 1px solid var(--normal-border-color);
   position: relative;
   min-height: 200px;
 }
@@ -141,4 +140,11 @@ export default {
   pointer-events: all;
   z-index: 10;
 }
+
+@media (max-width: 768px) {
+  .post-editor-container {
+    min-height: 100px;
+  }
+}
+
 </style>

--- a/frontend/src/utils/markdown.js
+++ b/frontend/src/utils/markdown.js
@@ -2,7 +2,7 @@ import MarkdownIt from 'markdown-it'
 import hljs from 'highlight.js'
 import 'highlight.js/styles/github.css'
 import { toast } from '../main'
-import { tiebaEmoji, TIEBA_EMOJI_CDN } from './tiebaEmoji'
+import { tiebaEmoji } from './tiebaEmoji'
 
 function mentionPlugin(md) {
   const mentionReg = /^@\[([^\]]+)\]/
@@ -32,7 +32,7 @@ function tiebaEmojiPlugin(md) {
   md.renderer.rules['tieba-emoji'] = (tokens, idx) => {
     const name = tokens[idx].content
     const file = tiebaEmoji[name]
-    return `<img class="emoji" src="${TIEBA_EMOJI_CDN}${file}" alt="${name}">`
+    return `<img class="emoji" src="${file}" alt="${name}">`
   }
   md.inline.ruler.before('emphasis', 'tieba-emoji', (state, silent) => {
     const pos = state.pos

--- a/frontend/src/utils/tiebaEmoji.js
+++ b/frontend/src/utils/tiebaEmoji.js
@@ -1,10 +1,11 @@
 export const TIEBA_EMOJI_CDN = 'https://cdn.jsdelivr.net/gh/microlong666/tieba_mobile_emotions@master/'
+// export const TIEBA_EMOJI_CDN = 'https://openisle-1307107697.cos.ap-guangzhou.myqcloud.com/assert/vditor/dist/images/emoji/'
 
 export const tiebaEmoji = (() => {
-  const map = { tieba1: 'image_emoticon.png' }
+  const map = { tieba1: TIEBA_EMOJI_CDN + 'image_emoticon.png' }
   for (let i = 2; i <= 124; i++) {
     if (i > 50 && i < 62) continue
-    map[`tieba${i}`] = `image_emoticon${i}.png`
+    map[`tieba${i}`] = TIEBA_EMOJI_CDN + `image_emoticon${i}.png`
   }
   return map
 })()

--- a/frontend/src/utils/tiebaEmoji.js
+++ b/frontend/src/utils/tiebaEmoji.js
@@ -1,0 +1,10 @@
+export const TIEBA_EMOJI_CDN = 'https://cdn.jsdelivr.net/gh/microlong666/tieba_mobile_emotions@master/'
+
+export const tiebaEmoji = (() => {
+  const map = { tieba1: 'image_emoticon.png' }
+  for (let i = 2; i <= 124; i++) {
+    if (i > 50 && i < 62) continue
+    map[`tieba${i}`] = `image_emoticon${i}.png`
+  }
+  return map
+})()

--- a/frontend/src/utils/vditor.js
+++ b/frontend/src/utils/vditor.js
@@ -3,7 +3,7 @@ import 'vditor/dist/index.css'
 import { API_BASE_URL } from '../main'
 import { getToken, authState } from './auth'
 import { searchUsers, fetchFollowings, fetchAdmins } from './user'
-import { tiebaEmoji, TIEBA_EMOJI_CDN } from './tiebaEmoji'
+import { tiebaEmoji } from './tiebaEmoji'
 
 export function getEditorTheme() {
   return document.documentElement.dataset.theme === 'dark' ? 'dark' : 'classic'
@@ -45,12 +45,9 @@ export function createVditor(editorId, options = {}) {
     theme: getEditorTheme(),
     preview: Object.assign({
       theme: { current: getPreviewTheme() },
-      customEmoji: tiebaEmoji,
-      emojiPath: TIEBA_EMOJI_CDN
     }, preview),
     hint: {
       emoji: tiebaEmoji,
-      emojiPath: TIEBA_EMOJI_CDN,
       extend: [
         {
           key: '@',

--- a/frontend/src/utils/vditor.js
+++ b/frontend/src/utils/vditor.js
@@ -3,6 +3,7 @@ import 'vditor/dist/index.css'
 import { API_BASE_URL } from '../main'
 import { getToken, authState } from './auth'
 import { searchUsers, fetchFollowings, fetchAdmins } from './user'
+import { tiebaEmoji, TIEBA_EMOJI_CDN } from './tiebaEmoji'
 
 export function getEditorTheme() {
   return document.documentElement.dataset.theme === 'dark' ? 'dark' : 'classic'
@@ -42,8 +43,14 @@ export function createVditor(editorId, options = {}) {
     placeholder,
     height: 'auto',
     theme: getEditorTheme(),
-    preview: Object.assign({ theme: { current: getPreviewTheme() } }, preview),
+    preview: Object.assign({
+      theme: { current: getPreviewTheme() },
+      customEmoji: tiebaEmoji,
+      emojiPath: TIEBA_EMOJI_CDN
+    }, preview),
     hint: {
+      emoji: tiebaEmoji,
+      emojiPath: TIEBA_EMOJI_CDN,
       extend: [
         {
           key: '@',

--- a/frontend/src/utils/vditor.js
+++ b/frontend/src/utils/vditor.js
@@ -40,7 +40,7 @@ export function createVditor(editorId, options = {}) {
 
   const isMobile = window.innerWidth <= 768
   const toolbar = isMobile
-    ? ['emoji', 'bold', 'italic', 'strike', '|', 'link', 'upload']
+    ? ['emoji', 'upload']
     : [
         'emoji',
         'bold',

--- a/frontend/src/views/MessagePageView.vue
+++ b/frontend/src/views/MessagePageView.vue
@@ -628,11 +628,12 @@ export default {
 
 .message-page {
   background-color: var(--background-color);
+  overflow-x: hidden;
 }
 
 .message-page-header {
   position: sticky;
-  top: calc(var(--header-height) + 1px);
+  top: 1px;
   z-index: 200;
   background-color: var(--background-color-blur);
   display: flex;
@@ -768,10 +769,6 @@ export default {
 @media (max-width: 768px) {
   .has_read_button {
     display: none;
-  }
-
-  .message-page {
-    overflow-x: hidden;
   }
 }
 </style>


### PR DESCRIPTION
## Summary
- add Tieba emoji mapping
- wire Vditor to use Tieba emoji set
- render Tieba emojis in Markdown output

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint`
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_689333242ef88327a5dd38920f74e15f