### PR TITLE
feat: add channel support

### DIFF
--- a/backend/src/main/java/com/openisle/config/ChannelInitializer.java
+++ b/backend/src/main/java/com/openisle/config/ChannelInitializer.java
@@ -1,0 +1,32 @@
+package com.openisle.config;
+
+import com.openisle.model.MessageConversation;
+import com.openisle.repository.MessageConversationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ChannelInitializer implements CommandLineRunner {
+    private final MessageConversationRepository conversationRepository;
+
+    @Override
+    public void run(String... args) {
+        if (conversationRepository.countByChannelTrue() == 0) {
+            MessageConversation chat = new MessageConversation();
+            chat.setChannel(true);
+            chat.setName("吹水群");
+            chat.setDescription("吹水聊天");
+            chat.setAvatar("/default-avatar.svg");
+            conversationRepository.save(chat);
+
+            MessageConversation tech = new MessageConversation();
+            tech.setChannel(true);
+            tech.setName("技术讨论群");
+            tech.setDescription("讨论技术相关话题");
+            tech.setAvatar("/default-avatar.svg");
+            conversationRepository.save(tech);
+        }
+    }
+}

--- a/backend/src/main/java/com/openisle/controller/ChannelController.java
+++ b/backend/src/main/java/com/openisle/controller/ChannelController.java
@@ -1,0 +1,35 @@
+package com.openisle.controller;
+
+import com.openisle.dto.ChannelDto;
+import com.openisle.model.User;
+import com.openisle.repository.UserRepository;
+import com.openisle.service.ChannelService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/channels")
+@RequiredArgsConstructor
+public class ChannelController {
+    private final ChannelService channelService;
+    private final UserRepository userRepository;
+
+    private Long getCurrentUserId(Authentication auth) {
+        User user = userRepository.findByUsername(auth.getName())
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+        return user.getId();
+    }
+
+    @GetMapping
+    public List<ChannelDto> listChannels(Authentication auth) {
+        return channelService.listChannels(getCurrentUserId(auth));
+    }
+
+    @PostMapping("/{channelId}/join")
+    public ChannelDto joinChannel(@PathVariable Long channelId, Authentication auth) {
+        return channelService.joinChannel(channelId, getCurrentUserId(auth));
+    }
+}

--- a/backend/src/main/java/com/openisle/controller/MessageController.java
+++ b/backend/src/main/java/com/openisle/controller/MessageController.java
@@ -59,6 +59,14 @@ public class MessageController {
         return ResponseEntity.ok(toDto(message));
     }
 
