### PR TITLE
feat: pass invite token through signup flow

### DIFF
--- a/backend/src/main/java/com/openisle/dto/DiscordLoginRequest.java
+++ b/backend/src/main/java/com/openisle/dto/DiscordLoginRequest.java
@@ -7,4 +7,5 @@ import lombok.Data;
 public class DiscordLoginRequest {
     private String code;
     private String redirectUri;
+    private String inviteToken;
 }

--- a/backend/src/main/java/com/openisle/dto/GithubLoginRequest.java
+++ b/backend/src/main/java/com/openisle/dto/GithubLoginRequest.java
@@ -7,4 +7,5 @@ import lombok.Data;
 public class GithubLoginRequest {
     private String code;
     private String redirectUri;
+    private String inviteToken;
 }

--- a/backend/src/main/java/com/openisle/dto/GoogleLoginRequest.java
+++ b/backend/src/main/java/com/openisle/dto/GoogleLoginRequest.java
@@ -6,4 +6,5 @@ import lombok.Data;
 @Data
 public class GoogleLoginRequest {
     private String idToken;
+    private String inviteToken;
 }

--- a/backend/src/main/java/com/openisle/dto/MakeReasonRequest.java
+++ b/backend/src/main/java/com/openisle/dto/MakeReasonRequest.java
@@ -7,4 +7,5 @@ import lombok.Data;
 public class MakeReasonRequest {
     private String token;
     private String reason;
+    private String inviteToken;
 }

--- a/backend/src/main/java/com/openisle/dto/RegisterRequest.java
+++ b/backend/src/main/java/com/openisle/dto/RegisterRequest.java
@@ -9,4 +9,5 @@ public class RegisterRequest {
     private String email;
     private String password;
     private String captcha;
+    private String inviteToken;
 }

--- a/backend/src/main/java/com/openisle/dto/TwitterLoginRequest.java
+++ b/backend/src/main/java/com/openisle/dto/TwitterLoginRequest.java
@@ -8,4 +8,5 @@ public class TwitterLoginRequest {
     private String code;
     private String redirectUri;
     private String codeVerifier;
+    private String inviteToken;
 }

--- a/backend/src/main/java/com/openisle/dto/VerifyRequest.java
+++ b/backend/src/main/java/com/openisle/dto/VerifyRequest.java
@@ -7,4 +7,5 @@ import lombok.Data;
 public class VerifyRequest {
     private String username;
     private String code;
+    private String inviteToken;
 }

