### PR TITLE
feat: add point mall module

### DIFF
--- a/frontend_nuxt/pages/about/points.vue
+++ b/frontend_nuxt/pages/about/points.vue
@@ -1,0 +1,29 @@
+<template>
+  <div class="point-mall-page">
+    <p v-if="authState.loggedIn && point !== null">我的积分：{{ point }}</p>
+    <p v-else>请先登录以查看积分</p>
+  </div>
+</template>
+
+<script setup>
+import { onMounted, ref } from 'vue'
+import { authState, fetchCurrentUser } from '~/utils/auth'
+
+const point = ref(null)
+
+onMounted(async () => {
+  if (authState.loggedIn) {
+    const user = await fetchCurrentUser()
+    point.value = user ? user.point : null
+  }
+})
+</script>
+
+<style scoped>
+.point-mall-page {
+  padding: 20px;
+  max-width: var(--page-max-width);
+  background-color: var(--background-color);
+  margin: 0 auto;
+}
+</style>


### PR DESCRIPTION
## Summary
- show a new point mall item under site stats
- fetch and display current user's points in menu
- add page to show user's points

## Testing
- `npm test` *(fails: Error: no test specified)*
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68a0bd825b548327adc6d1f266a379d9