### PR TITLE
feat: limit BaseTimeline hover to private messages

### DIFF
--- a/frontend_nuxt/components/BaseTimeline.vue
+++ b/frontend_nuxt/components/BaseTimeline.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="timeline">
+  <div class="timeline" :class="{ 'hover-enabled': hover }">
     <div class="timeline-item" v-for="(item, idx) in items" :key="idx">
       <div
         class="timeline-icon"
@@ -22,6 +22,7 @@ export default {
   name: 'BaseTimeline',
   props: {
     items: { type: Array, default: () => [] },
+    hover: { type: Boolean, default: false },
   },
 }
 </script>
@@ -41,7 +42,7 @@ export default {
   margin-top: 10px;
 }
 
-.timeline-item:hover {
+.hover-enabled .timeline-item:hover {
   background-color: var(--menu-selected-background-color);
   transition: background-color 0.2s;
   border-radius: 10px;

--- a/frontend_nuxt/pages/message-box/[id].vue
+++ b/frontend_nuxt/pages/message-box/[id].vue
@@ -20,7 +20,7 @@
             {{ loadingMore ? '加载中...' : '查看更多消息' }}
           </div>
         </div>
-        <BaseTimeline :items="messages">
+        <BaseTimeline :items="messages" hover>
           <template #item="{ item }">
             <div class="message-header">
               <div class="user-name">


### PR DESCRIPTION
## Summary
- add optional `hover` prop to `BaseTimeline` and only enable when requested
- enable hover for private message timeline

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx prettier --write frontend_nuxt/components/BaseTimeline.vue frontend_nuxt/pages/message-box/[id].vue`


------
https://chatgpt.com/codex/tasks/task_e_68abc9bfc3548327aeda3673b241da89