### PR TITLE
feat: support notification type preferences

### DIFF
--- a/backend/src/main/java/com/openisle/controller/NotificationController.java
+++ b/backend/src/main/java/com/openisle/controller/NotificationController.java
@@ -3,6 +3,8 @@ package com.openisle.controller;
 import com.openisle.dto.NotificationDto;
 import com.openisle.dto.NotificationMarkReadRequest;
 import com.openisle.dto.NotificationUnreadCountDto;
+import com.openisle.dto.NotificationPreferenceDto;
+import com.openisle.dto.NotificationPreferenceUpdateRequest;
 import com.openisle.mapper.NotificationMapper;
 import com.openisle.service.NotificationService;
 import lombok.RequiredArgsConstructor;
@@ -39,5 +41,15 @@ public class NotificationController {
     @PostMapping("/read")
     public void markRead(@RequestBody NotificationMarkReadRequest req, Authentication auth) {
         notificationService.markRead(auth.getName(), req.getIds());
+    }
+
+    @GetMapping("/prefs")
+    public List<NotificationPreferenceDto> prefs(Authentication auth) {
+        return notificationService.listPreferences(auth.getName());
+    }
+
+    @PostMapping("/prefs")
+    public void updatePref(@RequestBody NotificationPreferenceUpdateRequest req, Authentication auth) {
+        notificationService.updatePreference(auth.getName(), req.getType(), req.isEnabled());
     }
 }

--- a/backend/src/main/java/com/openisle/dto/NotificationPreferenceDto.java
+++ b/backend/src/main/java/com/openisle/dto/NotificationPreferenceDto.java
@@ -1,0 +1,11 @@
+package com.openisle.dto;
+
+import com.openisle.model.NotificationType;
+import lombok.Data;
+
+/** User notification preference DTO. */
+@Data
+public class NotificationPreferenceDto {
+    private NotificationType type;
+    private boolean enabled;
+}

--- a/backend/src/main/java/com/openisle/dto/NotificationPreferenceUpdateRequest.java
+++ b/backend/src/main/java/com/openisle/dto/NotificationPreferenceUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.openisle.dto;
+
+import com.openisle.model.NotificationType;
+import lombok.Data;
+
+/** Request to update a single notification preference. */
+@Data
+public class NotificationPreferenceUpdateRequest {
+    private NotificationType type;
+    private boolean enabled;
+}

--- a/backend/src/main/java/com/openisle/model/User.java
+++ b/backend/src/main/java/com/openisle/model/User.java
@@ -7,6 +7,8 @@ import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Simple user entity with basic fields and a role.
@@ -61,6 +63,12 @@ public class User {
 
     @Enumerated(EnumType.STRING)
     private MedalType displayMedal;
+
+    @ElementCollection(targetClass = NotificationType.class)
+    @CollectionTable(name = "user_disabled_notification_types", joinColumns = @JoinColumn(name = "user_id"))
+    @Column(name = "notification_type")
+    @Enumerated(EnumType.STRING)
+    private Set<NotificationType> disabledNotificationTypes = new HashSet<>();
 
     @CreationTimestamp
     @Column(nullable = false, updatable = false,

--- a/frontend_nuxt/utils/notification.js
+++ b/frontend_nuxt/utils/notification.js
@@ -46,3 +46,35 @@ export async function markNotificationsRead(ids) {
     return false
   }
 }
+
+export async function fetchNotificationPreferences() {
+  try {
+    const token = getToken()
+    if (!token) return []
+    const res = await fetch(`${API_BASE_URL}/api/notifications/prefs`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    if (!res.ok) return []
+    return await res.json()
+  } catch (e) {
+    return []
+  }
+}
+
+export async function updateNotificationPreference(type, enabled) {
+  try {
+    const token = getToken()
+    if (!token) return false
+    const res = await fetch(`${API_BASE_URL}/api/notifications/prefs`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ type, enabled }),
+    })
+    return res.ok
+  } catch (e) {
+    return false
+  }
+}


### PR DESCRIPTION
## Summary
- allow users to toggle notification types and store preferences
- expose APIs to read/update notification preferences and filter notifications
- show dynamic notification settings tab in frontend and update unread count accordingly

## Testing
- `mvn test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent from/to central (Network is unreachable))*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689adc19ab5c8327aa98e7f5518374ed