### PR TITLE
fix: prevent header logo from triggering page reload

### DIFF
--- a/frontend_nuxt/components/HeaderComponent.vue
+++ b/frontend_nuxt/components/HeaderComponent.vue
@@ -8,7 +8,7 @@
           </button>
           <span v-if="isMobile && unreadCount > 0" class="menu-unread-dot"></span>
         </div>
-        <NuxtLink class="logo-container" to="/" @click.prevent="goToHome">
+        <NuxtLink class="logo-container" to="/" replace @click="handleLogoClick">
           <img
             alt="OpenIsle"
             src="https://openisle-1307107697.cos.ap-guangzhou.myqcloud.com/assert/image.png"
@@ -74,11 +74,10 @@ const searchDropdown = ref(null)
 const userMenu = ref(null)
 const menuBtn = ref(null)
 
-const goToHome = async () => {
+const handleLogoClick = (event) => {
   if (router.currentRoute.value.fullPath === '/') {
+    event.preventDefault()
     window.dispatchEvent(new Event('refresh-home'))
-  } else {
-    await navigateTo('/', { replace: true })
   }
 }
 const search = () => {


### PR DESCRIPTION
## Summary
- avoid double navigation when clicking header logo
- only refresh home when already on homepage

## Testing
- `npm test` *(fails: Error: no test specified)*
- `cd frontend_nuxt && npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689d68160b04832785fb7600e04f96f3