### PR TITLE
feat: 更新 README “开发”章节

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 OpenIsle 是一个使用 Spring Boot 和 Vue 3 构建的全栈开源社区平台，提供用户注册、登录、贴文发布、评论交互等完整功能，可用于项目社区或直接打造自主社区站点。
 
-## 🚀 部署
+## 🚧 开发
 
 ### 后端
 
@@ -20,9 +20,26 @@ OpenIsle 是一个使用 Spring Boot 和 Vue 3 构建的全栈开源社区平台
 
 ### 前端
 
-1. `cd open-isle-cli`
-2. 执行 `npm install`
-3. `npm run serve`可在本地启动开发服务，产品环境使用 `npm run build`生成 `dist/` 文件，配合线上网站方式部署
+1. 进入前端目录
+    ```bash
+    cd frontend_nuxt
+    ```
+2. 安装依赖
+    ```bash
+    npm install
+    ```
+3. 启动开发服务
+    ```bash
+    npm run dev
+    ```
+
+    生产版本使用如下命令编译：
+
+    ```bash
+    npm run build
+    ```
+
+    会在 `.output` 目录生成文件，配合线上网站方式部署
 
 ## ✨ 项目特点
 


### PR DESCRIPTION
在本地初始化项目并启动服务，发现命令和文档不太正确，遂进行修正。

原先这一节叫做 “🚀 部署”，在建设阶段，可能大家会更关心本地开发，部署直接在 ci 中配置即可。因此这样修改，不知我的理解是否合理。

后续这一节可以抽离到 `CONTRIBUTING.md`，这样会有专门的 Tab 来展示

<img width="564" height="66" alt="Clipboard_Screenshot_1755233232" src="https://github.com/user-attachments/assets/d6ef5e8d-e459-49f7-bc83-2cec471616ce" />
