### PR TITLE
Avoid PostService self-dependency at startup

### DIFF
--- a/backend/src/main/java/com/openisle/service/PostService.java
+++ b/backend/src/main/java/com/openisle/service/PostService.java
@@ -43,8 +43,8 @@ import java.util.HashSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledFuture;
-
-import jakarta.annotation.PostConstruct;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
 
 @Slf4j
 @Service
@@ -108,8 +108,8 @@ public class PostService {
         this.publishMode = publishMode;
     }
 
-    @PostConstruct
-    private void rescheduleLotteries() {
+    @EventListener(ApplicationReadyEvent.class)
+    public void rescheduleLotteries() {
         LocalDateTime now = LocalDateTime.now();
         for (LotteryPost lp : lotteryPostRepository.findByEndTimeAfterAndWinnersIsEmpty(now)) {
             ScheduledFuture<?> future = taskScheduler.schedule(


### PR DESCRIPTION
## Summary
- trigger lottery rescheduling on ApplicationReadyEvent instead of PostConstruct

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.1.1)*

------
https://chatgpt.com/codex/tasks/task_e_68995dc5c1508327b663454713e677e0