### PR TITLE
feat: add paginated notifications and unread endpoint

### DIFF
--- a/backend/src/main/java/com/openisle/controller/NotificationController.java
+++ b/backend/src/main/java/com/openisle/controller/NotificationController.java
@@ -24,8 +24,17 @@ public class NotificationController {
 
     @GetMapping
     public List<NotificationDto> list(@RequestParam(value = "read", required = false) Boolean read,
+                                      @RequestParam(value = "page", defaultValue = "0") int page,
                                       Authentication auth) {
-        return notificationService.listNotifications(auth.getName(), read).stream()
+        return notificationService.listNotifications(auth.getName(), read, page, 50).stream()
+                .map(notificationMapper::toDto)
+                .collect(Collectors.toList());
+    }
+
+    @GetMapping("/unread")
+    public List<NotificationDto> listUnread(@RequestParam(value = "page", defaultValue = "0") int page,
+                                            Authentication auth) {
+        return notificationService.listNotifications(auth.getName(), false, page, 50).stream()
                 .map(notificationMapper::toDto)
                 .collect(Collectors.toList());
     }

--- a/backend/src/main/java/com/openisle/repository/NotificationRepository.java
+++ b/backend/src/main/java/com/openisle/repository/NotificationRepository.java
@@ -6,6 +6,8 @@ import com.openisle.model.Post;
 import com.openisle.model.Comment;
 import com.openisle.model.NotificationType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
@@ -13,6 +15,8 @@ import java.util.List;
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
     List<Notification> findByUserOrderByCreatedAtDesc(User user);
     List<Notification> findByUserAndReadOrderByCreatedAtDesc(User user, boolean read);
+    Page<Notification> findByUser(User user, Pageable pageable);
+    Page<Notification> findByUserAndRead(User user, boolean read, Pageable pageable);
     long countByUserAndRead(User user, boolean read);
     List<Notification> findByPost(Post post);
     List<Notification> findByComment(Comment comment);

--- a/backend/src/main/java/com/openisle/service/NotificationService.java
+++ b/backend/src/main/java/com/openisle/service/NotificationService.java
@@ -24,6 +24,10 @@ import java.util.List;
 import java.util.ArrayList;
 import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 
 /** Service for creating and retrieving notifications. */
 @Service
@@ -180,17 +184,19 @@ public class NotificationService {
         userRepository.save(user);
     }
 
-    public List<Notification> listNotifications(String username, Boolean read) {
+    public List<Notification> listNotifications(String username, Boolean read, int page, int size) {
         User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> new com.openisle.exception.NotFoundException("User not found"));
         Set<NotificationType> disabled = user.getDisabledNotificationTypes();
-        List<Notification> list;
+        Pageable pageable = PageRequest.of(page, size,
+                Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<Notification> pg;
         if (read == null) {
-            list = notificationRepository.findByUserOrderByCreatedAtDesc(user);
+            pg = notificationRepository.findByUser(user, pageable);
         } else {
-            list = notificationRepository.findByUserAndReadOrderByCreatedAtDesc(user, read);
+            pg = notificationRepository.findByUserAndRead(user, read, pageable);
         }
-        return list.stream().filter(n -> !disabled.contains(n.getType())).collect(Collectors.toList());
+        return pg.stream().filter(n -> !disabled.contains(n.getType())).collect(Collectors.toList());
     }
 
     public void markRead(String username, List<Long> ids) {

--- a/backend/src/test/java/com/openisle/controller/NotificationControllerTest.java
+++ b/backend/src/test/java/com/openisle/controller/NotificationControllerTest.java
@@ -45,7 +45,7 @@ class NotificationControllerTest {
         p.setId(2L);
         n.setPost(p);
         n.setCreatedAt(LocalDateTime.now());
-        when(notificationService.listNotifications("alice", null))
+        when(notificationService.listNotifications("alice", null, 0, 50))
                 .thenReturn(List.of(n));
 
         NotificationDto dto = new NotificationDto();
@@ -55,7 +55,33 @@ class NotificationControllerTest {
         dto.setPost(ps);
         when(notificationMapper.toDto(n)).thenReturn(dto);
 
-        mockMvc.perform(get("/api/notifications")
+        mockMvc.perform(get("/api/notifications?page=0")
+                        .principal(new UsernamePasswordAuthenticationToken("alice","p")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(1))
+                .andExpect(jsonPath("$[0].post.id").value(2));
+    }
+
+    @Test
+    void listUnreadNotifications() throws Exception {
+        Notification n = new Notification();
+        n.setId(1L);
+        n.setType(NotificationType.POST_VIEWED);
+        Post p = new Post();
+        p.setId(2L);
+        n.setPost(p);
+        n.setCreatedAt(LocalDateTime.now());
+        when(notificationService.listNotifications("alice", false, 0, 50))
+                .thenReturn(List.of(n));
+
+        NotificationDto dto = new NotificationDto();
+        dto.setId(1L);
+        PostSummaryDto ps = new PostSummaryDto();
+        ps.setId(2L);
+        dto.setPost(ps);
+        when(notificationMapper.toDto(n)).thenReturn(dto);
+
+        mockMvc.perform(get("/api/notifications/unread?page=0")
                         .principal(new UsernamePasswordAuthenticationToken("alice","p")))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].id").value(1))

--- a/backend/src/test/java/com/openisle/service/NotificationServiceTest.java
+++ b/backend/src/test/java/com/openisle/service/NotificationServiceTest.java
@@ -65,12 +65,12 @@ class NotificationServiceTest {
         when(uRepo.findByUsername("bob")).thenReturn(Optional.of(user));
 
         Notification n = new Notification();
-        when(nRepo.findByUserOrderByCreatedAtDesc(user)).thenReturn(List.of(n));
+        when(nRepo.findByUser(eq(user), any())).thenReturn(new org.springframework.data.domain.PageImpl<>(List.of(n)));
 
-        List<Notification> list = service.listNotifications("bob", null);
+        List<Notification> list = service.listNotifications("bob", null, 0, 50);
 
         assertEquals(1, list.size());
-        verify(nRepo).findByUserOrderByCreatedAtDesc(user);
+        verify(nRepo).findByUser(eq(user), any());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add pagination and unread endpoint for notifications API
- implement paginated notifications fetching in frontend with InfiniteLoadMore

## Testing
- `mvn test` *(fails: Non-resolvable parent POM ...)*
- `npm test` *(fails: no test specified)*
- `npm test` in `frontend_nuxt` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a4444d61a08327a5c7be41f4eeab91