### PR TITLE
feat: add paginated notifications and unread endpoint

### DIFF
--- a/backend/src/main/java/com/openisle/controller/NotificationController.java
+++ b/backend/src/main/java/com/openisle/controller/NotificationController.java
@@ -24,8 +24,19 @@ public class NotificationController {
 
     @GetMapping
     public List<NotificationDto> list(@RequestParam(value = "read", required = false) Boolean read,
+                                      @RequestParam(value = "page", defaultValue = "0") int page,
+                                      @RequestParam(value = "size", defaultValue = "30") int size,
                                       Authentication auth) {
-        return notificationService.listNotifications(auth.getName(), read).stream()
+        return notificationService.listNotifications(auth.getName(), read, page, size).stream()
+                .map(notificationMapper::toDto)
+                .collect(Collectors.toList());
+    }
+
+    @GetMapping("/unread")
+    public List<NotificationDto> listUnread(@RequestParam(value = "page", defaultValue = "0") int page,
+                                            @RequestParam(value = "size", defaultValue = "30") int size,
+                                            Authentication auth) {
+        return notificationService.listNotifications(auth.getName(), false, page, size).stream()
                 .map(notificationMapper::toDto)
                 .collect(Collectors.toList());
     }

--- a/backend/src/main/java/com/openisle/repository/NotificationRepository.java
+++ b/backend/src/main/java/com/openisle/repository/NotificationRepository.java
@@ -6,6 +6,8 @@ import com.openisle.model.Post;
 import com.openisle.model.Comment;
 import com.openisle.model.NotificationType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
@@ -13,6 +15,8 @@ import java.util.List;
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
     List<Notification> findByUserOrderByCreatedAtDesc(User user);
     List<Notification> findByUserAndReadOrderByCreatedAtDesc(User user, boolean read);
+    Page<Notification> findByUserOrderByCreatedAtDesc(User user, Pageable pageable);
+    Page<Notification> findByUserAndReadOrderByCreatedAtDesc(User user, boolean read, Pageable pageable);
     long countByUserAndRead(User user, boolean read);
     List<Notification> findByPost(Post post);
     List<Notification> findByComment(Comment comment);

--- a/backend/src/main/java/com/openisle/service/NotificationService.java
+++ b/backend/src/main/java/com/openisle/service/NotificationService.java
@@ -180,15 +180,21 @@ public class NotificationService {
         userRepository.save(user);
     }
 
-    public List<Notification> listNotifications(String username, Boolean read) {
+    public List<Notification> listNotifications(String username, Boolean read, int page, int size) {
         User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> new com.openisle.exception.NotFoundException("User not found"));
         Set<NotificationType> disabled = user.getDisabledNotificationTypes();
+        org.springframework.data.domain.Pageable pageable =
+                org.springframework.data.domain.PageRequest.of(page, size);
         List<Notification> list;
         if (read == null) {
-            list = notificationRepository.findByUserOrderByCreatedAtDesc(user);
+            list = notificationRepository
+                    .findByUserOrderByCreatedAtDesc(user, pageable)
+                    .getContent();
         } else {
-            list = notificationRepository.findByUserAndReadOrderByCreatedAtDesc(user, read);
+            list = notificationRepository
+                    .findByUserAndReadOrderByCreatedAtDesc(user, read, pageable)
+                    .getContent();
         }
         return list.stream().filter(n -> !disabled.contains(n.getType())).collect(Collectors.toList());
     }

--- a/frontend_nuxt/pages/message.vue
+++ b/frontend_nuxt/pages/message.vue
@@ -505,13 +505,16 @@
             </div>
           </template>
         </BaseTimeline>
+        <div v-if="hasMore" class="load-more">
+          <button class="load-more-button" @click="loadMore">加载更多</button>
+        </div>
       </div>
     </template>
   </div>
 </template>
 
 <script setup>
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import BasePlaceholder from '~/components/BasePlaceholder.vue'
 import BaseTimeline from '~/components/BaseTimeline.vue'
 import NotificationContainer from '~/components/NotificationContainer.vue'
@@ -519,12 +522,17 @@ import { toast } from '~/main'
 import { authState, getToken } from '~/utils/auth'
 import { stripMarkdownLength } from '~/utils/markdown'
 import {
-  fetchNotifications,
+  fetchAllNotifications,
+  fetchUnreadNotifications,
   fetchUnreadCount,
-  isLoadingMessage,
+  isLoadingAll,
+  isLoadingUnread,
   markRead,
-  notifications,
+  notificationsAll,
+  notificationsUnread,
   markAllRead,
+  fetchNotificationPreferences,
+  updateNotificationPreference,
 } from '~/utils/notification'
 import TimeManager from '~/utils/time'
 
@@ -535,8 +543,18 @@ const selectedTab = ref(
   ['all', 'unread', 'control'].includes(route.query.tab) ? route.query.tab : 'unread',
 )
 const notificationPrefs = ref([])
+const pageAll = ref(0)
+const pageUnread = ref(0)
+const hasMoreAll = ref(true)
+const hasMoreUnread = ref(true)
 const filteredNotifications = computed(() =>
-  selectedTab.value === 'all' ? notifications.value : notifications.value.filter((n) => !n.read),
+  selectedTab.value === 'all' ? notificationsAll.value : notificationsUnread.value,
+)
+const isLoadingMessage = computed(() =>
+  selectedTab.value === 'all' ? isLoadingAll.value : isLoadingUnread.value,
+)
+const hasMore = computed(() =>
+  selectedTab.value === 'all' ? hasMoreAll.value : hasMoreUnread.value,
 )
 
 const fetchPrefs = async () => {
@@ -547,7 +565,14 @@ const togglePref = async (pref) => {
   const ok = await updateNotificationPreference(pref.type, !pref.enabled)
   if (ok) {
     pref.enabled = !pref.enabled
-    await fetchNotifications()
+    pageAll.value = 0
+    pageUnread.value = 0
+    const countAll = await fetchAllNotifications(0)
+    const countUnread = await fetchUnreadNotifications(0)
+    pageAll.value = 1
+    pageUnread.value = 1
+    hasMoreAll.value = countAll === 30
+    hasMoreUnread.value = countUnread === 30
     await fetchUnreadCount()
   } else {
     toast.error('操作失败')
@@ -627,9 +652,34 @@ const formatType = (t) => {
   }
 }
 
-onActivated(() => {
-  fetchNotifications()
-  fetchPrefs()
+const loadMore = async () => {
+  if (selectedTab.value === 'all') {
+    const c = await fetchAllNotifications(pageAll.value)
+    pageAll.value++
+    if (c < 30) hasMoreAll.value = false
+  } else {
+    const c = await fetchUnreadNotifications(pageUnread.value)
+    pageUnread.value++
+    if (c < 30) hasMoreUnread.value = false
+  }
+}
+
+onMounted(async () => {
+  await fetchPrefs()
+  await loadMore()
+  await fetchUnreadCount()
+})
+
+watch(selectedTab, async (tab) => {
+  if (tab === 'all' && notificationsAll.value.length === 0) {
+    pageAll.value = 0
+    hasMoreAll.value = true
+    await loadMore()
+  } else if (tab === 'unread' && notificationsUnread.value.length === 0) {
+    pageUnread.value = 0
+    hasMoreUnread.value = true
+    await loadMore()
+  }
 })
 </script>
 
@@ -689,6 +739,19 @@ onActivated(() => {
 .timeline-container {
   padding: 10px 20px;
   height: 100%;
+}
+
+.load-more {
+  text-align: center;
+}
+
+.load-more-button {
+  margin: 10px auto;
+  padding: 6px 12px;
+  border: 1px solid var(--normal-border-color);
+  border-radius: 6px;
+  background: transparent;
+  cursor: pointer;
 }
 
 .notif-content {


### PR DESCRIPTION
## Summary
- add page & size parameters to notification APIs and provide unread-only endpoint
- support pageable queries in notification service & repository
- paginate notifications on frontend with separate "all" and "unread" lists

## Testing
- `npm test` (fails: Error: no test specified)
- `mvn -q -f backend/pom.xml test` (fails: Non-resolvable parent POM: Network is unreachable)


------
https://chatgpt.com/codex/tasks/task_e_68a45a16b98c8327b830723d71969960