### PR TITLE
fix: restore comment pin handling

### DIFF
--- a/frontend_nuxt/pages/index.vue
+++ b/frontend_nuxt/pages/index.vue
@@ -265,7 +265,7 @@ const {
       time: TimeManager.format(
         selectedTopic.value === '最新回复' ? p.lastReplyAt || p.createdAt : p.createdAt,
       ),
-      pinned: !!p.pinnedAt,
+      pinned: Boolean(p.pinned ?? p.pinnedAt ?? p.pinned_at),
       type: p.type,
     }))
   },
@@ -308,7 +308,7 @@ const fetchNextPage = async () => {
         time: TimeManager.format(
           selectedTopic.value === '最新回复' ? p.lastReplyAt || p.createdAt : p.createdAt,
         ),
-        pinned: !!p.pinnedAt,
+        pinned: Boolean(p.pinned ?? p.pinnedAt ?? p.pinned_at),
         type: p.type,
       }))
       articles.value.push(...mapped)

--- a/frontend_nuxt/pages/posts/[id]/index.vue
+++ b/frontend_nuxt/pages/posts/[id]/index.vue
@@ -392,7 +392,7 @@ const mapComment = (c, parentUserName = '', level = 0) => ({
   avatar: c.author.avatar,
   text: c.content,
   reactions: c.reactions || [],
-  pinned: !!c.pinnedAt,
+  pinned: Boolean(c.pinned ?? c.pinnedAt ?? c.pinned_at),
   reply: (c.replies || []).map((r) => mapComment(r, c.author.username, level + 1)),
   openReplies: level === 0,
   src: c.author.avatar,


### PR DESCRIPTION
## Summary
- read pin state from `pinned`, `pinnedAt`, or `pinned_at` to handle back-end responses
- ensure pinned comments and posts display correctly

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM – network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689d95af6d0c832780453deb9e455086