### PR TITLE
Remove notification after marking read

### DIFF
--- a/frontend_nuxt/pages/message.vue
+++ b/frontend_nuxt/pages/message.vue
@@ -524,7 +524,7 @@ import {
   fetchNotifications,
   fetchUnreadCount,
   isLoadingMessage,
-  markRead,
+  markRead as markNotificationRead,
   notifications,
   markAllRead,
   hasMore,
@@ -576,6 +576,14 @@ const togglePref = async (pref) => {
     await fetchUnreadCount()
   } else {
     toast.error('操作失败')
+  }
+}
+
+const markRead = async (id) => {
+  await markNotificationRead(id)
+  if (selectedTab.value === 'unread') {
+    const index = notifications.value.findIndex((n) => n.id === id)
+    if (index !== -1) notifications.value.splice(index, 1)
   }
 }
 


### PR DESCRIPTION
## Summary
- remove notifications from unread tab upon marking read

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b5452c4c83279ccbd0249b76843c