### PR TITLE
feat: Add inner and outer margins to code elements

### DIFF
--- a/frontend_nuxt/assets/global.css
+++ b/frontend_nuxt/assets/global.css
@@ -186,6 +186,8 @@ body {
   white-space: no-wrap;
   background-color: var(--code-highlight-background-color);
   color: var(--text-color);
+  padding: 2px 4px;
+  margin: 0 2px;
 }
 
 .copy-code-btn {


### PR DESCRIPTION
<img width="1670" height="456" alt="image" src="https://github.com/user-attachments/assets/bd468a61-ba42-4979-bb41-f8acd46f38d3" />

这样修改后，现在看起来是这样子的