### PR TITLE
Add point redemption history record

### DIFF
--- a/backend/src/main/java/com/openisle/model/PointHistoryType.java
+++ b/backend/src/main/java/com/openisle/model/PointHistoryType.java
@@ -6,5 +6,6 @@ public enum PointHistoryType {
     POST_LIKED,
     COMMENT_LIKED,
     INVITE,
-    SYSTEM_ONLINE
+    SYSTEM_ONLINE,
+    REDEEM
 }

--- a/backend/src/main/java/com/openisle/service/PointMallService.java
+++ b/backend/src/main/java/com/openisle/service/PointMallService.java
@@ -3,8 +3,11 @@ package com.openisle.service;
 import com.openisle.exception.FieldException;
 import com.openisle.exception.NotFoundException;
 import com.openisle.model.PointGood;
+import com.openisle.model.PointHistory;
+import com.openisle.model.PointHistoryType;
 import com.openisle.model.User;
 import com.openisle.repository.PointGoodRepository;
+import com.openisle.repository.PointHistoryRepository;
 import com.openisle.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,6 +21,7 @@ public class PointMallService {
     private final PointGoodRepository pointGoodRepository;
     private final UserRepository userRepository;
     private final NotificationService notificationService;
+    private final PointHistoryRepository pointHistoryRepository;
 
     public List<PointGood> listGoods() {
         return pointGoodRepository.findAll();
@@ -32,6 +36,13 @@ public class PointMallService {
         user.setPoint(user.getPoint() - good.getCost());
         userRepository.save(user);
         notificationService.createPointRedeemNotifications(user, good.getName() + ": " + contact);
+        PointHistory history = new PointHistory();
+        history.setUser(user);
+        history.setType(PointHistoryType.REDEEM);
+        history.setAmount(-good.getCost());
+        history.setBalance(user.getPoint());
+        history.setCreatedAt(java.time.LocalDateTime.now());
+        pointHistoryRepository.save(history);
         return user.getPoint();
     }
 }

--- a/frontend_nuxt/pages/points.vue
+++ b/frontend_nuxt/pages/points.vue
@@ -136,6 +136,9 @@
                 }}</NuxtLink>
                 加入社区 🎉，获得 {{ item.amount }} 积分
               </template>
+              <template v-else-if="item.type === 'REDEEM'">
+                兑换商品，消耗 {{ -item.amount }} 积分
+              </template>
               <template v-else-if="item.type === 'SYSTEM_ONLINE'"> 积分历史系统上线 </template>
               <i class="fas fa-coins"></i> 你目前的积分是 {{ item.balance }}
             </div>
@@ -188,6 +191,7 @@ const iconMap = {
   COMMENT_LIKED: 'fas fa-thumbs-up',
   INVITE: 'fas fa-user-plus',
   SYSTEM_ONLINE: 'fas fa-clock',
+  REDEEM: 'fas fa-gift',
 }
 
 onMounted(async () => {


### PR DESCRIPTION
## Summary
- log REDEEM type in point history when goods are redeemed
- show redemption entries in points page history

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a6af42a29c8327b7535a56680a29ca