### PR TITLE
fix: apply theme before render to avoid flash

### DIFF
--- a/frontend_nuxt/nuxt.config.ts
+++ b/frontend_nuxt/nuxt.config.ts
@@ -5,6 +5,21 @@ export default defineNuxtConfig({
   css: ['~/assets/global.css'],
   app: {
     head: {
+      script: [
+        {
+          tagPriority: 'high',
+          children: `
+            (function () {
+              try {
+                const mode = localStorage.getItem('theme-mode');
+                const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+                const theme = mode === 'dark' || mode === 'light' ? mode : (prefersDark ? 'dark' : 'light');
+                document.documentElement.dataset.theme = theme;
+              } catch (e) {}
+            })();
+          `
+        }
+      ],
       link: [
         {
           rel: 'stylesheet',


### PR DESCRIPTION
## Summary
- Set theme attribute in `nuxt.config.ts` head script to prevent white flash before dark mode is applied

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895ad7927dc8327a6fcd4e7eb7bff76