+    @PostMapping("/conversations/{conversationId}/messages")
+    public ResponseEntity<MessageDto> sendMessageToConversation(@PathVariable Long conversationId,
+                                                                @RequestBody ChannelMessageRequest req,
+                                                                Authentication auth) {
+        Message message = messageService.sendMessageToConversation(getCurrentUserId(auth), conversationId, req.getContent());
+        return ResponseEntity.ok(toDto(message));
+    }
+
     @PostMapping("/conversations/{conversationId}/read")
     public ResponseEntity<Void> markAsRead(@PathVariable Long conversationId, Authentication auth) {
         messageService.markConversationAsRead(conversationId, getCurrentUserId(auth));
@@ -105,6 +113,18 @@ public class MessageController {
         public void setRecipientId(Long recipientId) {
             this.recipientId = recipientId;
         }
+
+        public String getContent() {
+            return content;
+        }
+
+        public void setContent(String content) {
+            this.content = content;
+        }
+    }
+
+    static class ChannelMessageRequest {
+        private String content;
 
         public String getContent() {
             return content;

--- a/backend/src/main/java/com/openisle/dto/ChannelDto.java
+++ b/backend/src/main/java/com/openisle/dto/ChannelDto.java
@@ -1,0 +1,16 @@
+package com.openisle.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ChannelDto {
+    private Long id;
+    private String name;
+    private String description;
+    private String avatar;
+    private long memberCount;
+    private boolean joined;
+    private long unreadCount;
+}

--- a/backend/src/main/java/com/openisle/dto/ConversationDetailDto.java
+++ b/backend/src/main/java/com/openisle/dto/ConversationDetailDto.java
@@ -8,6 +8,9 @@ import java.util.List;
 @Data
 public class ConversationDetailDto {
     private Long id;
+    private String name;
+    private boolean channel;
+    private String avatar;
     private List<UserSummaryDto> participants;
     private Page<MessageDto> messages;
 }

--- a/backend/src/main/java/com/openisle/dto/ConversationDto.java
+++ b/backend/src/main/java/com/openisle/dto/ConversationDto.java
@@ -10,6 +10,9 @@ import java.util.List;
 @Setter
 public class ConversationDto {
     private Long id;
+    private String name;
+    private boolean channel;
+    private String avatar;
     private MessageDto lastMessage;
     private List<UserSummaryDto> participants;
     private LocalDateTime createdAt;

--- a/backend/src/main/java/com/openisle/model/MessageConversation.java
+++ b/backend/src/main/java/com/openisle/model/MessageConversation.java
@@ -20,6 +20,18 @@ public class MessageConversation {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    // Indicates whether this conversation represents a public channel
+    @Column(nullable = false)
+    private boolean channel = false;
+
+    // Channel metadata
+    private String name;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    private String avatar;
+
     @CreationTimestamp
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;

--- a/backend/src/main/java/com/openisle/repository/MessageConversationRepository.java
+++ b/backend/src/main/java/com/openisle/repository/MessageConversationRepository.java
@@ -28,4 +28,8 @@ public interface MessageConversationRepository extends JpaRepository<MessageConv
            "WHERE p.user.id = :userId " +
            "ORDER BY COALESCE(lm.createdAt, c.createdAt) DESC")
     List<MessageConversation> findConversationsByUserIdOrderByLastMessageDesc(@Param("userId") Long userId);
+
+    List<MessageConversation> findByChannelTrue();
+
+    long countByChannelTrue();
 }

--- a/backend/src/main/java/com/openisle/service/ChannelService.java
+++ b/backend/src/main/java/com/openisle/service/ChannelService.java
@@ -1,0 +1,76 @@
+package com.openisle.service;
+
+import com.openisle.dto.ChannelDto;
+import com.openisle.model.MessageConversation;
+import com.openisle.model.MessageParticipant;
+import com.openisle.model.User;
+import com.openisle.repository.MessageConversationRepository;
+import com.openisle.repository.MessageParticipantRepository;
+import com.openisle.repository.MessageRepository;
+import com.openisle.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ChannelService {
+    private final MessageConversationRepository conversationRepository;
+    private final MessageParticipantRepository participantRepository;
+    private final MessageRepository messageRepository;
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public List<ChannelDto> listChannels(Long userId) {
+        List<MessageConversation> channels = conversationRepository.findByChannelTrue();
+        return channels.stream().map(c -> toDto(c, userId)).collect(Collectors.toList());
+    }
+
+    @Transactional
+    public ChannelDto joinChannel(Long channelId, Long userId) {
+        MessageConversation channel = conversationRepository.findById(channelId)
+                .orElseThrow(() -> new IllegalArgumentException("Channel not found"));
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+        participantRepository.findByConversationIdAndUserId(channelId, userId)
+                .orElseGet(() -> {
+                    MessageParticipant p = new MessageParticipant();
+                    p.setConversation(channel);
+                    p.setUser(user);
+                    MessageParticipant saved = participantRepository.save(p);
+                    channel.getParticipants().add(saved);
+                    return saved;
+                });
+        return toDto(channel, userId);
+    }
+
+    private ChannelDto toDto(MessageConversation channel, Long userId) {
+        ChannelDto dto = new ChannelDto();
+        dto.setId(channel.getId());
+        dto.setName(channel.getName());
+        dto.setDescription(channel.getDescription());
+        dto.setAvatar(channel.getAvatar());
+        dto.setMemberCount(channel.getParticipants().size());
+        boolean joined = channel.getParticipants().stream()
+                .anyMatch(p -> p.getUser().getId().equals(userId));
+        dto.setJoined(joined);
+        if (joined) {
+            MessageParticipant participant = channel.getParticipants().stream()
+                    .filter(p -> p.getUser().getId().equals(userId))
+                    .findFirst().orElse(null);
+            LocalDateTime lastRead = participant.getLastReadAt() == null
+                    ? LocalDateTime.of(1970, 1, 1, 0, 0)
+                    : participant.getLastReadAt();
+            long unread = messageRepository
+                    .countByConversationIdAndCreatedAtAfterAndSenderIdNot(channel.getId(), lastRead, userId);
+            dto.setUnreadCount(unread);
+        } else {
+            dto.setUnreadCount(0);
+        }
+        return dto;
+    }
+}

--- a/backend/src/main/java/com/openisle/service/MessageService.java
+++ b/backend/src/main/java/com/openisle/service/MessageService.java
@@ -82,6 +82,49 @@ public class MessageService {
         return message;
     }
 
+    @Transactional
+    public Message sendMessageToConversation(Long senderId, Long conversationId, String content) {
+        User sender = userRepository.findById(senderId)
+                .orElseThrow(() -> new IllegalArgumentException("Sender not found"));
+        MessageConversation conversation = conversationRepository.findById(conversationId)
+                .orElseThrow(() -> new IllegalArgumentException("Conversation not found"));
+
+        // Join the conversation if not already a participant (useful for channels)
+        participantRepository.findByConversationIdAndUserId(conversationId, senderId)
+                .orElseGet(() -> {
+                    MessageParticipant p = new MessageParticipant();
+                    p.setConversation(conversation);
+                    p.setUser(sender);
+                    return participantRepository.save(p);
+                });
+
+        Message message = new Message();
+        message.setConversation(conversation);
+        message.setSender(sender);
+        message.setContent(content);
+        message = messageRepository.save(message);
+
+        conversation.setLastMessage(message);
+        conversationRepository.save(conversation);
+
+        MessageDto messageDto = toDto(message);
+        String conversationDestination = "/topic/conversation/" + conversation.getId();
+        messagingTemplate.convertAndSend(conversationDestination, messageDto);
+
+        // Notify all participants except sender for updates
+        for (MessageParticipant participant : conversation.getParticipants()) {
+            if (participant.getUser().getId().equals(senderId)) continue;
+            String userDestination = "/topic/user/" + participant.getUser().getId() + "/messages";
+            messagingTemplate.convertAndSend(userDestination, messageDto);
+
+            long unreadCount = getUnreadMessageCount(participant.getUser().getId());
+            String username = participant.getUser().getUsername();
+            messagingTemplate.convertAndSendToUser(username, "/queue/unread-count", unreadCount);
+        }
+
+        return message;
+    }
+
     private MessageDto toDto(Message message) {
         MessageDto dto = new MessageDto();
         dto.setId(message.getId());
@@ -134,12 +177,18 @@ public class MessageService {
     @Transactional(readOnly = true)
     public List<ConversationDto> getConversations(Long userId) {
         List<MessageConversation> conversations = conversationRepository.findConversationsByUserIdOrderByLastMessageDesc(userId);
-        return conversations.stream().map(c -> toDto(c, userId)).collect(Collectors.toList());
+        return conversations.stream()
+                .filter(c -> !c.isChannel())
+                .map(c -> toDto(c, userId))
+                .collect(Collectors.toList());
     }
 
     private ConversationDto toDto(MessageConversation conversation, Long userId) {
         ConversationDto dto = new ConversationDto();
         dto.setId(conversation.getId());
+        dto.setChannel(conversation.isChannel());
+        dto.setName(conversation.getName());
+        dto.setAvatar(conversation.getAvatar());
         dto.setCreatedAt(conversation.getCreatedAt());
         if (conversation.getLastMessage() != null) {
             dto.setLastMessage(toDto(conversation.getLastMessage()));
@@ -189,6 +238,9 @@ public class MessageService {
 
         ConversationDetailDto detailDto = new ConversationDetailDto();
         detailDto.setId(conversation.getId());
+        detailDto.setName(conversation.getName());
+        detailDto.setChannel(conversation.isChannel());
+        detailDto.setAvatar(conversation.getAvatar());
         detailDto.setParticipants(participants);
         detailDto.setMessages(messageDtoPage);
 


### PR DESCRIPTION
## Summary
- add tabbed message box with channel list and red-dot unread indicator
- seed default channels and provide API to list/join channels
- support chatting in channels via conversation-based messaging

## Testing
- `npx prettier --check frontend_nuxt/pages/message-box/index.vue frontend_nuxt/pages/message-box/[id].vue`
- `mvn -q -f backend/pom.xml test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a7d5445c8327b6374a04f957300b