### PR TITLE
fix: 修复超长文本造成ui宽度撑开

### DIFF
--- a/frontend_nuxt/assets/global.css
+++ b/frontend_nuxt/assets/global.css
@@ -184,7 +184,7 @@ body {
   font-family: 'Maple Mono', monospace;
   font-size: 13px;
   border-radius: 4px;
-  white-space: no-wrap;
+  white-space: break-spaces;
   background-color: var(--code-highlight-background-color);
   color: var(--text-color);
 }


### PR DESCRIPTION

<img width="1300" height="630" alt="3c2279f2-cb40-4cf1-a0fb-eb6242e929c3" src="https://github.com/user-attachments/assets/3e23679d-fb87-49e0-8810-840d5e68739d" />

<img width="1291" height="656" alt="image" src="https://github.com/user-attachments/assets/593415bb-d204-4175-9fa5-a53dc17e6e9f" />

Closed #602