### PR TITLE
fix: persist theme mode across refresh

### DIFF
--- a/frontend_nuxt/plugins/theme.client.ts
+++ b/frontend_nuxt/plugins/theme.client.ts
@@ -1,0 +1,7 @@
+import { defineNuxtPlugin } from '#app'
+import { initTheme } from '~/utils/theme'
+
+export default defineNuxtPlugin(() => {
+  initTheme()
+})
+


### PR DESCRIPTION
## Summary
- initialize saved theme on client startup to keep dark mode selection across page reloads

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6895a28de6e08327a696803ccd87c74c