### PR TITLE
Disable post-viewed and user-activity notifications by default

### DIFF
--- a/backend/src/main/java/com/openisle/config/NotificationPreferenceInitializer.java
+++ b/backend/src/main/java/com/openisle/config/NotificationPreferenceInitializer.java
@@ -1,0 +1,39 @@
+package com.openisle.config;
+
+import com.openisle.model.NotificationType;
+import com.openisle.model.User;
+import com.openisle.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Ensure default notification preferences are applied to existing users.
+ */
+@Component
+@RequiredArgsConstructor
+public class NotificationPreferenceInitializer implements CommandLineRunner {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public void run(String... args) {
+        List<User> users = userRepository.findAll();
+        for (User user : users) {
+            Set<NotificationType> disabled = user.getDisabledNotificationTypes();
+            boolean changed = false;
+            if (disabled.add(NotificationType.POST_VIEWED)) {
+                changed = true;
+            }
+            if (disabled.add(NotificationType.USER_ACTIVITY)) {
+                changed = true;
+            }
+            if (changed) {
+                userRepository.save(user);
+            }
+        }
+    }
+}

--- a/backend/src/main/java/com/openisle/model/User.java
+++ b/backend/src/main/java/com/openisle/model/User.java
@@ -7,7 +7,7 @@ import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
-import java.util.HashSet;
+import java.util.EnumSet;
 import java.util.Set;
 
 /**
@@ -68,7 +68,10 @@ public class User {
     @CollectionTable(name = "user_disabled_notification_types", joinColumns = @JoinColumn(name = "user_id"))
     @Column(name = "notification_type")
     @Enumerated(EnumType.STRING)
-    private Set<NotificationType> disabledNotificationTypes = new HashSet<>();
+    private Set<NotificationType> disabledNotificationTypes = EnumSet.of(
+            NotificationType.POST_VIEWED,
+            NotificationType.USER_ACTIVITY
+    );
 
     @CreationTimestamp
     @Column(nullable = false, updatable = false,

--- a/backend/src/test/java/com/openisle/config/NotificationPreferenceInitializerTest.java
+++ b/backend/src/test/java/com/openisle/config/NotificationPreferenceInitializerTest.java
@@ -1,0 +1,41 @@
+package com.openisle.config;
+
+import com.openisle.model.NotificationType;
+import com.openisle.model.User;
+import com.openisle.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+
+import java.util.EnumSet;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+class NotificationPreferenceInitializerTest {
+
+    @Test
+    void addsDefaultsToUsers() throws Exception {
+        User u1 = new User();
+        u1.setId(1L);
+        u1.getDisabledNotificationTypes().clear();
+
+        User u2 = new User();
+        u2.setId(2L);
+        u2.getDisabledNotificationTypes().clear();
+        u2.getDisabledNotificationTypes().add(NotificationType.POST_VIEWED);
+
+        UserRepository repo = mock(UserRepository.class);
+        when(repo.findAll()).thenReturn(List.of(u1, u2));
+
+        NotificationPreferenceInitializer init = new NotificationPreferenceInitializer(repo);
+        init.run();
+
+        assertTrue(u1.getDisabledNotificationTypes().containsAll(
+                EnumSet.of(NotificationType.POST_VIEWED, NotificationType.USER_ACTIVITY)));
+        assertTrue(u2.getDisabledNotificationTypes().containsAll(
+                EnumSet.of(NotificationType.POST_VIEWED, NotificationType.USER_ACTIVITY)));
+
+        verify(repo).save(u1);
+        verify(repo).save(u2);
+    }
+}


### PR DESCRIPTION
## Summary
- Default `POST_VIEWED` and `USER_ACTIVITY` notifications are disabled for all users
- Apply default notification filters to existing users at startup
- Add test for notification preference initializer

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689afda1a36883279afbcac0e07fb3e8