### PR TITLE
feat: add paginated notification endpoints

### DIFF
--- a/backend/src/main/java/com/openisle/controller/NotificationController.java
+++ b/backend/src/main/java/com/openisle/controller/NotificationController.java
@@ -23,9 +23,19 @@ public class NotificationController {
     private final NotificationMapper notificationMapper;
 
     @GetMapping
-    public List<NotificationDto> list(@RequestParam(value = "read", required = false) Boolean read,
+    public List<NotificationDto> list(@RequestParam(value = "page", defaultValue = "0") int page,
+                                      @RequestParam(value = "size", defaultValue = "30") int size,
                                       Authentication auth) {
-        return notificationService.listNotifications(auth.getName(), read).stream()
+        return notificationService.listNotifications(auth.getName(), null, page, size).stream()
+                .map(notificationMapper::toDto)
+                .collect(Collectors.toList());
+    }
+
+    @GetMapping("/unread")
+    public List<NotificationDto> listUnread(@RequestParam(value = "page", defaultValue = "0") int page,
+                                            @RequestParam(value = "size", defaultValue = "30") int size,
+                                            Authentication auth) {
+        return notificationService.listNotifications(auth.getName(), false, page, size).stream()
                 .map(notificationMapper::toDto)
                 .collect(Collectors.toList());
     }

--- a/backend/src/main/java/com/openisle/repository/NotificationRepository.java
+++ b/backend/src/main/java/com/openisle/repository/NotificationRepository.java
@@ -6,6 +6,8 @@ import com.openisle.model.Post;
 import com.openisle.model.Comment;
 import com.openisle.model.NotificationType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
@@ -13,6 +15,8 @@ import java.util.List;
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
     List<Notification> findByUserOrderByCreatedAtDesc(User user);
     List<Notification> findByUserAndReadOrderByCreatedAtDesc(User user, boolean read);
+    Page<Notification> findByUserOrderByCreatedAtDesc(User user, Pageable pageable);
+    Page<Notification> findByUserAndReadOrderByCreatedAtDesc(User user, boolean read, Pageable pageable);
     long countByUserAndRead(User user, boolean read);
     List<Notification> findByPost(Post post);
     List<Notification> findByComment(Comment comment);

--- a/backend/src/main/java/com/openisle/service/NotificationService.java
+++ b/backend/src/main/java/com/openisle/service/NotificationService.java
@@ -180,17 +180,18 @@ public class NotificationService {
         userRepository.save(user);
     }
 
-    public List<Notification> listNotifications(String username, Boolean read) {
+    public List<Notification> listNotifications(String username, Boolean read, int page, int size) {
         User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> new com.openisle.exception.NotFoundException("User not found"));
         Set<NotificationType> disabled = user.getDisabledNotificationTypes();
-        List<Notification> list;
+        org.springframework.data.domain.Pageable pageable = org.springframework.data.domain.PageRequest.of(page, size);
+        org.springframework.data.domain.Page<Notification> result;
         if (read == null) {
-            list = notificationRepository.findByUserOrderByCreatedAtDesc(user);
+            result = notificationRepository.findByUserOrderByCreatedAtDesc(user, pageable);
         } else {
-            list = notificationRepository.findByUserAndReadOrderByCreatedAtDesc(user, read);
+            result = notificationRepository.findByUserAndReadOrderByCreatedAtDesc(user, read, pageable);
         }
-        return list.stream().filter(n -> !disabled.contains(n.getType())).collect(Collectors.toList());
+        return result.stream().filter(n -> !disabled.contains(n.getType())).collect(Collectors.toList());
     }
 
     public void markRead(String username, List<Long> ids) {

--- a/backend/src/test/java/com/openisle/controller/NotificationControllerTest.java
+++ b/backend/src/test/java/com/openisle/controller/NotificationControllerTest.java
@@ -45,7 +45,7 @@ class NotificationControllerTest {
         p.setId(2L);
         n.setPost(p);
         n.setCreatedAt(LocalDateTime.now());
-        when(notificationService.listNotifications("alice", null))
+        when(notificationService.listNotifications("alice", null, 0, 30))
                 .thenReturn(List.of(n));
 
         NotificationDto dto = new NotificationDto();
@@ -60,6 +60,24 @@ class NotificationControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].id").value(1))
                 .andExpect(jsonPath("$[0].post.id").value(2));
+    }
+
+    @Test
+    void listUnreadNotifications() throws Exception {
+        Notification n = new Notification();
+        n.setId(5L);
+        n.setType(NotificationType.POST_VIEWED);
+        when(notificationService.listNotifications("alice", false, 0, 30))
+                .thenReturn(List.of(n));
+
+        NotificationDto dto = new NotificationDto();
+        dto.setId(5L);
+        when(notificationMapper.toDto(n)).thenReturn(dto);
+
+        mockMvc.perform(get("/api/notifications/unread")
+                        .principal(new UsernamePasswordAuthenticationToken("alice","p")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(5));
     }
 
     @Test

--- a/backend/src/test/java/com/openisle/service/NotificationServiceTest.java
+++ b/backend/src/test/java/com/openisle/service/NotificationServiceTest.java
@@ -11,6 +11,8 @@ import org.mockito.Mockito;
 
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -65,12 +67,13 @@ class NotificationServiceTest {
         when(uRepo.findByUsername("bob")).thenReturn(Optional.of(user));
 
         Notification n = new Notification();
-        when(nRepo.findByUserOrderByCreatedAtDesc(user)).thenReturn(List.of(n));
+        when(nRepo.findByUserOrderByCreatedAtDesc(eq(user), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(n)));
 
-        List<Notification> list = service.listNotifications("bob", null);
+        List<Notification> list = service.listNotifications("bob", null, 0, 10);
 
         assertEquals(1, list.size());
-        verify(nRepo).findByUserOrderByCreatedAtDesc(user);
+        verify(nRepo).findByUserOrderByCreatedAtDesc(eq(user), any(Pageable.class));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- support page+size for notification queries and add unread endpoint
- fetch messages and unread separately with infinite scrolling
- enable front-end to request pages of notifications instead of client filtering

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a45a16b98c8327b830723d71969960