### PR TITLE
chore: 移除未使用的依赖 && 调整 husky 配置

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx lint-staged

--- a/package.json
+++ b/package.json
@@ -1,69 +1,28 @@
 {
   "name": "openisle",
   "version": "1.0.0",
+  "private": true,
   "description": "<p align=\"center\">   <img alt=\"OpenIsle\" src=\"https://openisle-1307107697.cos.ap-guangzhou.myqcloud.com/assert/image.png\" width=\"200\">   <br><br>   高效的开源社区前后端端平台   <br><br>   <a href=\"LICENSE\"><img src=\"https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square\"></a> </p>",
-  "main": "index.js",
-  "dependencies": {
-    "ansi-escapes": "^7.0.0",
-    "ansi-regex": "^6.1.0",
-    "ansi-styles": "^6.2.1",
-    "braces": "^3.0.3",
-    "chalk": "^5.5.0",
-    "cli-cursor": "^5.0.0",
-    "cli-truncate": "^4.0.0",
-    "colorette": "^2.0.20",
-    "commander": "^14.0.0",
-    "debug": "^4.4.1",
-    "emoji-regex": "^10.4.0",
-    "environment": "^1.1.0",
-    "eventemitter3": "^5.0.1",
-    "fill-range": "^7.1.1",
-    "get-east-asian-width": "^1.3.0",
-    "is-fullwidth-code-point": "^4.0.0",
-    "is-number": "^7.0.0",
-    "lilconfig": "^3.1.3",
-    "listr2": "^9.0.1",
-    "log-update": "^6.1.0",
-    "micromatch": "^4.0.8",
-    "mimic-function": "^5.0.1",
-    "ms": "^2.1.3",
-    "nano-spawn": "^1.0.2",
-    "onetime": "^7.0.0",
-    "picomatch": "^2.3.1",
-    "pidtree": "^0.6.0",
-    "restore-cursor": "^5.1.0",
-    "rfdc": "^1.4.1",
-    "signal-exit": "^4.1.0",
-    "slice-ansi": "^5.0.0",
-    "string-argv": "^0.3.2",
-    "string-width": "^7.2.0",
-    "strip-ansi": "^7.1.0",
-    "to-regex-range": "^5.0.1",
-    "wrap-ansi": "^9.0.0",
-    "yaml": "^2.8.1"
+  "author": "nagisa77",
+  "license": "ISC",
+  "homepage": "https://www.open-isle.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nagisa77/OpenIsle.git"
+  },
+  "bugs": {
+    "url": "https://github.com/nagisa77/OpenIsle/issues"
+  },
+  "keywords": [],
+  "scripts": {
+    "prepare": "husky"
   },
   "devDependencies": {
     "husky": "^9.1.7",
     "lint-staged": "^16.1.5",
     "prettier": "^3.6.2"
   },
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "prepare": "husky"
-  },
   "lint-staged": {
     "frontend_nuxt/**/*": "prettier --write --cache --ignore-unknown"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/nagisa77/OpenIsle.git"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
-  "type": "commonjs",
-  "bugs": {
-    "url": "https://github.com/nagisa77/OpenIsle/issues"
-  },
-  "homepage": "https://github.com/nagisa77/OpenIsle#readme"
+  }
 }


### PR DESCRIPTION
1. `git commit` 时会提示 `husky - DEPRECATED`，系 husky 的提示，见 https://github.com/typicode/husky/issues/1480
    <img width="677" height="280" alt="Clipboard_Screenshot_1755791516" src="https://github.com/user-attachments/assets/9f959bb1-1e42-4b20-a3a9-e0cd1924d531" />
2. 项目根目录存在不少未使用的依赖，如果是运行时依赖，也应该放在 `frontend_nuxt/` 中，遂进行清理，只保留脚手架相关的工具依赖