### PR TITLE
fix: detect mobile on server during SSR

### DIFF
--- a/frontend_nuxt/utils/screen.js
+++ b/frontend_nuxt/utils/screen.js
@@ -1,5 +1,5 @@
 import { ref, computed, onUnmounted } from 'vue'
-import { useRequestHeaders } from 'nuxt/app'
+import { useRequestEvent } from 'nuxt/app'
 
 export const useIsMobile = () => {
   const width = ref(0)
@@ -11,8 +11,8 @@ export const useIsMobile = () => {
     if (typeof navigator !== 'undefined') {
       userAgent = navigator.userAgent.toLowerCase()
     } else {
-      const headers = useRequestHeaders(['user-agent'])
-      userAgent = (headers['user-agent'] || '').toLowerCase()
+      const event = useRequestEvent()
+      userAgent = (event?.node?.req?.headers['user-agent'] || '').toLowerCase()
     }
 
     const mobileKeywords = [


### PR DESCRIPTION
## Summary
- ensure server-side user-agent detection uses request headers

## Testing
- `cd frontend_nuxt && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689860315bb48327bc4309d05f1b0ce1