### PR TITLE
feat: refresh home when clicking header logo

### DIFF
--- a/frontend_nuxt/components/HeaderComponent.vue
+++ b/frontend_nuxt/components/HeaderComponent.vue
@@ -75,7 +75,11 @@ const userMenu = ref(null)
 const menuBtn = ref(null)
 
 const goToHome = async () => {
-  await navigateTo('/', { replace: true })
+  if (router.currentRoute.value.fullPath === '/') {
+    window.dispatchEvent(new Event('refresh-home'))
+  } else {
+    await navigateTo('/', { replace: true })
+  }
 }
 const search = () => {
   showSearch.value = true

--- a/frontend_nuxt/pages/index.vue
+++ b/frontend_nuxt/pages/index.vue
@@ -112,7 +112,7 @@
 </template>
 
 <script setup>
-import { ref, watch } from 'vue'
+import { ref, watch, onMounted, onBeforeUnmount } from 'vue'
 import ArticleCategory from '~/components/ArticleCategory.vue'
 import ArticleTags from '~/components/ArticleTags.vue'
 import CategorySelect from '~/components/CategorySelect.vue'
@@ -396,6 +396,18 @@ const fetchContent = async (reset = false) => {
     await fetchPosts(reset)
   }
 }
+
+const refreshHome = () => {
+  fetchContent(true)
+}
+
+onMounted(() => {
+  window.addEventListener('refresh-home', refreshHome)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('refresh-home', refreshHome)
+})
 
 useScrollLoadMore(fetchContent)
 


### PR DESCRIPTION
## Summary
- refresh home posts when the logo is clicked while already on the home page
- listen for a `refresh-home` event on the home page and reload content

## Testing
- `npm test` *(fails: Error: no test specified)*
- `cd frontend_nuxt && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d4faee28c8327a2839e459785b63f