### PR TITLE
feat: allow closing posts

### DIFF
--- a/backend/src/main/java/com/openisle/controller/PostController.java
+++ b/backend/src/main/java/com/openisle/controller/PostController.java
@@ -62,6 +62,16 @@ public class PostController {
         postService.deletePost(id, auth.getName());
     }
 
+    @PostMapping("/{id}/close")
+    public PostSummaryDto close(@PathVariable Long id, Authentication auth) {
+        return postMapper.toSummaryDto(postService.closePost(id, auth.getName()));
+    }
+
+    @PostMapping("/{id}/reopen")
+    public PostSummaryDto reopen(@PathVariable Long id, Authentication auth) {
+        return postMapper.toSummaryDto(postService.reopenPost(id, auth.getName()));
+    }
+
     @GetMapping("/{id}")
     public ResponseEntity<PostDetailDto> getPost(@PathVariable Long id, Authentication auth) {
         String viewer = auth != null ? auth.getName() : null;

--- a/backend/src/main/java/com/openisle/dto/PostSummaryDto.java
+++ b/backend/src/main/java/com/openisle/dto/PostSummaryDto.java
@@ -32,5 +32,6 @@ public class PostSummaryDto {
     private PostType type;
     private LotteryDto lottery;
     private boolean rssExcluded;
+    private boolean closed;
 }
 

--- a/backend/src/main/java/com/openisle/mapper/PostMapper.java
+++ b/backend/src/main/java/com/openisle/mapper/PostMapper.java
@@ -64,6 +64,7 @@ public class PostMapper {
         dto.setStatus(post.getStatus());
         dto.setPinnedAt(post.getPinnedAt());
         dto.setRssExcluded(post.getRssExcluded() == null || post.getRssExcluded());
+        dto.setClosed(post.isClosed());
 
         List<ReactionDto> reactions = reactionService.getReactionsForPost(post.getId())
                 .stream()

--- a/backend/src/main/java/com/openisle/model/Post.java
+++ b/backend/src/main/java/com/openisle/model/Post.java
@@ -64,6 +64,9 @@ public class Post {
     @Column(nullable = false)
     private PostType type = PostType.NORMAL;
 
+    @Column(nullable = false)
+    private boolean closed = false;
+
     @Column
     private LocalDateTime pinnedAt;
 

--- a/backend/src/main/java/com/openisle/service/CommentService.java
+++ b/backend/src/main/java/com/openisle/service/CommentService.java
@@ -52,6 +52,9 @@ public class CommentService {
                 .orElseThrow(() -> new com.openisle.exception.NotFoundException("User not found"));
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new com.openisle.exception.NotFoundException("Post not found"));
+        if (post.isClosed()) {
+            throw new IllegalStateException("Post closed");
+        }
         Comment comment = new Comment();
         comment.setAuthor(author);
         comment.setPost(post);
@@ -94,6 +97,9 @@ public class CommentService {
                 .orElseThrow(() -> new com.openisle.exception.NotFoundException("User not found"));
         Comment parent = commentRepository.findById(parentId)
                 .orElseThrow(() -> new IllegalArgumentException("Comment not found"));
+        if (parent.getPost().isClosed()) {
+            throw new IllegalStateException("Post closed");
+        }
         Comment comment = new Comment();
         comment.setAuthor(author);
         comment.setPost(parent.getPost());

--- a/backend/src/main/java/com/openisle/service/PostService.java
+++ b/backend/src/main/java/com/openisle/service/PostService.java
@@ -512,6 +512,30 @@ public class PostService {
         return postRepository.save(post);
     }
 
+    public Post closePost(Long id, String username) {
+        Post post = postRepository.findById(id)
+                .orElseThrow(() -> new com.openisle.exception.NotFoundException("Post not found"));
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new com.openisle.exception.NotFoundException("User not found"));
+        if (!user.getId().equals(post.getAuthor().getId()) && user.getRole() != Role.ADMIN) {
+            throw new IllegalArgumentException("Unauthorized");
+        }
+        post.setClosed(true);
+        return postRepository.save(post);
+    }
+
+    public Post reopenPost(Long id, String username) {
+        Post post = postRepository.findById(id)
+                .orElseThrow(() -> new com.openisle.exception.NotFoundException("Post not found"));
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new com.openisle.exception.NotFoundException("User not found"));
+        if (!user.getId().equals(post.getAuthor().getId()) && user.getRole() != Role.ADMIN) {
+            throw new IllegalArgumentException("Unauthorized");
+        }
+        post.setClosed(false);
+        return postRepository.save(post);
+    }
+
     @org.springframework.transaction.annotation.Transactional
     public Post updatePost(Long id,
                            String username,

--- a/frontend_nuxt/components/CommentItem.vue
+++ b/frontend_nuxt/components/CommentItem.vue
@@ -57,7 +57,7 @@
           v-if="showEditor"
           @submit="submitReply"
           :loading="isWaitingForReply"
-          :disabled="!loggedIn"
+          :disabled="!loggedIn || postClosed"
           :show-login-overlay="!loggedIn"
           :parent-user-name="comment.userName"
         />
@@ -76,6 +76,7 @@
               :level="level + 1"
               :default-show-replies="item.openReplies"
               :post-author-id="postAuthorId"
+              :post-closed="postClosed"
             />
           </template>
         </BaseTimeline>
@@ -122,6 +123,10 @@ const props = defineProps({
     type: [Number, String],
     required: true,
   },
+  postClosed: {
+    type: Boolean,
+    default: false,
+  },
 })
 
 const emit = defineEmits(['deleted'])
@@ -148,6 +153,7 @@ const toggleReplies = () => {
 }
 
 const toggleEditor = () => {
+  if (props.postClosed) return
   showEditor.value = !showEditor.value
   if (showEditor.value) {
     setTimeout(() => {
@@ -213,6 +219,10 @@ const deleteComment = async () => {
 }
 const submitReply = async (parentUserName, text, clear) => {
   if (!text.trim()) return
+  if (props.postClosed) {
+    toast.error('帖子已关闭')
+    return
+  }
   isWaitingForReply.value = true
   const token = getToken()
   if (!token) {


### PR DESCRIPTION
## Summary
- support closing and reopening posts
- disable comment editors on closed posts
- show closed badge and menu actions in post page

## Testing
- `npm test` *(fails: Error: no test specified)*
- `mvn -q -f backend/pom.xml test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68a4843fc28c83278599c2d9762917b8