### PR TITLE
feat: add invite token support

### DIFF
--- a/backend/open-isle.env.example
+++ b/backend/open-isle.env.example
@@ -3,6 +3,12 @@ MYSQL_URL=jdbc:mysql://<数据库地址>:<端口>/<数据库名>?useUnicode=yes&
 MYSQL_USER=<数据库用户名>
 MYSQL_PASSWORD=<数据库密码>
 
+# === JWT ===
+JWT_SECRET=<jwt secret>
+JWT_REASON_SECRET=<jwt reason secret>
+JWT_RESET_SECRET=<jwt reset secret>
+JWT_INVITE_SECRET=<jwt invite secret>
+JWT_EXPIRATION=2592000000
 
 # === Resend ===
 RESEND_API_KEY=<你的resend-api-key>

--- a/backend/src/main/java/com/openisle/controller/InviteController.java
+++ b/backend/src/main/java/com/openisle/controller/InviteController.java
@@ -1,0 +1,23 @@
+package com.openisle.controller;
+
+import com.openisle.service.InviteService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/invite")
+@RequiredArgsConstructor
+public class InviteController {
+    private final InviteService inviteService;
+
+    @PostMapping("/generate")
+    public Map<String, String> generate(Authentication auth) {
+        String token = inviteService.generate(auth.getName());
+        return Map.of("token", token);
+    }
+}

--- a/backend/src/main/java/com/openisle/dto/DiscordLoginRequest.java
+++ b/backend/src/main/java/com/openisle/dto/DiscordLoginRequest.java
@@ -7,4 +7,5 @@ import lombok.Data;
 public class DiscordLoginRequest {
     private String code;
     private String redirectUri;
+    private String inviteToken;
 }

--- a/backend/src/main/java/com/openisle/dto/GithubLoginRequest.java
+++ b/backend/src/main/java/com/openisle/dto/GithubLoginRequest.java
@@ -7,4 +7,5 @@ import lombok.Data;
 public class GithubLoginRequest {
     private String code;
     private String redirectUri;
+    private String inviteToken;
 }

--- a/backend/src/main/java/com/openisle/dto/GoogleLoginRequest.java
+++ b/backend/src/main/java/com/openisle/dto/GoogleLoginRequest.java
@@ -6,4 +6,5 @@ import lombok.Data;
 @Data
 public class GoogleLoginRequest {
     private String idToken;
+    private String inviteToken;
 }

--- a/backend/src/main/java/com/openisle/dto/RegisterRequest.java
+++ b/backend/src/main/java/com/openisle/dto/RegisterRequest.java
@@ -9,4 +9,5 @@ public class RegisterRequest {
     private String email;
     private String password;
     private String captcha;
+    private String inviteToken;
 }

--- a/backend/src/main/java/com/openisle/dto/TwitterLoginRequest.java
+++ b/backend/src/main/java/com/openisle/dto/TwitterLoginRequest.java
@@ -8,4 +8,5 @@ public class TwitterLoginRequest {
     private String code;
     private String redirectUri;
     private String codeVerifier;
+    private String inviteToken;
 }

--- a/backend/src/main/java/com/openisle/model/InviteToken.java
+++ b/backend/src/main/java/com/openisle/model/InviteToken.java
@@ -1,0 +1,23 @@
+package com.openisle.model;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.time.LocalDate;
+
+/**
+ * Invite token entity tracking usage counts.
+ */
+@Data
+@Entity
+public class InviteToken {
+    @Id
+    private String token;
+
+    @ManyToOne
+    private User inviter;
+
+    private LocalDate createdDate;
+
+    private int usageCount;
+}

--- a/backend/src/main/java/com/openisle/repository/InviteTokenRepository.java
+++ b/backend/src/main/java/com/openisle/repository/InviteTokenRepository.java
@@ -1,0 +1,12 @@
+package com.openisle.repository;
+
+import com.openisle.model.InviteToken;
+import com.openisle.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+public interface InviteTokenRepository extends JpaRepository<InviteToken, String> {
+    Optional<InviteToken> findByInviterAndCreatedDate(User inviter, LocalDate createdDate);
+}

--- a/backend/src/main/java/com/openisle/service/AuthResult.java
+++ b/backend/src/main/java/com/openisle/service/AuthResult.java
@@ -1,0 +1,12 @@
+package com.openisle.service;
+
+import com.openisle.model.User;
+import lombok.Value;
+
+/** Result for OAuth authentication indicating whether a new user was created. */
+@Value
+public class AuthResult {
+    User user;
+    boolean newUser;
+}
+

