### PR TITLE
feat: add point redeem notification type

### DIFF
--- a/backend/src/main/java/com/openisle/model/NotificationType.java
+++ b/backend/src/main/java/com/openisle/model/NotificationType.java
@@ -32,6 +32,8 @@ public enum NotificationType {
     REGISTER_REQUEST,
     /** A user redeemed an activity reward */
     ACTIVITY_REDEEM,
+    /** A user redeemed a point good */
+    POINT_REDEEM,
     /** You won a lottery post */
     LOTTERY_WIN,
     /** Your lottery post was drawn */

--- a/backend/src/main/java/com/openisle/service/NotificationService.java
+++ b/backend/src/main/java/com/openisle/service/NotificationService.java
@@ -141,6 +141,19 @@ public class NotificationService {
         }
     }
 
+    /**
+     * Create notifications for all admins when a user redeems a point good.
+     * Old redeem notifications from the same user are removed first.
+     */
+    @org.springframework.transaction.annotation.Transactional
+    public void createPointRedeemNotifications(User user, String content) {
+        notificationRepository.deleteByTypeAndFromUser(NotificationType.POINT_REDEEM, user);
+        for (User admin : userRepository.findByRole(Role.ADMIN)) {
+            createNotification(admin, NotificationType.POINT_REDEEM, null, null,
+                    null, user, null, content);
+        }
+    }
+
     public List<NotificationPreferenceDto> listPreferences(String username) {
         User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> new com.openisle.exception.NotFoundException("User not found"));

--- a/backend/src/main/java/com/openisle/service/PointMallService.java
+++ b/backend/src/main/java/com/openisle/service/PointMallService.java
@@ -31,7 +31,7 @@ public class PointMallService {
         }
         user.setPoint(user.getPoint() - good.getCost());
         userRepository.save(user);
-        notificationService.createActivityRedeemNotifications(user, good.getName() + ": " + contact);
+        notificationService.createPointRedeemNotifications(user, good.getName() + ": " + contact);
         return user.getPoint();
     }
 }

--- a/backend/src/test/java/com/openisle/service/NotificationServiceTest.java
+++ b/backend/src/test/java/com/openisle/service/NotificationServiceTest.java
@@ -145,6 +145,30 @@ class NotificationServiceTest {
     }
 
     @Test
+    void createPointRedeemNotificationsDeletesOldOnes() {
+        NotificationRepository nRepo = mock(NotificationRepository.class);
+        UserRepository uRepo = mock(UserRepository.class);
+        ReactionRepository rRepo = mock(ReactionRepository.class);
+        EmailSender email = mock(EmailSender.class);
+        PushNotificationService push = mock(PushNotificationService.class);
+        Executor executor = Runnable::run;
+        NotificationService service = new NotificationService(nRepo, uRepo, email, push, rRepo, executor);
+        org.springframework.test.util.ReflectionTestUtils.setField(service, "websiteUrl", "https://ex.com");
+
+        User admin = new User();
+        admin.setId(10L);
+        User user = new User();
+        user.setId(20L);
+
+        when(uRepo.findByRole(Role.ADMIN)).thenReturn(List.of(admin));
+
+        service.createPointRedeemNotifications(user, "contact");
+
+        verify(nRepo).deleteByTypeAndFromUser(NotificationType.POINT_REDEEM, user);
+        verify(nRepo).save(any(Notification.class));
+    }
+
+    @Test
     void createNotificationSendsEmailForCommentReply() {
         NotificationRepository nRepo = mock(NotificationRepository.class);
         UserRepository uRepo = mock(UserRepository.class);

--- a/frontend_nuxt/pages/message.vue
+++ b/frontend_nuxt/pages/message.vue
@@ -130,6 +130,12 @@
                     申请进行奶茶兑换，联系方式是：{{ item.content }}
                   </NotificationContainer>
                 </template>
+                <template v-else-if="item.type === 'POINT_REDEEM' && !item.parentComment">
+                  <NotificationContainer :item="item" :markRead="markRead">
+                    <span class="notif-user">{{ item.fromUser.username }} </span>
+                    申请积分兑换，联系方式是：{{ item.content }}
+                  </NotificationContainer>
+                </template>
                 <template v-else-if="item.type === 'REACTION' && item.post && !item.comment">
                   <NotificationContainer :item="item" :markRead="markRead">
                     <span class="notif-user">{{ item.fromUser.username }} </span> 对我的文章
@@ -610,6 +616,8 @@ const formatType = (t) => {
       return '有人申请注册'
     case 'ACTIVITY_REDEEM':
       return '有人申请兑换奶茶'
+    case 'POINT_REDEEM':
+      return '有人申请积分兑换'
     case 'LOTTERY_WIN':
       return '抽奖中奖了'
     case 'LOTTERY_DRAW':

--- a/frontend_nuxt/utils/notification.js
+++ b/frontend_nuxt/utils/notification.js
@@ -22,6 +22,7 @@ const iconMap = {
   POST_UNSUBSCRIBED: 'fas fa-bookmark',
   REGISTER_REQUEST: 'fas fa-user-clock',
   ACTIVITY_REDEEM: 'fas fa-coffee',
+  POINT_REDEEM: 'fas fa-gift',
   LOTTERY_WIN: 'fas fa-trophy',
   LOTTERY_DRAW: 'fas fa-bullhorn',
   MENTION: 'fas fa-at',


### PR DESCRIPTION
## Summary
- add POINT_REDEEM notification type
- send point redeem notifications to admins
- display new notification type with icon and label

## Testing
- `npm test` (fails: Error: no test specified)
- `cd backend && mvn -q test` (fails: Non-resolvable parent POM: Network is unreachable)


------
https://chatgpt.com/codex/tasks/task_e_68a0cc3ed23c8327b0f8a18a4aab1b5f