### PR TITLE
feat: add daily stats reports

### DIFF
--- a/backend/src/main/java/com/openisle/controller/StatController.java
+++ b/backend/src/main/java/com/openisle/controller/StatController.java
@@ -1,6 +1,7 @@
 package com.openisle.controller;
 
 import com.openisle.service.UserVisitService;
+import com.openisle.service.StatService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,6 +18,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class StatController {
     private final UserVisitService userVisitService;
+    private final StatService statService;
 
     @GetMapping("/dau")
     public Map<String, Long> dau(@RequestParam(value = "date", required = false)
@@ -34,6 +36,48 @@ public class StatController {
         return data.entrySet().stream()
                 .map(e -> Map.<String,Object>of(
                         "date",  e.getKey().toString(),
+                        "value", e.getValue()
+                ))
+                .toList();
+    }
+
+    @GetMapping("/new-users-range")
+    public List<Map<String, Object>> newUsersRange(@RequestParam(value = "days", defaultValue = "30") int days) {
+        if (days < 1) days = 1;
+        LocalDate end = LocalDate.now();
+        LocalDate start = end.minusDays(days - 1L);
+        var data = statService.countNewUsersRange(start, end);
+        return data.entrySet().stream()
+                .map(e -> Map.<String,Object>of(
+                        "date", e.getKey().toString(),
+                        "value", e.getValue()
+                ))
+                .toList();
+    }
+
+    @GetMapping("/posts-range")
+    public List<Map<String, Object>> postsRange(@RequestParam(value = "days", defaultValue = "30") int days) {
+        if (days < 1) days = 1;
+        LocalDate end = LocalDate.now();
+        LocalDate start = end.minusDays(days - 1L);
+        var data = statService.countPostsRange(start, end);
+        return data.entrySet().stream()
+                .map(e -> Map.<String,Object>of(
+                        "date", e.getKey().toString(),
+                        "value", e.getValue()
+                ))
+                .toList();
+    }
+
+    @GetMapping("/comments-range")
+    public List<Map<String, Object>> commentsRange(@RequestParam(value = "days", defaultValue = "30") int days) {
+        if (days < 1) days = 1;
+        LocalDate end = LocalDate.now();
+        LocalDate start = end.minusDays(days - 1L);
+        var data = statService.countCommentsRange(start, end);
+        return data.entrySet().stream()
+                .map(e -> Map.<String,Object>of(
+                        "date", e.getKey().toString(),
                         "value", e.getValue()
                 ))
                 .toList();

--- a/backend/src/main/java/com/openisle/repository/CommentRepository.java
+++ b/backend/src/main/java/com/openisle/repository/CommentRepository.java
@@ -32,4 +32,8 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     long countByAuthor_Id(Long userId);
 
+    @org.springframework.data.jpa.repository.Query("SELECT FUNCTION('date', c.createdAt) AS d, COUNT(c) AS c FROM Comment c " +
+            "WHERE c.createdAt >= :start AND c.createdAt < :end GROUP BY d ORDER BY d")
+    java.util.List<Object[]> countDailyRange(@org.springframework.data.repository.query.Param("start") java.time.LocalDateTime start,
+                                             @org.springframework.data.repository.query.Param("end") java.time.LocalDateTime end);
 }

--- a/backend/src/main/java/com/openisle/repository/PostRepository.java
+++ b/backend/src/main/java/com/openisle/repository/PostRepository.java
@@ -95,4 +95,9 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     long countDistinctByTags_Id(Long tagId);
 
     long countByAuthor_Id(Long userId);
+
+    @Query("SELECT FUNCTION('date', p.createdAt) AS d, COUNT(p) AS c FROM Post p " +
+           "WHERE p.createdAt >= :start AND p.createdAt < :end GROUP BY d ORDER BY d")
+    java.util.List<Object[]> countDailyRange(@Param("start") LocalDateTime start,
+                                             @Param("end") LocalDateTime end);
 }

--- a/backend/src/main/java/com/openisle/repository/UserRepository.java
+++ b/backend/src/main/java/com/openisle/repository/UserRepository.java
@@ -1,6 +1,8 @@
 package com.openisle.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import com.openisle.model.User;
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -12,4 +14,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
     java.util.List<User> findByRole(com.openisle.model.Role role);
     long countByExperienceGreaterThanEqual(int experience);
     long countByCreatedAtBefore(LocalDateTime createdAt);
+
+    @Query("SELECT FUNCTION('date', u.createdAt) AS d, COUNT(u) AS c FROM User u " +
+           "WHERE u.createdAt >= :start AND u.createdAt < :end GROUP BY d ORDER BY d")
+    java.util.List<Object[]> countDailyRange(@Param("start") LocalDateTime start,
+                                             @Param("end") LocalDateTime end);
 }

