### PR TITLE
fix: preserve comment text on failure

### DIFF
--- a/frontend/src/components/CommentEditor.vue
+++ b/frontend/src/components/CommentEditor.vue
@@ -67,9 +67,11 @@ export default {
       if (!vditorInstance.value || isDisabled.value) return
       const value = vditorInstance.value.getValue()
       console.debug('CommentEditor submit', value)
-      emit('submit', value)
-      vditorInstance.value.setValue('')
-      text.value = ''
+      emit('submit', value, () => {
+        if (!vditorInstance.value) return
+        vditorInstance.value.setValue('')
+        text.value = ''
+      })
     }
 
     onMounted(() => {

--- a/frontend/src/components/CommentItem.vue
+++ b/frontend/src/components/CommentItem.vue
@@ -157,7 +157,7 @@ const CommentItem = {
         toast.error('操作失败')
       }
     }
-    const submitReply = async (text) => {
+    const submitReply = async (text, clear) => {
       if (!text.trim()) return
       isWaitingForReply.value = true
       const token = getToken()
@@ -201,6 +201,7 @@ const CommentItem = {
             src: data.author.avatar,
             iconClick: () => router.push(`/users/${data.author.id}`)
           })
+          clear()
           showEditor.value = false
           toast.success('回复成功')
         } else if (res.status === 429) {

--- a/frontend/src/views/PostPageView.vue
+++ b/frontend/src/views/PostPageView.vue
@@ -364,7 +364,7 @@ export default {
       }
     }
 
-    const postComment = async (text) => {
+    const postComment = async (text, clear) => {
       if (!text.trim()) return
       console.debug('Posting comment', { postId, text })
       isWaitingPostingComment.value = true
@@ -385,6 +385,7 @@ export default {
           const data = await res.json()
           console.debug('Post comment response data', data)
           await fetchComments()
+          clear()
           if (data.reward && data.reward > 0) {
             toast.success(`评论成功，获得 ${data.reward} 经验值`)
           } else {


### PR DESCRIPTION
## Summary
- stop clearing the vditor editor when submitting comments
- clear comment editors only after successful POST replies

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6893351c9d148327b8c10fbb701a7eb9