--- a/backend/src/main/java/com/openisle/service/InviteService.java
+++ b/backend/src/main/java/com/openisle/service/InviteService.java
@@ -1,0 +1,54 @@
+package com.openisle.service;
+
+import com.openisle.model.InviteToken;
+import com.openisle.model.User;
+import com.openisle.repository.InviteTokenRepository;
+import com.openisle.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class InviteService {
+    private final InviteTokenRepository inviteTokenRepository;
+    private final UserRepository userRepository;
+    private final JwtService jwtService;
+    private final PointService pointService;
+
+    public String generate(String username) {
+        User inviter = userRepository.findByUsername(username).orElseThrow();
+        LocalDate today = LocalDate.now();
+        Optional<InviteToken> existing = inviteTokenRepository.findByInviterAndCreatedDate(inviter, today);
+        if (existing.isPresent()) {
+            return existing.get().getToken();
+        }
+        String token = jwtService.generateInviteToken(username);
+        InviteToken inviteToken = new InviteToken();
+        inviteToken.setToken(token);
+        inviteToken.setInviter(inviter);
+        inviteToken.setCreatedDate(today);
+        inviteToken.setUsageCount(0);
+        inviteTokenRepository.save(inviteToken);
+        return token;
+    }
+
+    public boolean validate(String token) {
+        try {
+            jwtService.validateAndGetSubjectForInvite(token);
+        } catch (Exception e) {
+            return false;
+        }
+        InviteToken invite = inviteTokenRepository.findById(token).orElse(null);
+        return invite != null && invite.getUsageCount() < 3;
+    }
+
+    public void consume(String token) {
+        InviteToken invite = inviteTokenRepository.findById(token).orElseThrow();
+        invite.setUsageCount(invite.getUsageCount() + 1);
+        inviteTokenRepository.save(invite);
+        pointService.awardForInvite(invite.getInviter().getUsername());
+    }
+}

--- a/backend/src/main/java/com/openisle/service/JwtService.java
+++ b/backend/src/main/java/com/openisle/service/JwtService.java
@@ -24,6 +24,9 @@ public class JwtService {
     @Value("${app.jwt.reset-secret}")
     private String resetSecret;
 
+    @Value("${app.jwt.invite-secret}")
+    private String inviteSecret;
+
     @Value("${app.jwt.expiration}")
     private long expiration;
 
@@ -70,6 +73,17 @@ public class JwtService {
                 .compact();
     }
 
+    public String generateInviteToken(String subject) {
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + expiration);
+        return Jwts.builder()
+                .setSubject(subject)
+                .setIssuedAt(now)
+                .setExpiration(expiryDate)
+                .signWith(getSigningKeyForSecret(inviteSecret))
+                .compact();
+    }
+
     public String validateAndGetSubject(String token) {
         Claims claims = Jwts.parserBuilder()
                 .setSigningKey(getSigningKeyForSecret(secret))
@@ -91,6 +105,15 @@ public class JwtService {
     public String validateAndGetSubjectForReset(String token) {
         Claims claims = Jwts.parserBuilder()
                 .setSigningKey(getSigningKeyForSecret(resetSecret))
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+        return claims.getSubject();
+    }
+
+    public String validateAndGetSubjectForInvite(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(getSigningKeyForSecret(inviteSecret))
                 .build()
                 .parseClaimsJws(token)
                 .getBody();

--- a/backend/src/main/java/com/openisle/service/PointService.java
+++ b/backend/src/main/java/com/openisle/service/PointService.java
@@ -26,6 +26,11 @@ public class PointService {
         return addPoint(user, 30);
     }
 
+    public int awardForInvite(String userName) {
+        User user = userRepository.findByUsername(userName).orElseThrow();
+        return addPoint(user, 500);
+    }
+
     private PointLog getTodayLog(User user) {
         LocalDate today = LocalDate.now();
         return pointLogRepository.findByUserAndLogDate(user, today)

--- a/backend/src/main/java/com/openisle/service/UserService.java
+++ b/backend/src/main/java/com/openisle/service/UserService.java
@@ -74,6 +74,13 @@ public class UserService {
         return userRepository.save(user);
     }
 
+    public User registerWithInvite(String username, String email, String password) {
+        User user = register(username, email, password, "", com.openisle.model.RegisterMode.DIRECT);
+        user.setVerified(true);
+        user.setVerificationCode(null);
+        return userRepository.save(user);
+    }
+
     private String genCode() {
         return String.format("%06d", new Random().nextInt(1000000));
     }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -10,6 +10,7 @@ spring.jpa.hibernate.ddl-auto=update
 app.jwt.secret=${JWT_SECRET:jwt_sec}
 app.jwt.reason-secret=${JWT_REASON_SECRET:jwt_reason_sec}
 app.jwt.reset-secret=${JWT_RESET_SECRET:jwt_reset_sec}
+app.jwt.invite-secret=${JWT_INVITE_SECRET:jwt_invite_sec}
 # 30 days
 app.jwt.expiration=${JWT_EXPIRATION:2592000000}
 # Password strength: LOW, MEDIUM or HIGH


### PR DESCRIPTION
## Summary
- support generating daily invite tokens and track usage
- allow registration via invite tokens and grant inviter points
- handle invite tokens for OAuth logins and surface INVITE_APPROVED reason code

## Testing
- `mvn -q -f backend/pom.xml test` *(fails: Network is unreachable for org.springframework.boot:spring-boot-starter-parent:3.1.1)*


------
https://chatgpt.com/codex/tasks/task_e_68a20799a28c83279f6edef7b5026efe