--- a/frontend_nuxt/pages/discord-callback.vue
+++ b/frontend_nuxt/pages/discord-callback.vue
@@ -9,11 +9,12 @@ import { discordExchange } from '~/utils/discord'
 onMounted(async () => {
   const url = new URL(window.location.href)
   const code = url.searchParams.get('code')
-  const state = url.searchParams.get('state')
-  const result = await discordExchange(code, state, '')
+  const inviteToken = url.searchParams.get('state')
+  const result = await discordExchange(code, inviteToken, '')
 
   if (result.needReason) {
-    navigateTo(`/signup-reason?token=${result.token}`, { replace: true })
+    const q = inviteToken ? `&invite_token=${inviteToken}` : ''
+    navigateTo(`/signup-reason?token=${result.token}${q}`, { replace: true })
   } else {
     navigateTo('/', { replace: true })
   }

--- a/frontend_nuxt/pages/github-callback.vue
+++ b/frontend_nuxt/pages/github-callback.vue
@@ -9,11 +9,12 @@ import { githubExchange } from '~/utils/github'
 onMounted(async () => {
   const url = new URL(window.location.href)
   const code = url.searchParams.get('code')
-  const state = url.searchParams.get('state')
-  const result = await githubExchange(code, state, '')
+  const inviteToken = url.searchParams.get('state')
+  const result = await githubExchange(code, inviteToken, '')
 
   if (result.needReason) {
-    navigateTo(`/signup-reason?token=${result.token}`, { replace: true })
+    const q = inviteToken ? `&invite_token=${inviteToken}` : ''
+    navigateTo(`/signup-reason?token=${result.token}${q}`, { replace: true })
   } else {
     navigateTo('/', { replace: true })
   }

--- a/frontend_nuxt/pages/google-callback.vue
+++ b/frontend_nuxt/pages/google-callback.vue
@@ -9,14 +9,17 @@ import { googleAuthWithToken } from '~/utils/google'
 onMounted(async () => {
   const hash = new URLSearchParams(window.location.hash.substring(1))
   const idToken = hash.get('id_token')
+  const inviteToken = hash.get('state')
   if (idToken) {
     await googleAuthWithToken(
       idToken,
+      inviteToken,
       () => {
         navigateTo('/', { replace: true })
       },
       (token) => {
-        navigateTo(`/signup-reason?token=${token}`, { replace: true })
+        const q = inviteToken ? `&invite_token=${inviteToken}` : ''
+        navigateTo(`/signup-reason?token=${token}${q}`, { replace: true })
       },
     )
   } else {

--- a/frontend_nuxt/pages/login.vue
+++ b/frontend_nuxt/pages/login.vue
@@ -35,7 +35,7 @@
     </div>
 
     <div class="other-login-page-content">
-      <div class="login-page-button" @click="googleAuthorize">
+      <div class="login-page-button" @click="loginWithGoogle">
         <img class="login-page-button-icon" src="../assets/icons/google.svg" alt="Google Logo" />
         <div class="login-page-button-text">Google 登录</div>
       </div>
@@ -114,6 +114,9 @@ const loginWithDiscord = () => {
 }
 const loginWithTwitter = () => {
   twitterAuthorize()
+}
+const loginWithGoogle = () => {
+  googleAuthorize()
 }
 </script>
 

--- a/frontend_nuxt/pages/signup-reason.vue
+++ b/frontend_nuxt/pages/signup-reason.vue
@@ -23,14 +23,17 @@ import BaseInput from '~/components/BaseInput.vue'
 import { toast } from '~/main'
 const config = useRuntimeConfig()
 const API_BASE_URL = config.public.apiBaseUrl
+const route = useRoute()
 
 const reason = ref('')
 const error = ref('')
 const isWaitingForRegister = ref(false)
 const token = ref('')
+const inviteToken = ref('')
 
 onMounted(async () => {
   token.value = route.query.token || ''
+  inviteToken.value = route.query.invite_token || ''
   if (!token.value) {
     await navigateTo({ path: '/signup' }, { replace: true })
   }
@@ -50,8 +53,9 @@ const submit = async () => {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        token: this.token,
-        reason: this.reason,
+        token: token.value,
+        reason: reason.value,
+        ...(inviteToken.value ? { inviteToken: inviteToken.value } : {}),
       }),
     })
     isWaitingForRegister.value = false

--- a/frontend_nuxt/pages/signup.vue
+++ b/frontend_nuxt/pages/signup.vue
@@ -69,7 +69,7 @@
     </div>
 
     <div class="other-signup-page-content">
-      <div class="signup-page-button" @click="googleAuthorize">
+      <div class="signup-page-button" @click="signupWithGoogle">
         <img class="signup-page-button-icon" src="~/assets/icons/google.svg" alt="Google Logo" />
         <div class="signup-page-button-text">Google 注册</div>
       </div>
@@ -97,6 +97,7 @@ import { githubAuthorize } from '~/utils/github'
 import { googleAuthorize } from '~/utils/google'
 import { twitterAuthorize } from '~/utils/twitter'
 const config = useRuntimeConfig()
+const route = useRoute()
 const API_BASE_URL = config.public.apiBaseUrl
 const emailStep = ref(0)
 const email = ref('')
@@ -109,9 +110,11 @@ const passwordError = ref('')
 const code = ref('')
 const isWaitingForEmailSent = ref(false)
 const isWaitingForEmailVerified = ref(false)
+const inviteToken = ref('')
 
 onMounted(async () => {
   username.value = route.query.u || ''
+  inviteToken.value = route.query.invite_token || ''
   try {
     const res = await fetch(`${API_BASE_URL}/api/config`)
     if (res.ok) {
@@ -156,6 +159,7 @@ const sendVerification = async () => {
         username: username.value,
         email: email.value,
         password: password.value,
+        ...(inviteToken.value ? { inviteToken: inviteToken.value } : {}),
       }),
     })
     isWaitingForEmailSent.value = false
@@ -184,12 +188,14 @@ const verifyCode = async () => {
       body: JSON.stringify({
         code: code.value,
         username: username.value,
+        ...(inviteToken.value ? { inviteToken: inviteToken.value } : {}),
       }),
     })
     const data = await res.json()
     if (res.ok) {
       if (registerMode.value === 'WHITELIST') {
-        navigateTo(`/signup-reason?token=${data.token}`, { replace: true })
+        const q = inviteToken.value ? `&invite_token=${inviteToken.value}` : ''
+        navigateTo(`/signup-reason?token=${data.token}${q}`, { replace: true })
       } else {
         toast.success('注册成功，请登录')
         navigateTo('/login', { replace: true })
@@ -203,14 +209,17 @@ const verifyCode = async () => {
     isWaitingForEmailVerified.value = false
   }
 }
+const signupWithGoogle = () => {
+  googleAuthorize(inviteToken.value)
+}
 const signupWithGithub = () => {
-  githubAuthorize()
+  githubAuthorize(inviteToken.value)
 }
 const signupWithDiscord = () => {
-  discordAuthorize()
+  discordAuthorize(inviteToken.value)
 }
 const signupWithTwitter = () => {
-  twitterAuthorize()
+  twitterAuthorize(inviteToken.value)
 }
 </script>
 

--- a/frontend_nuxt/pages/twitter-callback.vue
+++ b/frontend_nuxt/pages/twitter-callback.vue
@@ -9,11 +9,12 @@ import { twitterExchange } from '~/utils/twitter'
 onMounted(async () => {
   const url = new URL(window.location.href)
   const code = url.searchParams.get('code')
-  const state = url.searchParams.get('state')
-  const result = await twitterExchange(code, state, '')
+  const inviteToken = url.searchParams.get('state')
+  const result = await twitterExchange(code, inviteToken, '')
 
   if (result.needReason) {
-    navigateTo(`/signup-reason?token=${result.token}`, { replace: true })
+    const q = inviteToken ? `&invite_token=${inviteToken}` : ''
+    navigateTo(`/signup-reason?token=${result.token}${q}`, { replace: true })
   } else {
     navigateTo('/', { replace: true })
   }

--- a/frontend_nuxt/utils/discord.js
+++ b/frontend_nuxt/utils/discord.js
@@ -15,7 +15,7 @@ export function discordAuthorize(state = '') {
   window.location.href = url
 }
 
-export async function discordExchange(code, state, reason) {
+export async function discordExchange(code, inviteToken, reason) {
   try {
     const config = useRuntimeConfig()
     const API_BASE_URL = config.public.apiBaseUrl
@@ -26,7 +26,7 @@ export async function discordExchange(code, state, reason) {
         code,
         redirectUri: `${window.location.origin}/discord-callback`,
         reason,
-        state,
+        inviteToken,
       }),
     })
     const data = await res.json()

--- a/frontend_nuxt/utils/github.js
+++ b/frontend_nuxt/utils/github.js
@@ -15,7 +15,7 @@ export function githubAuthorize(state = '') {
   window.location.href = url
 }
 
-export async function githubExchange(code, state, reason) {
+export async function githubExchange(code, inviteToken, reason) {
   try {
     const config = useRuntimeConfig()
     const API_BASE_URL = config.public.apiBaseUrl
@@ -26,7 +26,7 @@ export async function githubExchange(code, state, reason) {
         code,
         redirectUri: `${window.location.origin}/github-callback`,
         reason,
-        state,
+        inviteToken,
       }),
     })
     const data = await res.json()

--- a/frontend_nuxt/utils/google.js
+++ b/frontend_nuxt/utils/google.js
@@ -21,7 +21,7 @@ export async function googleGetIdToken() {
   })
 }
 
-export function googleAuthorize() {
+export function googleAuthorize(state = '') {
   const config = useRuntimeConfig()
   const GOOGLE_CLIENT_ID = config.public.googleClientId
   const WEBSITE_BASE_URL = config.public.websiteBaseUrl
@@ -31,18 +31,23 @@ export function googleAuthorize() {
   }
   const redirectUri = `${WEBSITE_BASE_URL}/google-callback`
   const nonce = Math.random().toString(36).substring(2)
-  const url = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${GOOGLE_CLIENT_ID}&redirect_uri=${encodeURIComponent(redirectUri)}&response_type=id_token&scope=openid%20email%20profile&nonce=${nonce}`
+  const url = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${GOOGLE_CLIENT_ID}&redirect_uri=${encodeURIComponent(redirectUri)}&response_type=id_token&scope=openid%20email%20profile&nonce=${nonce}&state=${state}`
   window.location.href = url
 }
 
-export async function googleAuthWithToken(idToken, redirect_success, redirect_not_approved) {
+export async function googleAuthWithToken(
+  idToken,
+  inviteToken,
+  redirect_success,
+  redirect_not_approved,
+) {
   try {
     const config = useRuntimeConfig()
     const API_BASE_URL = config.public.apiBaseUrl
     const res = await fetch(`${API_BASE_URL}/api/auth/google`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ idToken }),
+      body: JSON.stringify({ idToken, inviteToken }),
     })
     const data = await res.json()
     if (res.ok && data.token) {
@@ -66,7 +71,7 @@ export async function googleAuthWithToken(idToken, redirect_success, redirect_no
 export async function googleSignIn(redirect_success, redirect_not_approved) {
   try {
     const token = await googleGetIdToken()
-    await googleAuthWithToken(token, redirect_success, redirect_not_approved)
+    await googleAuthWithToken(token, '', redirect_success, redirect_not_approved)
   } catch {
     /* ignore */
   }

--- a/frontend_nuxt/utils/twitter.js
+++ b/frontend_nuxt/utils/twitter.js
@@ -42,7 +42,7 @@ export async function twitterAuthorize(state = '') {
   window.location.href = url
 }
 
-export async function twitterExchange(code, state, reason) {
+export async function twitterExchange(code, inviteToken, reason) {
   try {
     const config = useRuntimeConfig()
     const API_BASE_URL = config.public.apiBaseUrl
@@ -55,7 +55,7 @@ export async function twitterExchange(code, state, reason) {
         code,
         redirectUri: `${window.location.origin}/twitter-callback`,
         reason,
-        state,
+        inviteToken,
         codeVerifier,
       }),
     })


### PR DESCRIPTION
## Summary
- capture invite_token from signup URL and forward to backend during email verification and OAuth signups
- propagate invite_token through OAuth callbacks and reason submission
- allow backend auth DTOs to accept inviteToken field

## Testing
- `npm test` (fails: Error: no test specified)
- `mvn -q -f backend/pom.xml test` (fails: Non-resolvable parent POM)


------
https://chatgpt.com/codex/tasks/task_e_68a1532b1a388327b9e32822405ab881