### PR TITLE
fix: mobile emoji panel width

### DIFF
--- a/frontend/src/assets/global.css
+++ b/frontend/src/assets/global.css
@@ -75,6 +75,13 @@ body {
   min-width: 400px;
 }
 
+@media (max-width: 768px) {
+  .vditor-panel {
+    min-width: 0;
+    width: 100%;
+  }
+}
+
 .emoji {
   width: 20px;
   height: 20px;


### PR DESCRIPTION
## Summary
- allow Vditor emoji panel to scale on small screens

## Testing
- `npm run lint`
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6893412334608327a683bb460dadcff0