### PR TITLE
feat: add contributor achievement

### DIFF
--- a/backend/src/main/java/com/openisle/OpenIsleApplication.java
+++ b/backend/src/main/java/com/openisle/OpenIsleApplication.java
@@ -2,8 +2,10 @@ package com.openisle;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class OpenIsleApplication {
     public static void main(String[] args) {
         SpringApplication.run(OpenIsleApplication.class, args);

--- a/backend/src/main/java/com/openisle/dto/ContributorMedalDto.java
+++ b/backend/src/main/java/com/openisle/dto/ContributorMedalDto.java
@@ -1,0 +1,12 @@
+package com.openisle.dto;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class ContributorMedalDto extends MedalDto {
+    private long currentContributionLines;
+    private long targetContributionLines;
+}
+

--- a/backend/src/main/java/com/openisle/model/ContributorConfig.java
+++ b/backend/src/main/java/com/openisle/model/ContributorConfig.java
@@ -1,0 +1,27 @@
+package com.openisle.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@Table(name = "contributor_configs")
+public class ContributorConfig {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String userIname;
+
+    @Column(nullable = false, unique = true)
+    private String githubId;
+
+    @Column(nullable = false)
+    private long contributionLines = 0;
+}
+

--- a/backend/src/main/java/com/openisle/model/MedalType.java
+++ b/backend/src/main/java/com/openisle/model/MedalType.java
@@ -3,5 +3,6 @@ package com.openisle.model;
 public enum MedalType {
     COMMENT,
     POST,
+    CONTRIBUTOR,
     SEED
 }

--- a/backend/src/main/java/com/openisle/repository/ContributorConfigRepository.java
+++ b/backend/src/main/java/com/openisle/repository/ContributorConfigRepository.java
@@ -1,0 +1,11 @@
+package com.openisle.repository;
+
+import com.openisle.model.ContributorConfig;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ContributorConfigRepository extends JpaRepository<ContributorConfig, Long> {
+    Optional<ContributorConfig> findByUserIname(String userIname);
+}
+

--- a/backend/src/main/java/com/openisle/service/ContributorService.java
+++ b/backend/src/main/java/com/openisle/service/ContributorService.java
@@ -1,0 +1,73 @@
+package com.openisle.service;
+
+import com.openisle.model.ContributorConfig;
+import com.openisle.repository.ContributorConfigRepository;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class ContributorService {
+    private static final String OWNER = "OpenIsle";
+    private static final String REPO = "OpenIsle";
+
+    private final ContributorConfigRepository repository;
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    @PostConstruct
+    @Scheduled(cron = "0 0 * * * *")
+    public void updateContributions() {
+        for (ContributorConfig config : repository.findAll()) {
+            long lines = fetchContributionLines(config.getGithubId());
+            config.setContributionLines(lines);
+            repository.save(config);
+        }
+    }
+
+    private long fetchContributionLines(String githubId) {
+        try {
+            String url = String.format("https://api.github.com/repos/%s/%s/stats/contributors", OWNER, REPO);
+            ResponseEntity<List> response = restTemplate.getForEntity(url, List.class);
+            List<Map<String, Object>> body = response.getBody();
+            if (body == null) {
+                return 0;
+            }
+            for (Map<String, Object> item : body) {
+                Map<String, Object> author = (Map<String, Object>) item.get("author");
+                if (author != null && githubId.equals(author.get("login"))) {
+                    List<Map<String, Object>> weeks = (List<Map<String, Object>>) item.get("weeks");
+                    long total = 0;
+                    if (weeks != null) {
+                        for (Map<String, Object> week : weeks) {
+                            Number a = (Number) week.get("a");
+                            Number d = (Number) week.get("d");
+                            if (a != null) {
+                                total += a.longValue();
+                            }
+                            if (d != null) {
+                                total += d.longValue();
+                            }
+                        }
+                    }
+                    return total;
+                }
+            }
+        } catch (Exception ignored) {
+        }
+        return 0;
+    }
+
+    public long getContributionLines(String userIname) {
+        return repository.findByUserIname(userIname)
+                .map(ContributorConfig::getContributionLines)
+                .orElse(0L);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add contributor medal type with current/target lines
- store GitHub mapping in contributor_configs table
- schedule hourly job to sync GitHub contributions

## Testing
- `cd backend && mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689783f622e48327a65d278b8a956c95