### PR TITLE
fix(about): fix link color issue on about page (#566)

### DIFF
--- a/frontend_nuxt/assets/global.css
+++ b/frontend_nuxt/assets/global.css
@@ -190,11 +190,13 @@ body {
   opacity: 1;
 }
 
+.about-content a,
 .info-content-text a {
   color: var(--primary-color);
   text-decoration: none;
 }
 
+.about-content a:hover,
 .info-content-text a:hover {
   text-decoration: underline;
 }


### PR DESCRIPTION
Questions:
- Why are markdown styles split into `about-content` and `info-content-text`?
- Why is `about-content` defined both globally and inside the Vue component?