### PR TITLE
Handle nullable rssExcluded flag

### DIFF
--- a/backend/src/main/java/com/openisle/mapper/PostMapper.java
+++ b/backend/src/main/java/com/openisle/mapper/PostMapper.java
@@ -63,7 +63,7 @@ public class PostMapper {
         dto.setCommentCount(commentService.countComments(post.getId()));
         dto.setStatus(post.getStatus());
         dto.setPinnedAt(post.getPinnedAt());
-        dto.setRssExcluded(post.isRssExcluded());
+        dto.setRssExcluded(post.getRssExcluded() == null || post.getRssExcluded());
 
         List<ReactionDto> reactions = reactionService.getReactionsForPost(post.getId())
                 .stream()

--- a/backend/src/main/java/com/openisle/model/Post.java
+++ b/backend/src/main/java/com/openisle/model/Post.java
@@ -68,5 +68,5 @@ public class Post {
     private LocalDateTime pinnedAt;
 
     @Column(nullable = true)
-    private boolean rssExcluded = true;
+    private Boolean rssExcluded = true;
 }


### PR DESCRIPTION
## Summary
- Use `Boolean` in `Post` entity for `rssExcluded` so null database values no longer break entity mapping
- Interpret `null` as excluded from RSS when mapping posts to DTOs

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a3cfa94a30832798926958ce7641e2