### PR TITLE
feat: add pioneer medal for first 1000 users

### DIFF
--- a/backend/src/main/java/com/openisle/dto/PioneerMedalDto.java
+++ b/backend/src/main/java/com/openisle/dto/PioneerMedalDto.java
@@ -1,0 +1,10 @@
+package com.openisle.dto;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class PioneerMedalDto extends MedalDto {
+    private long rank;
+}

--- a/backend/src/main/java/com/openisle/model/MedalType.java
+++ b/backend/src/main/java/com/openisle/model/MedalType.java
@@ -4,5 +4,6 @@ public enum MedalType {
     COMMENT,
     POST,
     CONTRIBUTOR,
-    SEED
+    SEED,
+    PIONEER
 }

--- a/backend/src/main/java/com/openisle/repository/UserRepository.java
+++ b/backend/src/main/java/com/openisle/repository/UserRepository.java
@@ -2,6 +2,7 @@ package com.openisle.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import com.openisle.model.User;
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -10,4 +11,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
     java.util.List<User> findByUsernameContainingIgnoreCase(String keyword);
     java.util.List<User> findByRole(com.openisle.model.Role role);
     long countByExperienceGreaterThanEqual(int experience);
+    long countByCreatedAtBefore(LocalDateTime createdAt);
 }

--- a/backend/src/test/java/com/openisle/service/MedalServiceTest.java
+++ b/backend/src/test/java/com/openisle/service/MedalServiceTest.java
@@ -27,7 +27,7 @@ class MedalServiceTest {
 
         List<MedalDto> medals = service.getMedals(null);
         medals.forEach(m -> assertFalse(m.isCompleted()));
-        assertEquals(4, medals.size());
+        assertEquals(5, medals.size());
     }
 
     @Test
@@ -40,6 +40,7 @@ class MedalServiceTest {
         when(commentRepo.countByAuthor_Id(1L)).thenReturn(120L);
         when(postRepo.countByAuthor_Id(1L)).thenReturn(80L);
         when(contributorService.getContributionLines(anyString())).thenReturn(0L);
+        when(userRepo.countByCreatedAtBefore(any())).thenReturn(50L);
         User user = new User();
         user.setId(1L);
         user.setCreatedAt(LocalDateTime.of(2025, 9, 15, 0, 0));
@@ -56,6 +57,8 @@ class MedalServiceTest {
         assertFalse(medals.stream().filter(m -> m.getType() == MedalType.POST).findFirst().orElseThrow().isSelected());
         assertTrue(medals.stream().filter(m -> m.getType() == MedalType.SEED).findFirst().orElseThrow().isCompleted());
         assertFalse(medals.stream().filter(m -> m.getType() == MedalType.SEED).findFirst().orElseThrow().isSelected());
+        assertTrue(medals.stream().filter(m -> m.getType() == MedalType.PIONEER).findFirst().orElseThrow().isCompleted());
+        assertFalse(medals.stream().filter(m -> m.getType() == MedalType.PIONEER).findFirst().orElseThrow().isSelected());
         verify(userRepo).save(user);
     }
 
@@ -69,6 +72,7 @@ class MedalServiceTest {
         when(commentRepo.countByAuthor_Id(1L)).thenReturn(120L);
         when(postRepo.countByAuthor_Id(1L)).thenReturn(0L);
         when(contributorService.getContributionLines(anyString())).thenReturn(0L);
+        when(userRepo.countByCreatedAtBefore(any())).thenReturn(0L);
         User user = new User();
         user.setId(1L);
         user.setCreatedAt(LocalDateTime.of(2025, 9, 15, 0, 0));
@@ -90,6 +94,7 @@ class MedalServiceTest {
         when(commentRepo.countByAuthor_Id(1L)).thenReturn(10L);
         when(postRepo.countByAuthor_Id(1L)).thenReturn(0L);
         when(contributorService.getContributionLines(anyString())).thenReturn(0L);
+        when(userRepo.countByCreatedAtBefore(any())).thenReturn(0L);
         User user = new User();
         user.setId(1L);
         user.setCreatedAt(LocalDateTime.of(2025, 9, 15, 0, 0));

--- a/frontend_nuxt/components/AchievementList.vue
+++ b/frontend_nuxt/components/AchievementList.vue
@@ -29,6 +29,7 @@
         <template v-else-if="medal.type === 'CONTRIBUTOR'">
           {{ medal.currentContributionLines }}/{{ medal.targetContributionLines }}
         </template>
+        <template v-else-if="medal.type === 'PIONEER'"> 第{{ medal.rank }}位 </template>
       </div>
     </div>
   </div>

--- a/frontend_nuxt/utils/medal.js
+++ b/frontend_nuxt/utils/medal.js
@@ -3,6 +3,7 @@ export const medalTitles = {
   POST: '发帖达人',
   SEED: '种子用户',
   CONTRIBUTOR: '贡献者',
+  PIONEER: '开山鼻祖',
 }
 
 export function getMedalTitle(type) {


### PR DESCRIPTION
## Summary
- introduce PIONEER medal type for the first 1000 registered users
- expose rank progress and selection handling for pioneer users
- show pioneer progress on achievement list and include title mapping

## Testing
- `cd backend && mvn -q test` *(failed: Non-resolvable parent POM due to network)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6899dd2571c08327bdd822acc447b440