### PR TITLE
fix: support user profile trailing slash

### DIFF
--- a/frontend_nuxt/pages/users/[id].vue
+++ b/frontend_nuxt/pages/users/[id].vue
@@ -261,6 +261,10 @@ import { stripMarkdown, stripMarkdownLength } from '../utils/markdown'
 import TimeManager from '../utils/time'
 import { prevLevelExp } from '../utils/level'
 
+definePageMeta({
+  alias: ['/users/:id/']
+})
+
 export default {
   name: 'ProfileView',
   components: { BaseTimeline, UserList, BasePlaceholder, LevelProgress },


### PR DESCRIPTION
## Summary
- allow /users/:id/ to resolve to the user profile by adding a route alias

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895ba9a3ec48327995706283991ebed