--- a/backend/src/main/java/com/openisle/service/StatService.java
+++ b/backend/src/main/java/com/openisle/service/StatService.java
@@ -1,0 +1,48 @@
+package com.openisle.service;
+
+import com.openisle.repository.UserRepository;
+import com.openisle.repository.PostRepository;
+import com.openisle.repository.CommentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class StatService {
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
+
+    private Map<LocalDate, Long> toDateMap(LocalDate start, LocalDate end, java.util.List<Object[]> list) {
+        Map<LocalDate, Long> result = new LinkedHashMap<>();
+        for (var obj : list) {
+            LocalDate d = (LocalDate) obj[0];
+            Long c = ((Number) obj[1]).longValue();
+            result.put(d, c);
+        }
+        for (LocalDate d = start; !d.isAfter(end); d = d.plusDays(1)) {
+            result.putIfAbsent(d, 0L);
+        }
+        return result;
+    }
+
+    public Map<LocalDate, Long> countNewUsersRange(LocalDate start, LocalDate end) {
+        java.util.List<Object[]> list = userRepository.countDailyRange(start.atStartOfDay(), end.plusDays(1).atStartOfDay());
+        return toDateMap(start, end, list);
+    }
+
+    public Map<LocalDate, Long> countPostsRange(LocalDate start, LocalDate end) {
+        java.util.List<Object[]> list = postRepository.countDailyRange(start.atStartOfDay(), end.plusDays(1).atStartOfDay());
+        return toDateMap(start, end, list);
+    }
+
+    public Map<LocalDate, Long> countCommentsRange(LocalDate start, LocalDate end) {
+        java.util.List<Object[]> list = commentRepository.countDailyRange(start.atStartOfDay(), end.plusDays(1).atStartOfDay());
+        return toDateMap(start, end, list);
+    }
+}
+

--- a/backend/src/test/java/com/openisle/controller/StatControllerTest.java
+++ b/backend/src/test/java/com/openisle/controller/StatControllerTest.java
@@ -5,6 +5,7 @@ import com.openisle.config.SecurityConfig;
 import com.openisle.service.JwtService;
 import com.openisle.repository.UserRepository;
 import com.openisle.service.UserVisitService;
+import com.openisle.service.StatService;
 import com.openisle.model.Role;
 import com.openisle.model.User;
 import org.junit.jupiter.api.Test;
@@ -35,6 +36,8 @@ class StatControllerTest {
     private UserRepository userRepository;
     @MockBean
     private UserVisitService userVisitService;
+    @MockBean
+    private StatService statService;
 
     @Test
     void dauReturnsCount() throws Exception {
@@ -70,5 +73,65 @@ class StatControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].value").value(1))
                 .andExpect(jsonPath("$[1].value").value(2));
+    }
+
+    @Test
+    void newUsersRangeReturnsSeries() throws Exception {
+        Mockito.when(jwtService.validateAndGetSubject("token")).thenReturn("user");
+        User user = new User();
+        user.setUsername("user");
+        user.setPassword("p");
+        user.setEmail("u@example.com");
+        user.setRole(Role.USER);
+        Mockito.when(userRepository.findByUsername("user")).thenReturn(Optional.of(user));
+        java.util.Map<java.time.LocalDate, Long> map = new java.util.LinkedHashMap<>();
+        map.put(java.time.LocalDate.now().minusDays(1), 5L);
+        map.put(java.time.LocalDate.now(), 6L);
+        Mockito.when(statService.countNewUsersRange(Mockito.any(), Mockito.any())).thenReturn(map);
+
+        mockMvc.perform(get("/api/stats/new-users-range").param("days", "2").header("Authorization", "Bearer token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].value").value(5))
+                .andExpect(jsonPath("$[1].value").value(6));
+    }
+
+    @Test
+    void postsRangeReturnsSeries() throws Exception {
+        Mockito.when(jwtService.validateAndGetSubject("token")).thenReturn("user");
+        User user = new User();
+        user.setUsername("user");
+        user.setPassword("p");
+        user.setEmail("u@example.com");
+        user.setRole(Role.USER);
+        Mockito.when(userRepository.findByUsername("user")).thenReturn(Optional.of(user));
+        java.util.Map<java.time.LocalDate, Long> map = new java.util.LinkedHashMap<>();
+        map.put(java.time.LocalDate.now().minusDays(1), 7L);
+        map.put(java.time.LocalDate.now(), 8L);
+        Mockito.when(statService.countPostsRange(Mockito.any(), Mockito.any())).thenReturn(map);
+
+        mockMvc.perform(get("/api/stats/posts-range").param("days", "2").header("Authorization", "Bearer token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].value").value(7))
+                .andExpect(jsonPath("$[1].value").value(8));
+    }
+
+    @Test
+    void commentsRangeReturnsSeries() throws Exception {
+        Mockito.when(jwtService.validateAndGetSubject("token")).thenReturn("user");
+        User user = new User();
+        user.setUsername("user");
+        user.setPassword("p");
+        user.setEmail("u@example.com");
+        user.setRole(Role.USER);
+        Mockito.when(userRepository.findByUsername("user")).thenReturn(Optional.of(user));
+        java.util.Map<java.time.LocalDate, Long> map = new java.util.LinkedHashMap<>();
+        map.put(java.time.LocalDate.now().minusDays(1), 9L);
+        map.put(java.time.LocalDate.now(), 10L);
+        Mockito.when(statService.countCommentsRange(Mockito.any(), Mockito.any())).thenReturn(map);
+
+        mockMvc.perform(get("/api/stats/comments-range").param("days", "2").header("Authorization", "Bearer token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].value").value(9))
+                .andExpect(jsonPath("$[1].value").value(10));
     }
 }

