### PR TITLE
fix: ensure unique avatar keys on home page

### DIFF
--- a/frontend_nuxt/pages/index.vue
+++ b/frontend_nuxt/pages/index.vue
@@ -71,7 +71,7 @@
           <div class="article-member-avatars-container">
             <NuxtLink
               v-for="member in article.members"
-              :key="member.id"
+              :key="`${article.id}-${member.id}`"
               class="article-member-avatar-item"
               :to="`/users/${member.id}`"
             >


### PR DESCRIPTION
## Summary
- fix avatar mix-up by using unique keys per post and member

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689825adccf0832799565b968461ae7c