### PR TITLE
feat: propagate invite token during signup

### DIFF
--- a/frontend_nuxt/pages/google-callback.vue
+++ b/frontend_nuxt/pages/google-callback.vue
@@ -9,6 +9,7 @@ import { googleAuthWithToken } from '~/utils/google'
 onMounted(async () => {
   const hash = new URLSearchParams(window.location.hash.substring(1))
   const idToken = hash.get('id_token')
+  const state = hash.get('state') || ''
   if (idToken) {
     await googleAuthWithToken(
       idToken,
@@ -18,6 +19,7 @@ onMounted(async () => {
       (token) => {
         navigateTo(`/signup-reason?token=${token}`, { replace: true })
       },
+      state,
     )
   } else {
     navigateTo('/login', { replace: true })

--- a/frontend_nuxt/pages/login.vue
+++ b/frontend_nuxt/pages/login.vue
@@ -35,7 +35,7 @@
     </div>
 
     <div class="other-login-page-content">
-      <div class="login-page-button" @click="googleAuthorize">
+      <div class="login-page-button" @click="googleAuthorize()">
         <img class="login-page-button-icon" src="../assets/icons/google.svg" alt="Google Logo" />
         <div class="login-page-button-text">Google 登录</div>
       </div>

--- a/frontend_nuxt/pages/signup.vue
+++ b/frontend_nuxt/pages/signup.vue
@@ -69,7 +69,7 @@
     </div>
 
     <div class="other-signup-page-content">
-      <div class="signup-page-button" @click="googleAuthorize">
+      <div class="signup-page-button" @click="signupWithGoogle">
         <img class="signup-page-button-icon" src="~/assets/icons/google.svg" alt="Google Logo" />
         <div class="signup-page-button-text">Google 注册</div>
       </div>
@@ -98,6 +98,7 @@ import { googleAuthorize } from '~/utils/google'
 import { twitterAuthorize } from '~/utils/twitter'
 const config = useRuntimeConfig()
 const API_BASE_URL = config.public.apiBaseUrl
+const route = useRoute()
 const emailStep = ref(0)
 const email = ref('')
 const username = ref('')
@@ -109,9 +110,11 @@ const passwordError = ref('')
 const code = ref('')
 const isWaitingForEmailSent = ref(false)
 const isWaitingForEmailVerified = ref(false)
+const inviteToken = ref('')
 
 onMounted(async () => {
   username.value = route.query.u || ''
+  inviteToken.value = route.query.invite_token || ''
   try {
     const res = await fetch(`${API_BASE_URL}/api/config`)
     if (res.ok) {
@@ -156,6 +159,7 @@ const sendVerification = async () => {
         username: username.value,
         email: email.value,
         password: password.value,
+        inviteToken: inviteToken.value,
       }),
     })
     isWaitingForEmailSent.value = false
@@ -184,6 +188,7 @@ const verifyCode = async () => {
       body: JSON.stringify({
         code: code.value,
         username: username.value,
+        inviteToken: inviteToken.value,
       }),
     })
     const data = await res.json()
@@ -203,14 +208,17 @@ const verifyCode = async () => {
     isWaitingForEmailVerified.value = false
   }
 }
+const signupWithGoogle = () => {
+  googleAuthorize(inviteToken.value)
+}
 const signupWithGithub = () => {
-  githubAuthorize()
+  githubAuthorize(inviteToken.value)
 }
 const signupWithDiscord = () => {
-  discordAuthorize()
+  discordAuthorize(inviteToken.value)
 }
 const signupWithTwitter = () => {
-  twitterAuthorize()
+  twitterAuthorize(inviteToken.value)
 }
 </script>
 

--- a/frontend_nuxt/utils/google.js
+++ b/frontend_nuxt/utils/google.js
@@ -21,7 +21,7 @@ export async function googleGetIdToken() {
   })
 }
 
-export function googleAuthorize() {
+export function googleAuthorize(state = '') {
   const config = useRuntimeConfig()
   const GOOGLE_CLIENT_ID = config.public.googleClientId
   const WEBSITE_BASE_URL = config.public.websiteBaseUrl
@@ -31,18 +31,25 @@ export function googleAuthorize() {
   }
   const redirectUri = `${WEBSITE_BASE_URL}/google-callback`
   const nonce = Math.random().toString(36).substring(2)
-  const url = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${GOOGLE_CLIENT_ID}&redirect_uri=${encodeURIComponent(redirectUri)}&response_type=id_token&scope=openid%20email%20profile&nonce=${nonce}`
+  const url =
+    `https://accounts.google.com/o/oauth2/v2/auth?client_id=${GOOGLE_CLIENT_ID}&redirect_uri=${encodeURIComponent(redirectUri)}` +
+    `&response_type=id_token&scope=openid%20email%20profile&nonce=${nonce}&state=${state}`
   window.location.href = url
 }
 
-export async function googleAuthWithToken(idToken, redirect_success, redirect_not_approved) {
+export async function googleAuthWithToken(
+  idToken,
+  redirect_success,
+  redirect_not_approved,
+  state = '',
+) {
   try {
     const config = useRuntimeConfig()
     const API_BASE_URL = config.public.apiBaseUrl
     const res = await fetch(`${API_BASE_URL}/api/auth/google`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ idToken }),
+      body: JSON.stringify({ idToken, state }),
     })
     const data = await res.json()
     if (res.ok && data.token) {


### PR DESCRIPTION
## Summary
- carry `invite_token` from signup query through email and OAuth signup flows
- allow Google OAuth functions to accept and forward state tokens
- call `googleAuthorize()` explicitly in login page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a1532b1a388327b9e32822405ab881