### PR TITLE
feat: 优化部分样式和文案

### DIFF
--- a/frontend_nuxt/components/MenuComponent.vue
+++ b/frontend_nuxt/components/MenuComponent.vue
@@ -106,7 +106,7 @@
 
         <div class="menu-section">
           <div class="section-header" @click="tagOpen = !tagOpen">
-            <span>tag</span>
+            <span>标签</span>
             <i :class="tagOpen ? 'fas fa-chevron-up' : 'fas fa-chevron-down'"></i>
           </div>
           <div v-if="tagOpen" class="section-items">

--- a/frontend_nuxt/components/MenuComponent.vue
+++ b/frontend_nuxt/components/MenuComponent.vue
@@ -262,7 +262,7 @@ const gotoTag = (t) => {
   top: var(--header-height);
   width: 220px;
   background-color: var(--app-menu-background-color);
-  height: calc(100vh - 20px - var(--header-height));
+  height: calc(100vh - var(--header-height));
   border-right: 1px solid var(--menu-border-color);
   display: flex;
   flex-direction: column;
@@ -348,6 +348,7 @@ const gotoTag = (t) => {
   display: flex;
   align-items: center;
   justify-content: center;
+  cursor: pointer;
 }
 
 .menu-section {

--- a/frontend_nuxt/pages/about/index.vue
+++ b/frontend_nuxt/pages/about/index.vue
@@ -98,9 +98,7 @@ export default {
 }
 
 .about-tabs {
-  position: sticky;
   top: calc(var(--header-height) + 1px);
-  z-index: 200;
   background-color: var(--background-color-blur);
   display: flex;
   flex-direction: row;

--- a/frontend_nuxt/pages/index.vue
+++ b/frontend_nuxt/pages/index.vue
@@ -449,7 +449,7 @@ const sanitizeDescription = (text) => stripMarkdown(text)
 }
 
 .topic-item {
-  padding: 10px 20px;
+  padding: 6px 20px;
   cursor: pointer;
 }
 

--- a/frontend_nuxt/pages/index.vue
+++ b/frontend_nuxt/pages/index.vue
@@ -449,7 +449,7 @@ const sanitizeDescription = (text) => stripMarkdown(text)
 }
 
 .topic-item {
-  padding: 2px 10px;
+  padding: 10px 20px;
   cursor: pointer;
 }
 

--- a/frontend_nuxt/pages/message.vue
+++ b/frontend_nuxt/pages/message.vue
@@ -724,6 +724,7 @@ onActivated(async () => {
   justify-content: space-between;
   align-items: center;
   backdrop-filter: var(--blur-10);
+  border-bottom: 1px solid var(--normal-border-color);
 }
 
 .message-page-header-right {
@@ -837,7 +838,6 @@ onActivated(async () => {
 .message-tabs {
   display: flex;
   flex-direction: row;
-  border-bottom: 1px solid var(--normal-border-color);
 }
 
 .message-tab-item {

--- a/frontend_nuxt/pages/new-post.vue
+++ b/frontend_nuxt/pages/new-post.vue
@@ -16,7 +16,7 @@
           <div class="post-clear" @click="clearPost"><i class="fa-solid fa-eraser"></i> 清空</div>
           <div class="ai-generate" @click="aiGenerate">
             <i class="fa-solid fa-robot"></i>
-            md格式优化
+            MD 格式优化
           </div>
           <div class="post-draft" @click="saveDraft">
             <i class="fa-solid fa-floppy-disk"></i>

--- a/frontend_nuxt/pages/posts/[id]/edit.vue
+++ b/frontend_nuxt/pages/posts/[id]/edit.vue
@@ -15,7 +15,7 @@
           <div class="post-clear" @click="clearPost"><i class="fa-solid fa-eraser"></i> 清空</div>
           <div class="ai-generate" @click="aiGenerate">
             <i class="fa-solid fa-robot"></i>
-            md格式优化
+            MD 格式优化
           </div>
           <div class="post-cancel" @click="cancelEdit">取消</div>
           <div


### PR DESCRIPTION
1. 文案优化
    <img width="180" height="56" alt="Clipboard_Screenshot_1755790539" src="https://github.com/user-attachments/assets/fc4965fa-4740-4fa9-89dd-8064d96e43a0" />
2. 优化 about 页导航栏透明的问题
    <img width="597" height="115" alt="Clipboard_Screenshot_1755790442" src="https://github.com/user-attachments/assets/d3b89080-3492-4ca5-84b1-aed4ed315a4b" />
3. 优化 message 页导航栏未充满容器的问题
    <img width="588" height="72" alt="Clipboard_Screenshot_1755790606" src="https://github.com/user-attachments/assets/8dd2d9ab-d496-4158-88a5-f0120a60e63a" />
4. 优化左侧栏高度未撑满容器的问题
    <img width="242" height="142" alt="Clipboard_Screenshot_1755790665" src="https://github.com/user-attachments/assets/e499b5d5-066a-498e-be4b-15ed471d97fb" />
5. 优化 tags 页导航栏间距
    <img width="336" height="80" alt="Clipboard_Screenshot_1755790765" src="https://github.com/user-attachments/assets/d7c34f6d-f510-464a-85d4-11f4ae8937a3" />
