### PR TITLE
Fix scroll reset on home page after hydration

### DIFF
--- a/frontend_nuxt/pages/index.vue
+++ b/frontend_nuxt/pages/index.vue
@@ -122,6 +122,10 @@ import ArticleCategory from '~/components/ArticleCategory.vue'
 import SearchDropdown from '~/components/SearchDropdown.vue'
 import { isMobile } from '~/utils/screen'
 
+definePageMeta({
+  scrollToTop: false,
+})
+
 export default {
   name: 'HomePageView',
   components: {


### PR DESCRIPTION
## Summary
- preserve scroll position after hydration by disabling scrollToTop meta on home page

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895ca840c2483278f66cc6efa8f71a0