### PR TITLE
chore: split large vite chunks

### DIFF
--- a/frontend_nuxt/nuxt.config.ts
+++ b/frontend_nuxt/nuxt.config.ts
@@ -60,4 +60,27 @@ export default defineNuxtConfig({
       isCustomElement: (tag) => ['l-hatch', 'l-hatch-spinner'].includes(tag),
     },
   },
+  vite: {
+    build: {
+      // increase warning limit and split large libraries into separate chunks
+      chunkSizeWarningLimit: 1024,
+      rollupOptions: {
+        output: {
+          manualChunks(id) {
+            if (id.includes('node_modules')) {
+              if (id.includes('vditor')) {
+                return 'vditor'
+              }
+              if (id.includes('echarts')) {
+                return 'echarts'
+              }
+              if (id.includes('highlight.js')) {
+                return 'highlight'
+              }
+            }
+          },
+        },
+      },
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- improve Vite build to split large libraries into dedicated chunks and raise chunk size warning limit

## Testing
- `npm run build` in frontend_nuxt
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ec097b7ec8327add7d0463acef1ab