### PR TITLE
feat: add lottery post fields

### DIFF
--- a/frontend_nuxt/components/PostTypeSelect.vue
+++ b/frontend_nuxt/components/PostTypeSelect.vue
@@ -1,0 +1,27 @@
+<template>
+  <Dropdown v-model="selected" :fetch-options="fetchOptions" placeholder="帖子类型" :initial-options="options" />
+</template>
+
+<script>
+import { computed } from 'vue'
+import Dropdown from '~/components/Dropdown.vue'
+
+export default {
+  name: 'PostTypeSelect',
+  components: { Dropdown },
+  props: { modelValue: { type: String, default: 'NORMAL' } },
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    const options = [
+      { id: 'NORMAL', name: '普通帖' },
+      { id: 'LOTTERY', name: '抽奖贴' }
+    ]
+    const fetchOptions = async () => options
+    const selected = computed({
+      get: () => props.modelValue,
+      set: v => emit('update:modelValue', v)
+    })
+    return { selected, fetchOptions, options }
+  }
+}
+</script>


### PR DESCRIPTION
## Summary
- add post type dropdown on new post page
- show prize image, quantity, and end time inputs for lottery posts
- handle uploading and submitting lottery post data

## Testing
- `npm test` *(fails: Missing script "test")*
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6898d5baf32c8327b4c678e843d24971