### PR TITLE
Handle multiple conversations between users

### DIFF
--- a/backend/src/main/java/com/openisle/repository/MessageConversationRepository.java
+++ b/backend/src/main/java/com/openisle/repository/MessageConversationRepository.java
@@ -1,23 +1,19 @@
 package com.openisle.repository;
 
 import com.openisle.model.MessageConversation;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
 import com.openisle.model.User;
-import java.util.List;
-
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
-import com.openisle.model.User;
 import java.util.List;
 
 @Repository
 public interface MessageConversationRepository extends JpaRepository<MessageConversation, Long> {
-    @Query("SELECT c FROM MessageConversation c JOIN c.participants p1 JOIN c.participants p2 WHERE p1.user = :user1 AND p2.user = :user2")
-    Optional<MessageConversation> findConversationByUsers(@Param("user1") User user1, @Param("user2") User user2);
+    @Query("SELECT c FROM MessageConversation c JOIN c.participants p1 JOIN c.participants p2 " +
+           "WHERE p1.user = :user1 AND p2.user = :user2 ORDER BY c.createdAt DESC")
+    List<MessageConversation> findConversationsByUsers(@Param("user1") User user1, @Param("user2") User user2);
     
     @Query("SELECT DISTINCT c FROM MessageConversation c " +
            "JOIN c.participants p " +

--- a/backend/src/main/java/com/openisle/service/MessageService.java
+++ b/backend/src/main/java/com/openisle/service/MessageService.java
@@ -154,7 +154,8 @@ public class MessageService {
 
     private MessageConversation findOrCreateConversation(User user1, User user2) {
         log.info("Searching for existing conversation between {} and {}", user1.getUsername(), user2.getUsername());
-        return conversationRepository.findConversationByUsers(user1, user2)
+        return conversationRepository.findConversationsByUsers(user1, user2).stream()
+                .findFirst()
                 .orElseGet(() -> {
                     log.info("No existing conversation found. Creating a new one.");
                     MessageConversation conversation = new MessageConversation();


### PR DESCRIPTION
## Summary
- Fetch conversations between two users as an ordered list to avoid incorrect result size errors
- Use the first existing conversation or create a new one if none are found

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM because network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b8433cf8832790ef83cfe1e78485