### PR TITLE
fix: initialize router before async operations in MenuComponent

### DIFF
--- a/frontend_nuxt/components/MenuComponent.vue
+++ b/frontend_nuxt/components/MenuComponent.vue
@@ -127,6 +127,9 @@ export default {
     }
   },
   async setup(props, { emit }) {
+    // `useRouter` must be called before any `await` to retain Nuxt instance
+    const router = useRouter()
+
     const categories = ref([])
     const tags = ref([])
     const categoryOpen = ref(true)
@@ -189,8 +192,6 @@ export default {
       await updateCount()
       watch(() => authState.loggedIn, updateCount)
     })
-
-    const router = useRouter()
 
     const handleHomeClick = () => {
       router.push('/').then(() => {


### PR DESCRIPTION
## Summary
- ensure router composable is invoked before awaiting API calls in MenuComponent

## Testing
- `npm test` (frontend_nuxt) *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6895904f5cc48327af12c36dbf445b8d