### PR TITLE
fix: correct SSR mobile detection

### DIFF
--- a/frontend_nuxt/utils/screen.js
+++ b/frontend_nuxt/utils/screen.js
@@ -1,5 +1,5 @@
 import { ref, computed, onUnmounted } from 'vue'
-import { useRequestHeaders } from 'nuxt/app'
+import { useRequestHeaders, useRequestEvent } from 'nuxt/app'
 
 export const useIsMobile = () => {
   const width = ref(0)
@@ -7,12 +7,15 @@ export const useIsMobile = () => {
 
   const isMobileUserAgent = () => {
     let userAgent = ''
+    let mobileHint = ''
 
     if (typeof navigator !== 'undefined') {
       userAgent = navigator.userAgent.toLowerCase()
     } else {
-      const headers = useRequestHeaders(['user-agent'])
+      const event = useRequestEvent()
+      const headers = event?.node?.req?.headers || useRequestHeaders()
       userAgent = (headers['user-agent'] || '').toLowerCase()
+      mobileHint = (headers['sec-ch-ua-mobile'] || '').toLowerCase()
     }
 
     const mobileKeywords = [
@@ -20,7 +23,7 @@ export const useIsMobile = () => {
       'mobile', 'tablet', 'opera mini', 'iemobile'
     ]
 
-    return mobileKeywords.some(keyword => userAgent.includes(keyword))
+    return mobileHint.includes('?1') || mobileKeywords.some(keyword => userAgent.includes(keyword))
   }
 
   if (typeof window !== 'undefined') {


### PR DESCRIPTION
## Summary
- improve mobile detection during SSR by inspecting `user-agent` and `sec-ch-ua-mobile` headers

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689860315bb48327bc4309d05f1b0ce1