### PR TITLE
feat: support comment pinning

### DIFF
--- a/backend/src/main/java/com/openisle/controller/AdminCommentController.java
+++ b/backend/src/main/java/com/openisle/controller/AdminCommentController.java
@@ -1,0 +1,29 @@
+package com.openisle.controller;
+
+import com.openisle.dto.CommentDto;
+import com.openisle.mapper.CommentMapper;
+import com.openisle.service.CommentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * Endpoints for administrators to manage comments.
+ */
+@RestController
+@RequestMapping("/api/admin/comments")
+@RequiredArgsConstructor
+public class AdminCommentController {
+    private final CommentService commentService;
+    private final CommentMapper commentMapper;
+
+    @PostMapping("/{id}/pin")
+    public CommentDto pin(@PathVariable Long id, Authentication auth) {
+        return commentMapper.toDto(commentService.pinComment(auth.getName(), id));
+    }
+
+    @PostMapping("/{id}/unpin")
+    public CommentDto unpin(@PathVariable Long id, Authentication auth) {
+        return commentMapper.toDto(commentService.unpinComment(auth.getName(), id));
+    }
+}

--- a/backend/src/main/java/com/openisle/controller/CommentController.java
+++ b/backend/src/main/java/com/openisle/controller/CommentController.java
@@ -85,4 +85,16 @@ public class CommentController {
         commentService.deleteComment(auth.getName(), id);
         log.debug("deleteComment completed for comment {}", id);
     }
+
+    @PostMapping("/comments/{id}/pin")
+    public CommentDto pinComment(@PathVariable Long id, Authentication auth) {
+        log.debug("pinComment called by user {} for comment {}", auth.getName(), id);
+        return commentMapper.toDto(commentService.pinComment(auth.getName(), id));
+    }
+
+    @PostMapping("/comments/{id}/unpin")
+    public CommentDto unpinComment(@PathVariable Long id, Authentication auth) {
+        log.debug("unpinComment called by user {} for comment {}", auth.getName(), id);
+        return commentMapper.toDto(commentService.unpinComment(auth.getName(), id));
+    }
 }

--- a/backend/src/main/java/com/openisle/dto/CommentDto.java
+++ b/backend/src/main/java/com/openisle/dto/CommentDto.java
@@ -13,6 +13,7 @@ public class CommentDto {
     private Long id;
     private String content;
     private LocalDateTime createdAt;
+    private LocalDateTime pinnedAt;
     private AuthorDto author;
     private List<CommentDto> replies;
     private List<ReactionDto> reactions;

--- a/backend/src/main/java/com/openisle/mapper/CommentMapper.java
+++ b/backend/src/main/java/com/openisle/mapper/CommentMapper.java
@@ -24,6 +24,7 @@ public class CommentMapper {
         dto.setId(comment.getId());
         dto.setContent(comment.getContent());
         dto.setCreatedAt(comment.getCreatedAt());
+        dto.setPinnedAt(comment.getPinnedAt());
         dto.setAuthor(userMapper.toAuthorDto(comment.getAuthor()));
         dto.setReward(0);
         return dto;

--- a/backend/src/main/java/com/openisle/model/Comment.java
+++ b/backend/src/main/java/com/openisle/model/Comment.java
@@ -38,4 +38,7 @@ public class Comment {
     @JoinColumn(name = "parent_id")
     private Comment parent;
 
+    @Column
+    private LocalDateTime pinnedAt;
+
 }

--- a/backend/src/main/resources/db/migration/V1__add_pinned_at_to_comments.sql
+++ b/backend/src/main/resources/db/migration/V1__add_pinned_at_to_comments.sql
@@ -1,0 +1,1 @@
+ALTER TABLE comments ADD COLUMN pinned_at DATETIME(6) NULL;

--- a/frontend_nuxt/pages/posts/[id]/index.vue
+++ b/frontend_nuxt/pages/posts/[id]/index.vue
@@ -195,6 +195,7 @@
               :comment="item"
               :level="0"
               :default-show-replies="item.openReplies"
+              :post-author-id="author.id"
               @deleted="onCommentDeleted"
             />
           </template>
@@ -405,6 +406,7 @@ export default {
       avatar: c.author.avatar,
       text: c.content,
       reactions: c.reactions || [],
+      pinned: !!c.pinnedAt,
       reply: (c.replies || []).map((r) => mapComment(r, c.author.username, level + 1)),
       openReplies: level === 0,
       src: c.author.avatar,


### PR DESCRIPTION
## Summary
- allow post authors or admins to pin and unpin comments
- add REST endpoints with authorization checks
- surface pin/unpin actions in the UI for post authors

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689c49c05bd883279fa871fc2220875f