### PR TITLE
fix(frontend_nuxt): avoid duplicate home fetch

### DIFF
--- a/frontend_nuxt/pages/index.vue
+++ b/frontend_nuxt/pages/index.vue
@@ -109,6 +109,7 @@
 <script>
 import { ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
+import { useNuxtApp } from '#app'
 import { useScrollLoadMore } from '~/utils/loadMore'
 import { stripMarkdown } from '~/utils/markdown'
 import { API_BASE_URL } from '~/main'
@@ -133,6 +134,7 @@ export default {
   },
   async setup() {
     const route = useRoute()
+    const nuxtApp = useNuxtApp()
     const selectedCategory = ref('')
     if (route.query.category) {
       const c = decodeURIComponent(route.query.category)
@@ -376,7 +378,9 @@ export default {
 
     const sanitizeDescription = text => stripMarkdown(text)
 
-    await Promise.all([loadOptions(), fetchContent()])
+    if (process.server || !nuxtApp.isHydrating) {
+      await Promise.all([loadOptions(), fetchContent()])
+    }
 
     return {
       topics,


### PR DESCRIPTION
## Summary
- avoid duplicate data fetch on Nuxt home by skipping when hydrating

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6895c798e65c8327879fdf26b5b1922e