### PR TITLE
feat: add channel chat support with tabs

### DIFF
--- a/backend/src/main/java/com/openisle/config/ChannelInitializer.java
+++ b/backend/src/main/java/com/openisle/config/ChannelInitializer.java
@@ -1,0 +1,35 @@
+package com.openisle.config;
+
+import com.openisle.model.Channel;
+import com.openisle.model.MessageConversation;
+import com.openisle.repository.ChannelRepository;
+import com.openisle.repository.MessageConversationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ChannelInitializer implements CommandLineRunner {
+    private final ChannelRepository channelRepository;
+    private final MessageConversationRepository conversationRepository;
+
+    @Override
+    public void run(String... args) {
+        if (channelRepository.count() == 0) {
+            createChannel("吹水群", "闲聊讨论", "/default-avatar.svg");
+            createChannel("技术讨论群", "技术交流", "/default-avatar.svg");
+        }
+    }
+
+    private void createChannel(String name, String description, String avatar) {
+        MessageConversation conversation = new MessageConversation();
+        conversation = conversationRepository.save(conversation);
+        Channel channel = new Channel();
+        channel.setName(name);
+        channel.setDescription(description);
+        channel.setAvatar(avatar);
+        channel.setConversation(conversation);
+        channelRepository.save(channel);
+    }
+}

--- a/backend/src/main/java/com/openisle/controller/ChannelController.java
+++ b/backend/src/main/java/com/openisle/controller/ChannelController.java
@@ -1,0 +1,82 @@
+package com.openisle.controller;
+
+import com.openisle.dto.ChannelDto;
+import com.openisle.model.Channel;
+import com.openisle.model.MessageParticipant;
+import com.openisle.model.MessageConversation;
+import com.openisle.model.User;
+import com.openisle.repository.ChannelRepository;
+import com.openisle.repository.MessageParticipantRepository;
+import com.openisle.repository.UserRepository;
+import com.openisle.repository.MessageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/channels")
+@RequiredArgsConstructor
+public class ChannelController {
+    private final ChannelRepository channelRepository;
+    private final MessageParticipantRepository participantRepository;
+    private final UserRepository userRepository;
+    private final MessageRepository messageRepository;
+
+    private Long getCurrentUserId(Authentication auth) {
+        User user = userRepository.findByUsername(auth.getName()).orElseThrow(() -> new IllegalArgumentException("User not found"));
+        return user.getId();
+    }
+
+    @GetMapping
+    public ResponseEntity<List<ChannelDto>> listChannels(Authentication auth) {
+        Long userId = auth == null ? null : getCurrentUserId(auth);
+        List<ChannelDto> channels = channelRepository.findAll().stream()
+                .map(c -> toDto(c, userId))
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(channels);
+    }
+
+    @PostMapping("/{id}/join")
+    public ResponseEntity<Void> joinChannel(@PathVariable Long id, Authentication auth) {
+        Channel channel = channelRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("Channel not found"));
+        Long userId = getCurrentUserId(auth);
+        boolean exists = channel.getConversation().getParticipants().stream().anyMatch(p -> p.getUser().getId().equals(userId));
+        if (!exists) {
+            MessageParticipant participant = new MessageParticipant();
+            participant.setConversation(channel.getConversation());
+            participant.setUser(userRepository.findById(userId).orElseThrow(() -> new IllegalArgumentException("User not found")));
+            participantRepository.save(participant);
+        }
+        return ResponseEntity.ok().build();
+    }
+
+    private ChannelDto toDto(Channel channel, Long userId) {
+        ChannelDto dto = new ChannelDto();
+        dto.setId(channel.getId());
+        dto.setName(channel.getName());
+        dto.setDescription(channel.getDescription());
+        dto.setAvatar(channel.getAvatar());
+        if (channel.getConversation() != null) {
+            MessageConversation conversation = channel.getConversation();
+            dto.setConversationId(conversation.getId());
+            dto.setMemberCount(conversation.getParticipants().size());
+            if (userId != null) {
+                MessageParticipant self = conversation.getParticipants().stream()
+                        .filter(p -> p.getUser().getId().equals(userId))
+                        .findFirst().orElse(null);
+                if (self != null) {
+                    var lastRead = self.getLastReadAt();
+                    dto.setUnreadCount(messageRepository
+                            .countByConversationIdAndCreatedAtAfterAndSenderIdNot(conversation.getId(),
+                                    lastRead == null ? java.time.LocalDateTime.of(1970,1,1,0,0) : lastRead,
+                                    userId));
+                }
+            }
+        }
+        return dto;
+    }
+}

