### PR TITLE
feat: notify authors when admin deletes post

### DIFF
--- a/backend/src/main/java/com/openisle/model/NotificationType.java
+++ b/backend/src/main/java/com/openisle/model/NotificationType.java
@@ -14,6 +14,8 @@ public enum NotificationType {
     POST_REVIEW_REQUEST,
     /** Your post under review was approved or rejected */
     POST_REVIEWED,
+    /** An administrator deleted your post */
+    POST_DELETED,
     /** A subscribed post received a new comment */
     POST_UPDATED,
     /** Someone subscribed to your post */

--- a/backend/src/test/java/com/openisle/service/PostServiceTest.java
+++ b/backend/src/test/java/com/openisle/service/PostServiceTest.java
@@ -62,6 +62,58 @@ class PostServiceTest {
     }
 
     @Test
+    void deletePostByAdminNotifiesAuthor() {
+        PostRepository postRepo = mock(PostRepository.class);
+        UserRepository userRepo = mock(UserRepository.class);
+        CategoryRepository catRepo = mock(CategoryRepository.class);
+        TagRepository tagRepo = mock(TagRepository.class);
+        LotteryPostRepository lotteryRepo = mock(LotteryPostRepository.class);
+        NotificationService notifService = mock(NotificationService.class);
+        SubscriptionService subService = mock(SubscriptionService.class);
+        CommentService commentService = mock(CommentService.class);
+        CommentRepository commentRepo = mock(CommentRepository.class);
+        ReactionRepository reactionRepo = mock(ReactionRepository.class);
+        PostSubscriptionRepository subRepo = mock(PostSubscriptionRepository.class);
+        NotificationRepository notificationRepo = mock(NotificationRepository.class);
+        PostReadService postReadService = mock(PostReadService.class);
+        ImageUploader imageUploader = mock(ImageUploader.class);
+        TaskScheduler taskScheduler = mock(TaskScheduler.class);
+        EmailSender emailSender = mock(EmailSender.class);
+        ApplicationContext context = mock(ApplicationContext.class);
+
+        PostService service = new PostService(postRepo, userRepo, catRepo, tagRepo, lotteryRepo,
+                notifService, subService, commentService, commentRepo,
+                reactionRepo, subRepo, notificationRepo, postReadService,
+                imageUploader, taskScheduler, emailSender, context, PublishMode.DIRECT);
+        when(context.getBean(PostService.class)).thenReturn(service);
+
+        Post post = new Post();
+        post.setId(1L);
+        post.setTitle("T");
+        post.setContent("");
+        User author = new User();
+        author.setId(2L);
+        author.setRole(Role.USER);
+        post.setAuthor(author);
+
+        User admin = new User();
+        admin.setId(1L);
+        admin.setRole(Role.ADMIN);
+
+        when(postRepo.findById(1L)).thenReturn(Optional.of(post));
+        when(userRepo.findByUsername("admin")).thenReturn(Optional.of(admin));
+        when(commentRepo.findByPostAndParentIsNullOrderByCreatedAtAsc(post)).thenReturn(List.of());
+        when(reactionRepo.findByPost(post)).thenReturn(List.of());
+        when(subRepo.findByPost(post)).thenReturn(List.of());
+        when(notificationRepo.findByPost(post)).thenReturn(List.of());
+
+        service.deletePost(1L, "admin");
+
+        verify(notifService).createNotification(eq(author), eq(NotificationType.POST_DELETED), isNull(),
+                isNull(), isNull(), eq(admin), isNull(), eq("T"));
+    }
+
+    @Test
     void createPostRespectsRateLimit() {
         PostRepository postRepo = mock(PostRepository.class);
         UserRepository userRepo = mock(UserRepository.class);

--- a/frontend_nuxt/pages/message.vue
+++ b/frontend_nuxt/pages/message.vue
@@ -495,6 +495,24 @@
                     已被管理员拒绝
                   </NotificationContainer>
                 </template>
+                <template v-else-if="item.type === 'POST_DELETED'">
+                  <NotificationContainer :item="item" :markRead="markRead">
+                    管理员
+                    <template v-if="item.fromUser">
+                      <NuxtLink
+                        class="notif-content-text"
+                        @click="markRead(item.id)"
+                        :to="`/users/${item.fromUser.id}`"
+                      >
+                        {{ item.fromUser.username }}
+                      </NuxtLink>
+                    </template>
+                    删除了您的帖子
+                    <span class="notif-content-text">
+                      {{ stripMarkdownLength(item.content, 100) }}
+                    </span>
+                  </NotificationContainer>
+                </template>
                 <template v-else>
                   <NotificationContainer :item="item" :markRead="markRead">
                     {{ formatType(item.type) }}
@@ -647,6 +665,8 @@ const formatType = (t) => {
       return '抽奖中奖了'
     case 'LOTTERY_DRAW':
       return '抽奖已开奖'
+    case 'POST_DELETED':
+      return '帖子被删除'
     default:
       return t
   }

--- a/frontend_nuxt/utils/notification.js
+++ b/frontend_nuxt/utils/notification.js
@@ -26,6 +26,7 @@ const iconMap = {
   LOTTERY_WIN: 'fas fa-trophy',
   LOTTERY_DRAW: 'fas fa-bullhorn',
   MENTION: 'fas fa-at',
+  POST_DELETED: 'fas fa-trash',
 }
 
 export async function fetchUnreadCount() {
@@ -174,6 +175,18 @@ function createFetchNotifications() {
             },
           })
         } else if (n.type === 'POST_VIEWED') {
+          arr.push({
+            ...n,
+            src: n.fromUser ? n.fromUser.avatar : null,
+            icon: n.fromUser ? undefined : iconMap[n.type],
+            iconClick: () => {
+              if (n.fromUser) {
+                markRead(n.id)
+                navigateTo(`/users/${n.fromUser.id}`, { replace: true })
+              }
+            },
+          })
+        } else if (n.type === 'POST_DELETED') {
           arr.push({
             ...n,
             src: n.fromUser ? n.fromUser.avatar : null,


### PR DESCRIPTION
## Summary
- add `POST_DELETED` notification type
- notify post authors when admins remove their posts
- display delete notifications in web UI

## Testing
- `npm test` *(fails: Error: no test specified)*
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b53997248327a927eef828b28a16