### PR TITLE
Add invite points activity

### DIFF
--- a/backend/src/main/java/com/openisle/config/ActivityInitializer.java
+++ b/backend/src/main/java/com/openisle/config/ActivityInitializer.java
@@ -6,6 +6,8 @@ import com.openisle.repository.ActivityRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Component
 @RequiredArgsConstructor
@@ -20,6 +22,17 @@ public class ActivityInitializer implements CommandLineRunner {
             a.setType(ActivityType.MILK_TEA);
             a.setIcon("https://icons.veryicon.com/png/o/food--drinks/delicious-food-1/coffee-36.png");
             a.setContent("为了有利于建站推广以及激励发布内容，我们推出了建站送奶茶的活动，前50名达到level 1的用户，可以联系站长获取奶茶/咖啡一杯");
+            activityRepository.save(a);
+        }
+
+        if (activityRepository.findByType(ActivityType.INVITE_POINTS) == null) {
+            Activity a = new Activity();
+            a.setTitle("🎁邀请码送积分活动");
+            a.setType(ActivityType.INVITE_POINTS);
+            a.setIcon("https://img.icons8.com/color/96/gift.png");
+            a.setContent("使用邀请码注册或邀请好友即可获得积分奖励，快来参与吧！");
+            a.setStartTime(LocalDateTime.now());
+            a.setEndTime(LocalDate.of(LocalDate.now().getYear(), 10, 1).atStartOfDay());
             activityRepository.save(a);
         }
     }

--- a/backend/src/main/java/com/openisle/model/ActivityType.java
+++ b/backend/src/main/java/com/openisle/model/ActivityType.java
@@ -3,5 +3,6 @@ package com.openisle.model;
 /** Activity type enumeration. */
 public enum ActivityType {
     NORMAL,
-    MILK_TEA
+    MILK_TEA,
+    INVITE_POINTS
 }


### PR DESCRIPTION
## Summary
- support INVITE_POINTS activity type
- seed invite points campaign with an October 1 end date

## Testing
- `npm test` *(fails: Error: no test specified)*
- `mvn -q -f backend/pom.xml test` *(fails: Non-resolvable parent POM for com.openisle:openisle:0.0.1-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_68a14d6f552c8327aa7be3b97f1069dc