--- a/backend/src/main/java/com/openisle/controller/MessageController.java
+++ b/backend/src/main/java/com/openisle/controller/MessageController.java
@@ -59,6 +59,14 @@ public class MessageController {
         return ResponseEntity.ok(toDto(message));
     }
 
+    @PostMapping("/conversations/{conversationId}/messages")
+    public ResponseEntity<MessageDto> sendMessageToConversation(@PathVariable Long conversationId,
+                                                                @RequestBody ContentRequest req,
+                                                                Authentication auth) {
+        Message message = messageService.sendMessageToConversation(getCurrentUserId(auth), conversationId, req.getContent());
+        return ResponseEntity.ok(toDto(message));
+    }
+
     @PostMapping("/conversations/{conversationId}/read")
     public ResponseEntity<Void> markAsRead(@PathVariable Long conversationId, Authentication auth) {
         messageService.markConversationAsRead(conversationId, getCurrentUserId(auth));
@@ -105,6 +113,18 @@ public class MessageController {
         public void setRecipientId(Long recipientId) {
             this.recipientId = recipientId;
         }
+
+        public String getContent() {
+            return content;
+        }
+
+        public void setContent(String content) {
+            this.content = content;
+        }
+    }
+
+    static class ContentRequest {
+        private String content;
 
         public String getContent() {
             return content;

--- a/backend/src/main/java/com/openisle/dto/ChannelDto.java
+++ b/backend/src/main/java/com/openisle/dto/ChannelDto.java
@@ -1,0 +1,16 @@
+package com.openisle.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ChannelDto {
+    private Long id;
+    private String name;
+    private String description;
+    private String avatar;
+    private Long conversationId;
+    private int memberCount;
+    private long unreadCount;
+}

--- a/backend/src/main/java/com/openisle/dto/ConversationDetailDto.java
+++ b/backend/src/main/java/com/openisle/dto/ConversationDetailDto.java
@@ -10,4 +10,5 @@ public class ConversationDetailDto {
     private Long id;
     private List<UserSummaryDto> participants;
     private Page<MessageDto> messages;
+    private ChannelDto channel;
 }

--- a/backend/src/main/java/com/openisle/dto/ConversationDto.java
+++ b/backend/src/main/java/com/openisle/dto/ConversationDto.java
@@ -3,6 +3,7 @@ package com.openisle.dto;
 import lombok.Getter;
 import lombok.Setter;
 
+
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -14,4 +15,5 @@ public class ConversationDto {
     private List<UserSummaryDto> participants;
     private LocalDateTime createdAt;
     private long unreadCount;
+    private ChannelDto channel;
 }

--- a/backend/src/main/java/com/openisle/model/Channel.java
+++ b/backend/src/main/java/com/openisle/model/Channel.java
@@ -1,0 +1,27 @@
+package com.openisle.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "channels")
+@Getter
+@Setter
+@NoArgsConstructor
+public class Channel {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    private String description;
+
+    private String avatar;
+
+    @OneToOne
+    @JoinColumn(name = "conversation_id")
+    private MessageConversation conversation;
+}

--- a/backend/src/main/java/com/openisle/repository/ChannelRepository.java
+++ b/backend/src/main/java/com/openisle/repository/ChannelRepository.java
@@ -1,0 +1,10 @@
+package com.openisle.repository;
+
+import com.openisle.model.Channel;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ChannelRepository extends JpaRepository<Channel, Long> {
+    Optional<Channel> findByConversationId(Long conversationId);
+}


### PR DESCRIPTION
## Summary
- add channel entities and REST endpoints for listing and joining channels
- expose message conversation API to send messages directly to channel conversations
- update message box UI with tabs for site messages and channels, showing unread indicators

## Testing
- `npm test` *(fails: Missing script "test")*
- `cd backend && mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a63625408327a045e36efa32020b