### PR TITLE
feat: enable user medal selection and display

### DIFF
--- a/backend/src/main/java/com/openisle/controller/MedalController.java
+++ b/backend/src/main/java/com/openisle/controller/MedalController.java
@@ -1,12 +1,12 @@
 package com.openisle.controller;
 
 import com.openisle.dto.MedalDto;
+import com.openisle.dto.MedalSelectRequest;
 import com.openisle.service.MedalService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -19,5 +19,15 @@ public class MedalController {
     @GetMapping
     public List<MedalDto> getMedals(@RequestParam(value = "userId", required = false) Long userId) {
         return medalService.getMedals(userId);
+    }
+
+    @PostMapping("/select")
+    public ResponseEntity<Void> selectMedal(@RequestBody MedalSelectRequest req, Authentication auth) {
+        try {
+            medalService.selectMedal(auth.getName(), req.getType());
+            return ResponseEntity.ok().build();
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().build();
+        }
     }
 }

--- a/backend/src/main/java/com/openisle/dto/AuthorDto.java
+++ b/backend/src/main/java/com/openisle/dto/AuthorDto.java
@@ -1,6 +1,7 @@
 package com.openisle.dto;
 
 import lombok.Data;
+import com.openisle.model.MedalType;
 
 /**
  * DTO representing a post or comment author.
@@ -10,5 +11,6 @@ public class AuthorDto {
     private Long id;
     private String username;
     private String avatar;
+    private MedalType displayMedal;
 }
 

--- a/backend/src/main/java/com/openisle/dto/MedalDto.java
+++ b/backend/src/main/java/com/openisle/dto/MedalDto.java
@@ -10,4 +10,5 @@ public class MedalDto {
     private String description;
     private MedalType type;
     private boolean completed;
+    private boolean selected;
 }

--- a/backend/src/main/java/com/openisle/dto/MedalSelectRequest.java
+++ b/backend/src/main/java/com/openisle/dto/MedalSelectRequest.java
@@ -1,0 +1,9 @@
+package com.openisle.dto;
+
+import com.openisle.model.MedalType;
+import lombok.Data;
+
+@Data
+public class MedalSelectRequest {
+    private MedalType type;
+}

--- a/backend/src/main/java/com/openisle/mapper/UserMapper.java
+++ b/backend/src/main/java/com/openisle/mapper/UserMapper.java
@@ -31,6 +31,7 @@ public class UserMapper {
         dto.setId(user.getId());
         dto.setUsername(user.getUsername());
         dto.setAvatar(user.getAvatar());
+        dto.setDisplayMedal(user.getDisplayMedal());
         return dto;
     }
 

--- a/backend/src/main/java/com/openisle/model/User.java
+++ b/backend/src/main/java/com/openisle/model/User.java
@@ -59,6 +59,9 @@ public class User {
     @Column(nullable = false)
     private Role role = Role.USER;
 
+    @Enumerated(EnumType.STRING)
+    private MedalType displayMedal;
+
     @CreationTimestamp
     @Column(nullable = false, updatable = false,
             columnDefinition = "DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6)")

--- a/backend/src/test/java/com/openisle/controller/MedalControllerTest.java
+++ b/backend/src/test/java/com/openisle/controller/MedalControllerTest.java
@@ -9,11 +9,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -48,5 +50,25 @@ class MedalControllerTest {
         mockMvc.perform(get("/api/medals").param("userId", "1"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].completed").value(true));
+    }
+
+    @Test
+    void selectMedal() throws Exception {
+        mockMvc.perform(post("/api/medals/select")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"type\":\"COMMENT\"}")
+                .principal(() -> "user"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void selectMedalBadRequest() throws Exception {
+        Mockito.doThrow(new IllegalArgumentException()).when(medalService)
+                .selectMedal("user", MedalType.COMMENT);
+        mockMvc.perform(post("/api/medals/select")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"type\":\"COMMENT\"}")
+                .principal(() -> "user"))
+                .andExpect(status().isBadRequest());
     }
 }

--- a/backend/src/test/java/com/openisle/service/MedalServiceTest.java
+++ b/backend/src/test/java/com/openisle/service/MedalServiceTest.java
@@ -41,13 +41,55 @@ class MedalServiceTest {
         User user = new User();
         user.setId(1L);
         user.setCreatedAt(LocalDateTime.of(2025, 9, 15, 0, 0));
+        user.setDisplayMedal(MedalType.COMMENT);
         when(userRepo.findById(1L)).thenReturn(Optional.of(user));
+        when(userRepo.findByUsername("user")).thenReturn(Optional.of(user));
 
         MedalService service = new MedalService(commentRepo, postRepo, userRepo);
         List<MedalDto> medals = service.getMedals(1L);
 
         assertTrue(medals.stream().filter(m -> m.getType() == MedalType.COMMENT).findFirst().orElseThrow().isCompleted());
+        assertTrue(medals.stream().filter(m -> m.getType() == MedalType.COMMENT).findFirst().orElseThrow().isSelected());
         assertFalse(medals.stream().filter(m -> m.getType() == MedalType.POST).findFirst().orElseThrow().isCompleted());
+        assertFalse(medals.stream().filter(m -> m.getType() == MedalType.POST).findFirst().orElseThrow().isSelected());
         assertTrue(medals.stream().filter(m -> m.getType() == MedalType.SEED).findFirst().orElseThrow().isCompleted());
+        assertFalse(medals.stream().filter(m -> m.getType() == MedalType.SEED).findFirst().orElseThrow().isSelected());
+    }
+
+    @Test
+    void selectMedal() {
+        CommentRepository commentRepo = mock(CommentRepository.class);
+        PostRepository postRepo = mock(PostRepository.class);
+        UserRepository userRepo = mock(UserRepository.class);
+
+        when(commentRepo.countByAuthor_Id(1L)).thenReturn(120L);
+        when(postRepo.countByAuthor_Id(1L)).thenReturn(0L);
+        User user = new User();
+        user.setId(1L);
+        user.setCreatedAt(LocalDateTime.of(2025, 9, 15, 0, 0));
+        when(userRepo.findByUsername("user")).thenReturn(Optional.of(user));
+        when(userRepo.findById(1L)).thenReturn(Optional.of(user));
+
+        MedalService service = new MedalService(commentRepo, postRepo, userRepo);
+        service.selectMedal("user", MedalType.COMMENT);
+        assertEquals(MedalType.COMMENT, user.getDisplayMedal());
+    }
+
+    @Test
+    void selectMedalNotCompleted() {
+        CommentRepository commentRepo = mock(CommentRepository.class);
+        PostRepository postRepo = mock(PostRepository.class);
+        UserRepository userRepo = mock(UserRepository.class);
+
+        when(commentRepo.countByAuthor_Id(1L)).thenReturn(10L);
+        when(postRepo.countByAuthor_Id(1L)).thenReturn(0L);
+        User user = new User();
+        user.setId(1L);
+        user.setCreatedAt(LocalDateTime.of(2025, 9, 15, 0, 0));
+        when(userRepo.findByUsername("user")).thenReturn(Optional.of(user));
+        when(userRepo.findById(1L)).thenReturn(Optional.of(user));
+
+        MedalService service = new MedalService(commentRepo, postRepo, userRepo);
+        assertThrows(IllegalArgumentException.class, () -> service.selectMedal("user", MedalType.COMMENT));
     }
 }

--- a/frontend_nuxt/components/CommentItem.vue
+++ b/frontend_nuxt/components/CommentItem.vue
@@ -11,6 +11,7 @@
       <div class="common-info-content-header">
         <div class="info-content-header-left">
           <span class="user-name">{{ comment.userName }}</span>
+          <span v-if="comment.medal" class="medal-name">{{ getMedalTitle(comment.medal) }}</span>
           <span v-if="level >= 2">
             <i class="fas fa-reply reply-icon"></i>
             <span class="user-name reply-user-name">{{ comment.parentUserName }}</span>
@@ -64,6 +65,7 @@ import VueEasyLightbox from 'vue-easy-lightbox'
 import { useRouter } from 'vue-router'
 import CommentEditor from './CommentEditor.vue'
 import { renderMarkdown, handleMarkdownClick } from '../utils/markdown'
+import { getMedalTitle } from '../utils/medal'
 import TimeManager from '../utils/time'
 import BaseTimeline from './BaseTimeline.vue'
 import { API_BASE_URL, toast } from '../main'
@@ -232,7 +234,7 @@ const CommentItem = {
         lightboxVisible.value = true
       }
     }
-    return { showReplies, toggleReplies, showEditor, toggleEditor, submitReply, copyCommentLink, renderMarkdown, isWaitingForReply, commentMenuItems, deleteComment, lightboxVisible, lightboxIndex, lightboxImgs, handleContentClick, loggedIn, replyCount, replyList }
+    return { showReplies, toggleReplies, showEditor, toggleEditor, submitReply, copyCommentLink, renderMarkdown, isWaitingForReply, commentMenuItems, deleteComment, lightboxVisible, lightboxIndex, lightboxImgs, handleContentClick, loggedIn, replyCount, replyList, getMedalTitle }
   }
 }
 
@@ -281,6 +283,12 @@ export default CommentItem
 
 .reply-user-name {
   opacity: 0.3;
+}
+
+.medal-name {
+  font-size: 12px;
+  margin-left: 4px;
+  opacity: 0.6;
 }
 
 @keyframes highlight {

--- a/frontend_nuxt/pages/posts/[id]/index.vue
+++ b/frontend_nuxt/pages/posts/[id]/index.vue
@@ -41,14 +41,20 @@
             <img class="user-avatar-item-img" :src="author.avatar" alt="avatar">
           </div>
           <div v-if="isMobile" class="info-content-header">
-            <div class="user-name">{{ author.username }}</div>
+            <div class="user-name">
+              {{ author.username }}
+              <span v-if="author.displayMedal" class="user-medal">{{ getMedalTitle(author.displayMedal) }}</span>
+            </div>
             <div class="post-time">{{ postTime }}</div>
           </div>
         </div>
 
         <div class="info-content">
           <div v-if="!isMobile" class="info-content-header">
-            <div class="user-name">{{ author.username }}</div>
+            <div class="user-name">
+              {{ author.username }}
+              <span v-if="author.displayMedal" class="user-medal">{{ getMedalTitle(author.displayMedal) }}</span>
+            </div>
             <div class="post-time">{{ postTime }}</div>
           </div>
           <div class="info-content-text" v-html="renderMarkdown(postContent)" @click="handleContentClick"></div>
@@ -116,6 +122,7 @@ import ArticleCategory from '../../../components/ArticleCategory.vue'
 import ReactionsGroup from '../../../components/ReactionsGroup.vue'
 import DropdownMenu from '../../../components/DropdownMenu.vue'
 import { renderMarkdown, handleMarkdownClick, stripMarkdownLength } from '../../../utils/markdown'
+import { getMedalTitle } from '../../../utils/medal'
 import { API_BASE_URL, toast } from '../../../main'
 import { getToken, authState } from '../../../utils/auth'
 import TimeManager from '../../../utils/time'
@@ -228,6 +235,7 @@ export default {
     const mapComment = (c, parentUserName = '', level = 0) => ({
       id: c.id,
       userName: c.author.username,
+      medal: c.author.displayMedal,
       time: TimeManager.format(c.createdAt),
       avatar: c.author.avatar,
       text: c.content,
@@ -648,6 +656,8 @@ export default {
       commentSort,
       fetchCommentSorts,
       isFetchingComments
+      ,
+      getMedalTitle
     }
   }
 }
@@ -926,6 +936,12 @@ export default {
   opacity: 0.7;
 }
 
+.user-medal {
+  font-size: 12px;
+  margin-left: 4px;
+  opacity: 0.6;
+}
+
 .post-time {
   font-size: 14px;
   opacity: 0.5;
@@ -988,6 +1004,10 @@ export default {
 
   .user-name {
     font-size: 14px;
+  }
+
+  .user-medal {
+    font-size: 12px;
   }
 
   .post-time {

--- a/frontend_nuxt/pages/users/[id].vue
+++ b/frontend_nuxt/pages/users/[id].vue
@@ -244,7 +244,7 @@
         </div>
 
         <div v-else-if="selectedTab === 'achievements'" class="achievements-container">
-          <AchievementList :medals="medals" />
+          <AchievementList :medals="medals" :can-select="isMine" />
         </div>
       </template>
     </div>

--- a/frontend_nuxt/utils/medal.js
+++ b/frontend_nuxt/utils/medal.js
@@ -1,0 +1,9 @@
+export const medalTitles = {
+  COMMENT: '评论达人',
+  POST: '发帖达人',
+  SEED: '种子用户'
+}
+
+export function getMedalTitle(type) {
+  return medalTitles[type] || ''
+}


### PR DESCRIPTION
## Summary
- allow users to choose a display medal and store it on profile
- show selected medal names next to usernames on posts and comments
- add front-end medal selection UI with validation

## Testing
- `mvn -q test` *(failed: Network is unreachable)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68975b4974dc8327adaf18b1dda48999