### PR TITLE
feat(frontend_nuxt): add global loading progress bar

### DIFF
--- a/frontend_nuxt/assets/global.css
+++ b/frontend_nuxt/assets/global.css
@@ -274,3 +274,33 @@ body {
     min-width: 0;
   }
 }
+
+/* NProgress styles */
+#nprogress {
+  pointer-events: none;
+}
+
+#nprogress .bar {
+  background: var(--primary-color);
+  position: fixed;
+  z-index: 1031;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 3px;
+}
+
+#nprogress .peg {
+  display: block;
+  position: absolute;
+  right: 0;
+  width: 100px;
+  height: 100%;
+  box-shadow: 0 0 10px var(--primary-color), 0 0 5px var(--primary-color);
+  opacity: 1;
+  transform: rotate(3deg) translate(0px, -4px);
+}
+
+#nprogress .spinner {
+  display: none;
+}

--- a/frontend_nuxt/package-lock.json
+++ b/frontend_nuxt/package-lock.json
@@ -11,6 +11,7 @@
         "highlight.js": "^11.11.1",
         "ldrs": "^1.0.0",
         "markdown-it": "^14.1.0",
+        "nprogress": "^0.2.0",
         "nuxt": "latest",
         "vditor": "^3.11.1",
         "vue-easy-lightbox": "^1.19.0",
@@ -6414,6 +6415,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/nprogress": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/nprogress/-/nprogress-0.2.0.tgz",
+      "integrity": "sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA==",
+      "license": "MIT"
     },
     "node_modules/nth-check": {
       "version": "2.1.1",

--- a/frontend_nuxt/package.json
+++ b/frontend_nuxt/package.json
@@ -15,6 +15,7 @@
     "ldrs": "^1.0.0",
     "markdown-it": "^14.1.0",
     "nuxt": "latest",
+    "nprogress": "^0.2.0",
     "vditor": "^3.11.1",
     "vue-easy-lightbox": "^1.19.0",
     "vue-echarts": "^7.0.3",

--- a/frontend_nuxt/plugins/nprogress.client.ts
+++ b/frontend_nuxt/plugins/nprogress.client.ts
@@ -1,0 +1,18 @@
+import NProgress from 'nprogress'
+import 'nprogress/nprogress.css'
+
+export default defineNuxtPlugin((nuxtApp) => {
+  NProgress.configure({ showSpinner: false })
+
+  nuxtApp.hook('page:start', () => {
+    NProgress.start()
+  })
+
+  nuxtApp.hook('page:finish', () => {
+    NProgress.done()
+  })
+
+  nuxtApp.hook('page:error', () => {
+    NProgress.done()
+  })
+})


### PR DESCRIPTION
## Summary
- show a top progress bar using NProgress on page navigation
- style progress bar to match theme colors

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68959f68253083279c83413c37c52350