### PR TITLE
feat: enable page keepalive

### DIFF
--- a/frontend_nuxt/app.vue
+++ b/frontend_nuxt/app.vue
@@ -9,7 +9,7 @@
         <MenuComponent :visible="!hideMenu && menuVisible" @item-click="menuVisible = false" />
       </div>
       <div class="content" :class="{ 'menu-open': menuVisible && !hideMenu }">
-        <NuxtPage />
+        <NuxtPage keepalive />
       </div>
     </div>
     <GlobalPopups />

--- a/frontend_nuxt/pages/index.vue
+++ b/frontend_nuxt/pages/index.vue
@@ -106,6 +106,12 @@
   </div>
 </template>
 
+<script setup>
+definePageMeta({
+  keepalive: true
+})
+</script>
+
 <script>
 import { ref, watch } from 'vue'
 import { useRoute } from 'vue-router'

--- a/frontend_nuxt/pages/posts/[id]/index.vue
+++ b/frontend_nuxt/pages/posts/[id]/index.vue
@@ -104,6 +104,12 @@
   </div>
 </template>
 
+<script setup>
+definePageMeta({
+  keepalive: true
+})
+</script>
+
 <script>
 import { ref, computed, onMounted, onBeforeUnmount, nextTick, watch } from 'vue'
 import VueEasyLightbox from 'vue-easy-lightbox'


### PR DESCRIPTION
## Summary
- keep home and post pages cached via `definePageMeta`
- keep `NuxtPage` components alive to avoid reloads when navigating back

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6895bd91ca08832788fac8e893008ed2