--- a/frontend_nuxt/pages/about/stats.vue
+++ b/frontend_nuxt/pages/about/stats.vue
@@ -1,7 +1,30 @@
 <template>
   <div class="site-stats-page">
     <ClientOnly>
-      <VChart v-if="option" :option="option" :autoresize="true" style="height: 400px" />
+      <VChart
+        v-if="dauOption"
+        :option="dauOption"
+        :autoresize="true"
+        style="height: 400px; margin-bottom: 30px"
+      />
+      <VChart
+        v-if="newUserOption"
+        :option="newUserOption"
+        :autoresize="true"
+        style="height: 400px; margin-bottom: 30px"
+      />
+      <VChart
+        v-if="postOption"
+        :option="postOption"
+        :autoresize="true"
+        style="height: 400px; margin-bottom: 30px"
+      />
+      <VChart
+        v-if="commentOption"
+        :option="commentOption"
+        :autoresize="true"
+        style="height: 400px"
+      />
     </ClientOnly>
   </div>
 </template>
@@ -23,26 +46,51 @@ import { getToken } from '../utils/auth'
 
 use([LineChart, TitleComponent, TooltipComponent, GridComponent, DataZoomComponent, CanvasRenderer])
 
-const option = ref(null)
+const dauOption = ref(null)
+const newUserOption = ref(null)
+const postOption = ref(null)
+const commentOption = ref(null)
 
 async function loadData() {
   const token = getToken()
-  const res = await fetch(`${API_BASE_URL}/api/stats/dau-range?days=30`, {
-    headers: { Authorization: `Bearer ${token}` },
-  })
-  if (res.ok) {
-    const data = await res.json()
+  const headers = { Authorization: `Bearer ${token}` }
+
+  const [dauRes, newUserRes, postRes, commentRes] = await Promise.all([
+    fetch(`${API_BASE_URL}/api/stats/dau-range?days=30`, { headers }),
+    fetch(`${API_BASE_URL}/api/stats/new-users-range?days=30`, { headers }),
+    fetch(`${API_BASE_URL}/api/stats/posts-range?days=30`, { headers }),
+    fetch(`${API_BASE_URL}/api/stats/comments-range?days=30`, { headers }),
+  ])
+
+  function toOption(title, data) {
     data.sort((a, b) => new Date(a.date) - new Date(b.date))
     const dates = data.map((d) => d.date)
     const values = data.map((d) => d.value)
-    option.value = {
-      title: { text: '站点 DAU' },
+    return {
+      title: { text: title },
       tooltip: { trigger: 'axis' },
       xAxis: { type: 'category', data: dates },
       yAxis: { type: 'value' },
       dataZoom: [{ type: 'slider', start: 80 }, { type: 'inside' }],
       series: [{ type: 'line', areaStyle: {}, smooth: true, data: values }],
     }
+  }
+
+  if (dauRes.ok) {
+    const data = await dauRes.json()
+    dauOption.value = toOption('站点 DAU', data)
+  }
+  if (newUserRes.ok) {
+    const data = await newUserRes.json()
+    newUserOption.value = toOption('每日新增用户', data)
+  }
+  if (postRes.ok) {
+    const data = await postRes.json()
+    postOption.value = toOption('每日发帖量', data)
+  }
+  if (commentRes.ok) {
+    const data = await commentRes.json()
+    commentOption.value = toOption('每日回贴量', data)
   }
 }
 


### PR DESCRIPTION
## Summary
- add service and API endpoints for daily new users, posts and comments
- show new statistics in the site stats page
- cover new endpoints with controller tests

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689a97e3038c8327aa98d98bf7fc2563