### PR TITLE
Reschedule lottery finalization on startup

### DIFF
--- a/backend/src/main/java/com/openisle/repository/LotteryPostRepository.java
+++ b/backend/src/main/java/com/openisle/repository/LotteryPostRepository.java
@@ -3,5 +3,11 @@ package com.openisle.repository;
 import com.openisle.model.LotteryPost;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 public interface LotteryPostRepository extends JpaRepository<LotteryPost, Long> {
+    List<LotteryPost> findByEndTimeAfterAndWinnersIsEmpty(LocalDateTime now);
+
+    List<LotteryPost> findByEndTimeBeforeAndWinnersIsEmpty(LocalDateTime now);
 }


### PR DESCRIPTION
## Summary
- reschedule unfinished lottery posts when service starts
- finalize overdue lotteries immediately on restart
- add repository queries for pending lottery posts

## Testing
- `mvn -q test` *(failed: Non-resolvable parent POM ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689952714f6c832793c3fb46fc1308a7