### PR TITLE
feat: add floating message window

### DIFF
--- a/frontend_nuxt/app.vue
+++ b/frontend_nuxt/app.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="app">
-    <div class="header-container">
+    <div class="header-container" v-if="!isFloatMode">
       <HeaderComponent
         ref="header"
         @toggle-menu="menuVisible = !menuVisible"
@@ -9,19 +9,28 @@
     </div>
 
     <div class="main-container">
-      <div class="menu-container" v-click-outside="handleMenuOutside">
+      <div v-if="!isFloatMode" class="menu-container" v-click-outside="handleMenuOutside">
         <MenuComponent :visible="!hideMenu && menuVisible" @item-click="menuVisible = false" />
       </div>
-      <div class="content" :class="{ 'menu-open': menuVisible && !hideMenu }">
+      <div
+        class="content"
+        :class="{ 'menu-open': menuVisible && !hideMenu }"
+        :style="isFloatMode ? 'padding-top:0; min-height:100vh;' : ''"
+      >
         <NuxtPage keepalive />
       </div>
 
-      <div v-if="showNewPostIcon && isMobile" class="app-new-post-icon" @click="goToNewPost">
+      <div
+        v-if="showNewPostIcon && isMobile && !isFloatMode"
+        class="app-new-post-icon"
+        @click="goToNewPost"
+      >
         <i class="fas fa-edit"></i>
       </div>
     </div>
-    <GlobalPopups />
-    <ConfirmDialog />
+    <GlobalPopups v-if="!isFloatMode" />
+    <ConfirmDialog v-if="!isFloatMode" />
+    <MessageFloat />
   </div>
 </template>
 
@@ -30,12 +39,15 @@ import HeaderComponent from '~/components/HeaderComponent.vue'
 import MenuComponent from '~/components/MenuComponent.vue'
 import GlobalPopups from '~/components/GlobalPopups.vue'
 import ConfirmDialog from '~/components/ConfirmDialog.vue'
+import MessageFloat from '~/components/MessageFloat.vue'
 import { useIsMobile } from '~/utils/screen'
 
 const isMobile = useIsMobile()
 const menuVisible = ref(!isMobile.value)
 
 const showNewPostIcon = computed(() => useRoute().path === '/')
+
+const isFloatMode = computed(() => useRoute().query.float === '1')
 
 const hideMenu = computed(() => {
   return [

--- a/frontend_nuxt/components/MessageFloat.vue
+++ b/frontend_nuxt/components/MessageFloat.vue
@@ -1,0 +1,44 @@
+<template>
+  <div v-if="state.open" class="message-float">
+    <iframe :src="frameSrc" class="message-frame" />
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { useMessageFloat } from '~/composables/useMessageFloat'
+
+const state = useMessageFloat()
+
+const frameSrc = computed(() => {
+  const base = state.value.path || '/message-box'
+  return base + (base.includes('?') ? '&' : '?') + 'float=1'
+})
+</script>
+
+<style scoped>
+.message-float {
+  position: fixed;
+  bottom: 0;
+  right: 0;
+  width: 380px;
+  height: 500px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
+  z-index: 2000;
+  background: var(--background-color);
+}
+
+.message-frame {
+  width: 100%;
+  height: 100%;
+  border: none;
+}
+
+@media (max-width: 600px) {
+  .message-float {
+    width: 100%;
+    height: 100%;
+    right: 0;
+  }
+}
+</style>

--- a/frontend_nuxt/composables/useMessageFloat.ts
+++ b/frontend_nuxt/composables/useMessageFloat.ts
@@ -1,0 +1,15 @@
+export const useMessageFloat = () =>
+  useState<{ open: boolean; path: string }>('message-float', () => ({
+    open: false,
+    path: '/message-box',
+  }))
+export const openMessageFloat = (path: string) => {
+  const state = useMessageFloat()
+  state.value.open = true
+  state.value.path = path
+}
+
+export const closeMessageFloat = () => {
+  const state = useMessageFloat()
+  state.value.open = false
+}

--- a/frontend_nuxt/pages/message-box/index.vue
+++ b/frontend_nuxt/pages/message-box/index.vue
@@ -1,5 +1,13 @@
 <template>
   <div class="messages-container">
+    <div class="window-controls">
+      <button v-if="!isFloat" @click="shrink" class="control-btn">
+        <i class="fas fa-window-minimize"></i>
+      </button>
+      <button v-else @click="expand" class="control-btn">
+        <i class="fas fa-expand"></i>
+      </button>
+    </div>
     <div class="tabs">
       <div :class="['tab', { active: activeTab === 'messages' }]" @click="activeTab = 'messages'">
         站内信
@@ -114,8 +122,8 @@
 </template>
 
 <script setup>
-import { ref, onUnmounted, watch, onActivated } from 'vue'
-import { useRouter } from 'vue-router'
+import { ref, onUnmounted, watch, onActivated, computed } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
 import { getToken, fetchCurrentUser } from '~/utils/auth'
 import { toast } from '~/main'
 import { useWebSocket } from '~/composables/useWebSocket'
@@ -125,12 +133,15 @@ import TimeManager from '~/utils/time'
 import { stripMarkdownLength } from '~/utils/markdown'
 import SearchPersonDropdown from '~/components/SearchPersonDropdown.vue'
 import BasePlaceholder from '~/components/BasePlaceholder.vue'
+import { openMessageFloat } from '~/composables/useMessageFloat'
 
 const config = useRuntimeConfig()
 const conversations = ref([])
 const loading = ref(true)
 const error = ref(null)
 const router = useRouter()
+const route = useRoute()
+const isFloat = computed(() => route.query.float === '1')
 const currentUser = ref(null)
 const API_BASE_URL = config.public.apiBaseUrl
 const { connect, disconnect, subscribe, isConnected } = useWebSocket()
@@ -142,6 +153,16 @@ let subscription = null
 const activeTab = ref('messages')
 const channels = ref([])
 const loadingChannels = ref(false)
+
+function shrink() {
+  openMessageFloat(route.fullPath)
+  router.push('/')
+}
+
+function expand() {
+  const base = route.fullPath.replace(/(\?|&)float=1/, '')
+  window.top.location.href = base
+}
 
 async function fetchConversations() {
   const token = getToken()
@@ -278,6 +299,21 @@ function goToConversation(id) {
 
 <style scoped>
 .messages-container {
+  position: relative;
+}
+.window-controls {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 10;
+}
+
+.control-btn {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--text-color-primary);
+  margin-left: 4px;
 }
 
 .tabs {


### PR DESCRIPTION
## Summary
- add global MessageFloat component and composable to manage message-box floating window
- allow messages pages to shrink into bottom-right float and expand back to full view
- open user links in main window when in floating mode

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ac17edeafc83278116c4976ca34396