### PR TITLE
feat: default medal selection and clickable profile links

### DIFF
--- a/frontend_nuxt/components/AchievementList.vue
+++ b/frontend_nuxt/components/AchievementList.vue
@@ -27,7 +27,7 @@
 </template>
 
 <script setup>
-import { computed } from 'vue'
+import { computed, onMounted, watch } from 'vue'
 import { API_BASE_URL, toast } from '../main'
 import { getToken } from '../utils/auth'
 
@@ -75,6 +75,18 @@ const selectMedal = async (medal) => {
     toast('选择勋章失败')
   }
 }
+
+const ensureSelected = () => {
+  if (!props.canSelect) return
+  const selected = props.medals.some(m => m.selected)
+  if (!selected) {
+    const firstCompleted = props.medals.find(m => m.completed)
+    if (firstCompleted) selectMedal(firstCompleted)
+  }
+}
+
+onMounted(ensureSelected)
+watch(() => props.medals, ensureSelected, { deep: true })
 
 </script>
 

--- a/frontend_nuxt/components/CommentItem.vue
+++ b/frontend_nuxt/components/CommentItem.vue
@@ -11,7 +11,7 @@
       <div class="common-info-content-header">
         <div class="info-content-header-left">
           <span class="user-name">{{ comment.userName }}</span>
-          <span v-if="comment.medal" class="medal-name">{{ getMedalTitle(comment.medal) }}</span>
+          <span v-if="comment.medal" class="medal-name" @click="gotoMedals(comment.userId)">{{ getMedalTitle(comment.medal) }}</span>
           <span v-if="level >= 2">
             <i class="fas fa-reply reply-icon"></i>
             <span class="user-name reply-user-name">{{ comment.parentUserName }}</span>
@@ -113,6 +113,10 @@ const CommentItem = {
     }
     const toggleEditor = () => {
       showEditor.value = !showEditor.value
+    }
+
+    const gotoMedals = (id) => {
+      router.push({ path: `/users/${id}`, query: { tab: 'achievements' } })
     }
 
     // 合并所有子回复为一个扁平数组
@@ -234,7 +238,7 @@ const CommentItem = {
         lightboxVisible.value = true
       }
     }
-    return { showReplies, toggleReplies, showEditor, toggleEditor, submitReply, copyCommentLink, renderMarkdown, isWaitingForReply, commentMenuItems, deleteComment, lightboxVisible, lightboxIndex, lightboxImgs, handleContentClick, loggedIn, replyCount, replyList, getMedalTitle }
+    return { showReplies, toggleReplies, showEditor, toggleEditor, submitReply, copyCommentLink, renderMarkdown, isWaitingForReply, commentMenuItems, deleteComment, lightboxVisible, lightboxIndex, lightboxImgs, handleContentClick, loggedIn, replyCount, replyList, getMedalTitle, gotoMedals }
   }
 }
 
@@ -289,6 +293,7 @@ export default CommentItem
   font-size: 12px;
   margin-left: 4px;
   opacity: 0.6;
+  cursor: pointer;
 }
 
 @keyframes highlight {

--- a/frontend_nuxt/pages/posts/[id]/index.vue
+++ b/frontend_nuxt/pages/posts/[id]/index.vue
@@ -43,7 +43,11 @@
           <div v-if="isMobile" class="info-content-header">
             <div class="user-name">
               {{ author.username }}
-              <span v-if="author.displayMedal" class="user-medal">{{ getMedalTitle(author.displayMedal) }}</span>
+              <span
+                v-if="author.displayMedal"
+                class="user-medal"
+                @click="gotoUserMedals(author.id)"
+              >{{ getMedalTitle(author.displayMedal) }}</span>
             </div>
             <div class="post-time">{{ postTime }}</div>
           </div>
@@ -53,7 +57,11 @@
           <div v-if="!isMobile" class="info-content-header">
             <div class="user-name">
               {{ author.username }}
-              <span v-if="author.displayMedal" class="user-medal">{{ getMedalTitle(author.displayMedal) }}</span>
+              <span
+                v-if="author.displayMedal"
+                class="user-medal"
+                @click="gotoUserMedals(author.id)"
+              >{{ getMedalTitle(author.displayMedal) }}</span>
             </div>
             <div class="post-time">{{ postTime }}</div>
           </div>
@@ -234,6 +242,7 @@ export default {
 
     const mapComment = (c, parentUserName = '', level = 0) => ({
       id: c.id,
+      userId: c.author.id,
       userName: c.author.username,
       medal: c.author.displayMedal,
       time: TimeManager.format(c.createdAt),
@@ -598,6 +607,10 @@ export default {
       router.push(`/users/${author.value.id}`)
     }
 
+    const gotoUserMedals = (id) => {
+      router.push({ path: `/users/${id}`, query: { tab: 'achievements' } })
+    }
+
     await fetchPost()
 
     onMounted(async () => {
@@ -635,6 +648,7 @@ export default {
       isWaitingFetchingPost,
       isWaitingPostingComment,
       gotoProfile,
+      gotoUserMedals,
       subscribed,
       loggedIn,
       isAuthor,
@@ -940,6 +954,7 @@ export default {
   font-size: 12px;
   margin-left: 4px;
   opacity: 0.6;
+  cursor: pointer;
 }
 
 .post-time {
@@ -1008,6 +1023,7 @@ export default {
 
   .user-medal {
     font-size: 12px;
+    cursor: pointer;
   }
 
   .post-time {


### PR DESCRIPTION
## Summary
- auto-select a completed medal when none chosen
- allow clicking post and comment medals to view user achievements

## Testing
- `npm test`
- `mvn -q test` *(fails: Non-resolvable parent POM for com.openisle:openisle)*

------
https://chatgpt.com/codex/tasks/task_e_68977508fc4c83278dcedce8624f8cea