### PR TITLE
fix: apply global Vditor styles in SSR

### DIFF
--- a/frontend_nuxt/nuxt.config.ts
+++ b/frontend_nuxt/nuxt.config.ts
@@ -2,7 +2,8 @@ import { defineNuxtConfig } from 'nuxt/config'
 
 export default defineNuxtConfig({
   ssr: true,
-  css: ['~/assets/global.css'],
+  // Ensure Vditor styles load before our overrides in global.css
+  css: ['vditor/dist/index.css', '~/assets/global.css'],
   app: {
     head: {
       link: [

--- a/frontend_nuxt/utils/vditor.js
+++ b/frontend_nuxt/utils/vditor.js
@@ -1,5 +1,4 @@
 import Vditor from 'vditor'
-import 'vditor/dist/index.css'
 import { API_BASE_URL } from '../main'
 import { getToken, authState } from './auth'
 import { searchUsers, fetchFollowings, fetchAdmins } from './user'


### PR DESCRIPTION
## Summary
- load Vditor CSS before global overrides so SSR applies global.css
- remove duplicate Vditor CSS import from utility

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895bbff912083279c432148e2717193