### PR TITLE
feat: auto select medals and improve navigation

### DIFF
--- a/backend/src/main/java/com/openisle/service/MedalService.java
+++ b/backend/src/main/java/com/openisle/service/MedalService.java
@@ -82,6 +82,16 @@ public class MedalService {
         }
         seedUserMedal.setSelected(selected == MedalType.SEED);
         medals.add(seedUserMedal);
+        if (user != null && selected == null) {
+            for (MedalDto medal : medals) {
+                if (medal.isCompleted()) {
+                    medal.setSelected(true);
+                    user.setDisplayMedal(medal.getType());
+                    userRepository.save(user);
+                    break;
+                }
+            }
+        }
 
         return medals;
     }

--- a/backend/src/test/java/com/openisle/service/MedalServiceTest.java
+++ b/backend/src/test/java/com/openisle/service/MedalServiceTest.java
@@ -41,19 +41,20 @@ class MedalServiceTest {
         User user = new User();
         user.setId(1L);
         user.setCreatedAt(LocalDateTime.of(2025, 9, 15, 0, 0));
-        user.setDisplayMedal(MedalType.COMMENT);
         when(userRepo.findById(1L)).thenReturn(Optional.of(user));
         when(userRepo.findByUsername("user")).thenReturn(Optional.of(user));
 
         MedalService service = new MedalService(commentRepo, postRepo, userRepo);
         List<MedalDto> medals = service.getMedals(1L);
 
+        assertEquals(MedalType.COMMENT, user.getDisplayMedal());
         assertTrue(medals.stream().filter(m -> m.getType() == MedalType.COMMENT).findFirst().orElseThrow().isCompleted());
         assertTrue(medals.stream().filter(m -> m.getType() == MedalType.COMMENT).findFirst().orElseThrow().isSelected());
         assertFalse(medals.stream().filter(m -> m.getType() == MedalType.POST).findFirst().orElseThrow().isCompleted());
         assertFalse(medals.stream().filter(m -> m.getType() == MedalType.POST).findFirst().orElseThrow().isSelected());
         assertTrue(medals.stream().filter(m -> m.getType() == MedalType.SEED).findFirst().orElseThrow().isCompleted());
         assertFalse(medals.stream().filter(m -> m.getType() == MedalType.SEED).findFirst().orElseThrow().isSelected());
+        verify(userRepo).save(user);
     }
 
     @Test

--- a/frontend_nuxt/components/AchievementList.vue
+++ b/frontend_nuxt/components/AchievementList.vue
@@ -3,7 +3,7 @@
     <div
       v-for="medal in sortedMedals"
       :key="medal.type"
-      :class="['achievements-list-item', { select: medal.selected, clickable: canSelect }]"
+      :class="['achievements-list-item', { select: medal.selected && canSelect, clickable: canSelect }]"
       @click="selectMedal(medal)"
     >
       <img
@@ -11,7 +11,7 @@
         :alt="medal.title"
         :class="['achievements-list-item-icon', { not_completed: !medal.completed }]"
       />
-      <div v-if="medal.selected" class="achievements-list-item-top-right-label">展示</div>
+      <div v-if="medal.selected && canSelect" class="achievements-list-item-top-right-label">展示</div>
       <div class="achievements-list-item-title">{{ medal.title }}</div>
       <div class="achievements-list-item-description">
         {{ medal.description }}

--- a/frontend_nuxt/components/CommentItem.vue
+++ b/frontend_nuxt/components/CommentItem.vue
@@ -11,7 +11,11 @@
       <div class="common-info-content-header">
         <div class="info-content-header-left">
           <span class="user-name">{{ comment.userName }}</span>
-          <span v-if="comment.medal" class="medal-name">{{ getMedalTitle(comment.medal) }}</span>
+          <router-link
+            v-if="comment.medal"
+            class="medal-name"
+            :to="`/users/${comment.userId}?tab=achievements`"
+          >{{ getMedalTitle(comment.medal) }}</router-link>
           <span v-if="level >= 2">
             <i class="fas fa-reply reply-icon"></i>
             <span class="user-name reply-user-name">{{ comment.parentUserName }}</span>
@@ -289,6 +293,7 @@ export default CommentItem
   font-size: 12px;
   margin-left: 4px;
   opacity: 0.6;
+  cursor: pointer;
 }
 
 @keyframes highlight {

--- a/frontend_nuxt/pages/posts/[id]/index.vue
+++ b/frontend_nuxt/pages/posts/[id]/index.vue
@@ -43,7 +43,11 @@
           <div v-if="isMobile" class="info-content-header">
             <div class="user-name">
               {{ author.username }}
-              <span v-if="author.displayMedal" class="user-medal">{{ getMedalTitle(author.displayMedal) }}</span>
+              <router-link
+                v-if="author.displayMedal"
+                class="user-medal"
+                :to="`/users/${author.id}?tab=achievements`"
+              >{{ getMedalTitle(author.displayMedal) }}</router-link>
             </div>
             <div class="post-time">{{ postTime }}</div>
           </div>
@@ -53,7 +57,11 @@
           <div v-if="!isMobile" class="info-content-header">
             <div class="user-name">
               {{ author.username }}
-              <span v-if="author.displayMedal" class="user-medal">{{ getMedalTitle(author.displayMedal) }}</span>
+              <router-link
+                v-if="author.displayMedal"
+                class="user-medal"
+                :to="`/users/${author.id}?tab=achievements`"
+              >{{ getMedalTitle(author.displayMedal) }}</router-link>
             </div>
             <div class="post-time">{{ postTime }}</div>
           </div>
@@ -236,6 +244,7 @@ export default {
       id: c.id,
       userName: c.author.username,
       medal: c.author.displayMedal,
+      userId: c.author.id,
       time: TimeManager.format(c.createdAt),
       avatar: c.author.avatar,
       text: c.content,
@@ -940,6 +949,7 @@ export default {
   font-size: 12px;
   margin-left: 4px;
   opacity: 0.6;
+  cursor: pointer;
 }
 
 .post-time {


### PR DESCRIPTION
## Summary
- default to first completed medal when user has no display medal
- allow clicking medals on posts and comments to open user achievement tab
- hide medal selection UI when viewing other users

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68977c8cab708327aa4bbdeb81a07c66