### PR TITLE
fix: prevent homepage reload on logo click

### DIFF
--- a/frontend_nuxt/components/HeaderComponent.vue
+++ b/frontend_nuxt/components/HeaderComponent.vue
@@ -8,7 +8,7 @@
           </button>
           <span v-if="isMobile && unreadCount > 0" class="menu-unread-dot"></span>
         </div>
-        <NuxtLink class="logo-container" to="/">
+        <NuxtLink class="logo-container" to="/" @click.prevent="goToHome">
           <img
             alt="OpenIsle"
             src="https://openisle-1307107697.cos.ap-guangzhou.myqcloud.com/assert/image.png"


### PR DESCRIPTION
## Summary
- stop default link navigation when clicking header logo
- route via `goToHome` to avoid unnecessary page reload

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689d672481948327a14b714234ebf0b8