### PR TITLE
feat: add point rules and products to points mall

### DIFF
--- a/frontend_nuxt/pages/about/points.vue
+++ b/frontend_nuxt/pages/about/points.vue
@@ -2,6 +2,20 @@
   <div class="point-mall-page">
     <p v-if="authState.loggedIn && point !== null">我的积分：{{ point }}</p>
     <p v-else>请先登录以查看积分</p>
+
+    <section class="rules">
+      <h2>积分规则</h2>
+      <ul>
+        <li v-for="(rule, idx) in pointRules" :key="idx">{{ rule }}</li>
+      </ul>
+    </section>
+
+    <section class="goods">
+      <h2>积分兑换商品</h2>
+      <ul>
+        <li v-for="(good, idx) in goods" :key="idx">{{ good.name }} - {{ good.cost }} 积分</li>
+      </ul>
+    </section>
   </div>
 </template>
 
@@ -10,6 +24,18 @@ import { onMounted, ref } from 'vue'
 import { authState, fetchCurrentUser } from '~/utils/auth'
 
 const point = ref(null)
+
+const pointRules = [
+  '发帖：每天前两次，每次 30 积分',
+  '评论：每天前四条评论可获 10 积分，你的帖子被评论也可获 10 积分',
+  '帖子被点赞：每次 10 积分',
+  '评论被点赞：每次 10 积分',
+]
+
+const goods = [
+  { name: 'GPT Plus for 1 month', cost: 20000 },
+  { name: '奶茶', cost: 5000 },
+]
 
 onMounted(async () => {
   if (authState.loggedIn) {
@@ -25,5 +51,10 @@ onMounted(async () => {
   max-width: var(--page-max-width);
   background-color: var(--background-color);
   margin: 0 auto;
+}
+
+.rules,
+.goods {
+  margin-top: 20px;
 }
 </style>


### PR DESCRIPTION
## Summary
- Display existing point rules in the points mall
- Add GPT Plus and milk tea redemption options

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0bfdecb348327b219ea3d2db8e94e