### PR TITLE
Reset auth on token expiry

### DIFF
--- a/frontend_nuxt/plugins/auth-fetch.client.ts
+++ b/frontend_nuxt/plugins/auth-fetch.client.ts
@@ -1,0 +1,21 @@
+import { clearToken } from '~/utils/auth'
+
+export default defineNuxtPlugin(() => {
+  if (process.client) {
+    const originalFetch = window.fetch
+    window.fetch = async (input, init) => {
+      const response = await originalFetch(input, init)
+      if (response.status === 401) {
+        try {
+          const data = await response.clone().json()
+          if (data && data.error === 'Invalid or expired token') {
+            clearToken()
+          }
+        } catch (e) {
+          // ignore JSON parsing errors
+        }
+      }
+      return response
+    }
+  }
+})


### PR DESCRIPTION
## Summary
- Clear auth token on 401 Invalid/Expired responses

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689816a8653c8327a26a08de1b95bcdc