### PR TITLE
feat: add lottery win notification

### DIFF
--- a/backend/src/main/java/com/openisle/model/NotificationType.java
+++ b/backend/src/main/java/com/openisle/model/NotificationType.java
@@ -32,6 +32,8 @@ public enum NotificationType {
     REGISTER_REQUEST,
     /** A user redeemed an activity reward */
     ACTIVITY_REDEEM,
+    /** You won a lottery post */
+    LOTTERY_WIN,
     /** You were mentioned in a post or comment */
     MENTION
 }

--- a/backend/src/main/java/com/openisle/service/PostService.java
+++ b/backend/src/main/java/com/openisle/service/PostService.java
@@ -69,6 +69,8 @@ public class PostService {
     private final EmailSender emailSender;
     private final ApplicationContext applicationContext;
     private final ConcurrentMap<Long, ScheduledFuture<?>> scheduledFinalizations = new ConcurrentHashMap<>();
+    @Value("${app.website-url:https://www.open-isle.com}")
+    private String websiteUrl;
 
     @org.springframework.beans.factory.annotation.Autowired
     public PostService(PostRepository postRepository,
@@ -249,6 +251,8 @@ public class PostService {
                 if (w.getEmail() != null) {
                     emailSender.sendEmail(w.getEmail(), "你中奖了", "恭喜你在抽奖贴 \"" + lp.getTitle() + "\" 中获奖");
                 }
+                notificationService.createNotification(w, NotificationType.LOTTERY_WIN, lp, null, null, lp.getAuthor(), null, null);
+                notificationService.sendCustomPush(w, "你中奖了", String.format("%s/posts/%d", websiteUrl, lp.getId()));
             }
         });
     }

--- a/frontend_nuxt/pages/message.vue
+++ b/frontend_nuxt/pages/message.vue
@@ -185,6 +185,19 @@
                     </router-link>
                   </NotificationContainer>
                 </template>
+                <template v-else-if="item.type === 'LOTTERY_WIN'">
+                  <NotificationContainer :item="item" :markRead="markRead">
+                    恭喜你在抽奖贴
+                    <router-link
+                      class="notif-content-text"
+                      @click="markRead(item.id)"
+                      :to="`/posts/${item.post.id}`"
+                    >
+                      {{ stripMarkdownLength(item.post.title, 100) }}
+                    </router-link>
+                    中获奖
+                  </NotificationContainer>
+                </template>
                 <template v-else-if="item.type === 'POST_UPDATED'">
                   <NotificationContainer :item="item" :markRead="markRead">
                     您关注的帖子
@@ -565,6 +578,7 @@ export default {
       POST_UNSUBSCRIBED: 'fas fa-bookmark',
       REGISTER_REQUEST: 'fas fa-user-clock',
       ACTIVITY_REDEEM: 'fas fa-coffee',
+      LOTTERY_WIN: 'fas fa-trophy',
       MENTION: 'fas fa-at',
     }
 
@@ -619,6 +633,17 @@ export default {
                 if (n.fromUser) {
                   markRead(n.id)
                   router.push(`/users/${n.fromUser.id}`)
+                }
+              },
+            })
+          } else if (n.type === 'LOTTERY_WIN') {
+            notifications.value.push({
+              ...n,
+              icon: iconMap[n.type],
+              iconClick: () => {
+                if (n.post) {
+                  markRead(n.id)
+                  router.push(`/posts/${n.post.id}`)
                 }
               },
             })
@@ -791,6 +816,8 @@ export default {
           return '有人申请注册'
         case 'ACTIVITY_REDEEM':
           return '有人申请兑换奶茶'
+        case 'LOTTERY_WIN':
+          return '抽奖中奖了'
         default:
           return t
       }


### PR DESCRIPTION
## Summary
- add `LOTTERY_WIN` notification type
- notify lottery winners and display on frontend

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689c3a1330948327953ff76b7ee7c283