### PR TITLE
fix: load ldrs client-side

### DIFF
--- a/frontend/src/components/CallbackPage.vue
+++ b/frontend/src/components/CallbackPage.vue
@@ -6,10 +6,6 @@
 </template>
 
 <script>
-import { hatch } from 'ldrs'
-
-hatch.register()
-
 export default {
   name: 'CallbackPage'
 }

--- a/frontend/src/components/Dropdown.vue
+++ b/frontend/src/components/Dropdown.vue
@@ -147,9 +147,7 @@
 
 <script>
 import { ref, computed, watch, onMounted } from "vue"
-import { hatch } from "ldrs"
 import { isMobile } from "../utils/screen"
-hatch.register()
 
 export default {
   name: "BaseDropdown",

--- a/frontend/src/components/MenuComponent.vue
+++ b/frontend/src/components/MenuComponent.vue
@@ -117,8 +117,6 @@ import { authState } from '../utils/auth'
 import { fetchUnreadCount, notificationState } from '../utils/notification'
 import { watch } from 'vue'
 import { API_BASE_URL } from '../config'
-import { hatch } from 'ldrs'
-hatch.register()
 
 export default {
   name: 'MenuComponent',

--- a/frontend/src/components/MilkTeaActivityComponent.vue
+++ b/frontend/src/components/MilkTeaActivityComponent.vue
@@ -49,8 +49,6 @@ import BaseInput from './BaseInput.vue'
 import BasePopup from './BasePopup.vue'
 import { API_BASE_URL, toast } from '../config'
 import { getToken, fetchCurrentUser } from '../utils/auth'
-import { hatch } from 'ldrs'
-hatch.register()
 
 export default {
   name: 'MilkTeaActivityComponent',

--- a/frontend/src/components/PostEditor.vue
+++ b/frontend/src/components/PostEditor.vue
@@ -16,8 +16,6 @@ import {
   getPreviewTheme as getPreviewThemeUtil
 } from '../utils/vditor'
 import { clearVditorStorage } from '../utils/clearVditorStorage'
-import { hatch } from 'ldrs'
-hatch.register()
 
 export default {
   name: 'PostEditor',

--- a/frontend/src/pages/AboutPageView.vue
+++ b/frontend/src/pages/AboutPageView.vue
@@ -20,8 +20,6 @@
 <script>
 import { ref, onMounted } from 'vue'
 import { renderMarkdown, handleMarkdownClick } from '../utils/markdown'
-import { hatch } from 'ldrs'
-hatch.register()
 
 export default {
   name: 'AboutPageView',

--- a/frontend/src/pages/ActivityListPageView.vue
+++ b/frontend/src/pages/ActivityListPageView.vue
@@ -33,8 +33,6 @@
 import { API_BASE_URL } from '../config'
 import TimeManager from '../utils/time'
 import MilkTeaActivityComponent from '../components/MilkTeaActivityComponent.vue'
-import { hatch } from 'ldrs'
-hatch.register()
 
 export default {
   name: 'ActivityListPageView',

--- a/frontend/src/pages/MessagePageView.vue
+++ b/frontend/src/pages/MessagePageView.vue
@@ -303,9 +303,7 @@ import { markNotificationsRead, fetchUnreadCount, notificationState } from '../u
 import { toast } from '../config'
 import { stripMarkdownLength } from '../utils/markdown'
 import TimeManager from '../utils/time'
-import { hatch } from 'ldrs'
 import { reactionEmojiMap } from '../utils/reactions'
-hatch.register()
 
 export default {
   name: 'MessagePageView',

--- a/frontend/src/pages/PostPageView.vue
+++ b/frontend/src/pages/PostPageView.vue
@@ -119,11 +119,9 @@ import { renderMarkdown, handleMarkdownClick, stripMarkdownLength } from '../uti
 import { API_BASE_URL, toast } from '../config'
 import { getToken, authState } from '../utils/auth'
 import TimeManager from '../utils/time'
-import { hatch } from 'ldrs'
 import { useRouter } from 'vue-router'
 import { isMobile } from '../utils/screen'
 import Dropdown from '../components/Dropdown.vue'
-hatch.register()
 
 export default {
   name: 'PostPageView',

--- a/frontend/src/pages/ProfileView.vue
+++ b/frontend/src/pages/ProfileView.vue
@@ -260,8 +260,6 @@ import LevelProgress from '../components/LevelProgress.vue'
 import { stripMarkdown, stripMarkdownLength } from '../utils/markdown'
 import TimeManager from '../utils/time'
 import { prevLevelExp } from '../utils/level'
-import { hatch } from 'ldrs'
-hatch.register()
 
 export default {
   name: 'ProfileView',

--- a/frontend/src/pages/SettingsPageView.vue
+++ b/frontend/src/pages/SettingsPageView.vue
@@ -66,8 +66,6 @@ import { getToken, fetchCurrentUser, setToken } from '../utils/auth'
 import BaseInput from '../components/BaseInput.vue'
 import Dropdown from '../components/Dropdown.vue'
 import AvatarCropper from '../components/AvatarCropper.vue'
-import { hatch } from 'ldrs'
-hatch.register()
 export default {
   name: 'SettingsPageView',
   components: { BaseInput, Dropdown, AvatarCropper },

--- a/frontend/src/pages/index.vue
+++ b/frontend/src/pages/index.vue
@@ -119,9 +119,7 @@ import TagSelect from '../components/TagSelect.vue'
 import ArticleTags from '../components/ArticleTags.vue'
 import ArticleCategory from '../components/ArticleCategory.vue'
 import SearchDropdown from '../components/SearchDropdown.vue'
-import { hatch } from 'ldrs'
 import { isMobile } from '../utils/screen'
-hatch.register()
 
 
 export default {

--- a/frontend/src/plugins/ldrs.client.ts
+++ b/frontend/src/plugins/ldrs.client.ts
@@ -1,0 +1,7 @@
+import { defineNuxtPlugin } from '#app'
+import { hatch } from 'ldrs'
+
+export default defineNuxtPlugin(() => {
+  hatch.register()
+  hatch.register('l-hatch-spinner')
+})


### PR DESCRIPTION
## Summary
- register ldrs loaders in a Nuxt client plugin
- stop importing ldrs directly in components and pages

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894175adc98832798e4b5cdfa9b737f