### PR TITLE
Use DTO for activity list

### DIFF
--- a/backend/src/main/java/com/openisle/controller/ActivityController.java
+++ b/backend/src/main/java/com/openisle/controller/ActivityController.java
@@ -1,7 +1,9 @@
 package com.openisle.controller;
 
+import com.openisle.dto.ActivityDto;
 import com.openisle.dto.MilkTeaInfoDto;
 import com.openisle.dto.MilkTeaRedeemRequest;
+import com.openisle.mapper.ActivityMapper;
 import com.openisle.model.Activity;
 import com.openisle.model.ActivityType;
 import com.openisle.model.User;
@@ -12,6 +14,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/activities")
@@ -19,10 +22,13 @@ import java.util.List;
 public class ActivityController {
     private final ActivityService activityService;
     private final UserService userService;
+    private final ActivityMapper activityMapper;
 
     @GetMapping
-    public List<Activity> list() {
-        return activityService.list();
+    public List<ActivityDto> list() {
+        return activityService.list().stream()
+                .map(activityMapper::toDto)
+                .collect(Collectors.toList());
     }
 
     @GetMapping("/milk-tea")

--- a/backend/src/main/java/com/openisle/dto/ActivityDto.java
+++ b/backend/src/main/java/com/openisle/dto/ActivityDto.java
@@ -1,0 +1,21 @@
+package com.openisle.dto;
+
+import com.openisle.model.ActivityType;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+/**
+ * DTO representing an activity without participant details.
+ */
+@Data
+public class ActivityDto {
+    private Long id;
+    private String title;
+    private String icon;
+    private String content;
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+    private ActivityType type;
+    private boolean ended;
+}

--- a/backend/src/main/java/com/openisle/mapper/ActivityMapper.java
+++ b/backend/src/main/java/com/openisle/mapper/ActivityMapper.java
@@ -1,0 +1,23 @@
+package com.openisle.mapper;
+
+import com.openisle.dto.ActivityDto;
+import com.openisle.model.Activity;
+import org.springframework.stereotype.Component;
+
+/** Mapper for activity entities. */
+@Component
+public class ActivityMapper {
+
+    public ActivityDto toDto(Activity a) {
+        ActivityDto dto = new ActivityDto();
+        dto.setId(a.getId());
+        dto.setTitle(a.getTitle());
+        dto.setIcon(a.getIcon());
+        dto.setContent(a.getContent());
+        dto.setStartTime(a.getStartTime());
+        dto.setEndTime(a.getEndTime());
+        dto.setType(a.getType());
+        dto.setEnded(a.isEnded());
+        return dto;
+    }
+}


### PR DESCRIPTION
## Summary
- hide participant data by exposing activities as DTOs
- map `Activity` entity to `ActivityDto` via new `ActivityMapper`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.openisle:openisle:0.0.1-SNAPSHOT: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.1.1)*

------
https://chatgpt.com/codex/tasks/task_e_689a2561bf98832780f78d31d2fe9805