### PR TITLE
feat: integrate points with lottery participation

### DIFF
--- a/backend/src/main/java/com/openisle/controller/PostController.java
+++ b/backend/src/main/java/com/openisle/controller/PostController.java
@@ -41,7 +41,8 @@ public class PostController {
         Post post = postService.createPost(auth.getName(), req.getCategoryId(),
                 req.getTitle(), req.getContent(), req.getTagIds(),
                 req.getType(), req.getPrizeDescription(), req.getPrizeIcon(),
-                req.getPrizeCount(), req.getStartTime(), req.getEndTime());
+                req.getPrizeCount(), req.getPointCost(),
+                req.getStartTime(), req.getEndTime());
         draftService.deleteDraft(auth.getName());
         PostDetailDto dto = postMapper.toDetailDto(post, auth.getName());
         dto.setReward(levelService.awardForPost(auth.getName()));

--- a/backend/src/main/java/com/openisle/dto/LotteryDto.java
+++ b/backend/src/main/java/com/openisle/dto/LotteryDto.java
@@ -10,6 +10,7 @@ public class LotteryDto {
     private String prizeDescription;
     private String prizeIcon;
     private int prizeCount;
+    private int pointCost;
     private LocalDateTime startTime;
     private LocalDateTime endTime;
     private List<AuthorDto> participants;

--- a/backend/src/main/java/com/openisle/dto/PostRequest.java
+++ b/backend/src/main/java/com/openisle/dto/PostRequest.java
@@ -23,6 +23,7 @@ public class PostRequest {
     private String prizeDescription;
     private String prizeIcon;
     private Integer prizeCount;
+    private Integer pointCost;
     private LocalDateTime startTime;
     private LocalDateTime endTime;
 }

--- a/backend/src/main/java/com/openisle/mapper/PostMapper.java
+++ b/backend/src/main/java/com/openisle/mapper/PostMapper.java
@@ -86,6 +86,7 @@ public class PostMapper {
             l.setPrizeDescription(lp.getPrizeDescription());
             l.setPrizeIcon(lp.getPrizeIcon());
             l.setPrizeCount(lp.getPrizeCount());
+            l.setPointCost(lp.getPointCost());
             l.setStartTime(lp.getStartTime());
             l.setEndTime(lp.getEndTime());
             l.setParticipants(lp.getParticipants().stream().map(userMapper::toAuthorDto).collect(Collectors.toList()));

--- a/backend/src/main/java/com/openisle/model/LotteryPost.java
+++ b/backend/src/main/java/com/openisle/model/LotteryPost.java
@@ -26,6 +26,9 @@ public class LotteryPost extends Post {
     @Column(nullable = false)
     private int prizeCount;
 
+    @Column(nullable = false)
+    private int pointCost;
+
     @Column
     private LocalDateTime startTime;
 

--- a/backend/src/main/java/com/openisle/model/PointHistoryType.java
+++ b/backend/src/main/java/com/openisle/model/PointHistoryType.java
@@ -8,5 +8,7 @@ public enum PointHistoryType {
     INVITE,
     FEATURE,
     SYSTEM_ONLINE,
-    REDEEM
+    REDEEM,
+    LOTTERY_JOIN,
+    LOTTERY_REWARD
 }

--- a/backend/src/main/java/com/openisle/service/PointService.java
+++ b/backend/src/main/java/com/openisle/service/PointService.java
@@ -2,6 +2,7 @@ package com.openisle.service;
 
 import com.openisle.model.*;
 import com.openisle.repository.*;
+import com.openisle.exception.FieldException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -37,6 +38,17 @@ public class PointService {
         User user = userRepository.findByUsername(userName).orElseThrow();
         Post post = postRepository.findById(postId).orElseThrow();
         return addPoint(user, 500, PointHistoryType.FEATURE, post, null, null);
+    }
+
+    public void processLotteryJoin(User participant, LotteryPost post) {
+        int cost = post.getPointCost();
+        if (cost > 0) {
+            if (participant.getPoint() < cost) {
+                throw new FieldException("point", "积分不足");
+            }
+            addPoint(participant, -cost, PointHistoryType.LOTTERY_JOIN, post, null, post.getAuthor());
+            addPoint(post.getAuthor(), cost, PointHistoryType.LOTTERY_REWARD, post, null, participant);
+        }
     }
 
     private PointLog getTodayLog(User user) {

--- a/backend/src/main/resources/db/migration/V3__add_point_cost_to_lottery_posts.sql
+++ b/backend/src/main/resources/db/migration/V3__add_point_cost_to_lottery_posts.sql
@@ -1,0 +1,1 @@
+ALTER TABLE lottery_posts ADD COLUMN point_cost INT NOT NULL DEFAULT 0;

--- a/backend/src/test/java/com/openisle/controller/PostControllerTest.java
+++ b/backend/src/test/java/com/openisle/controller/PostControllerTest.java
@@ -76,7 +76,7 @@ class PostControllerTest {
         post.setTags(Set.of(tag));
 
         when(postService.createPost(eq("alice"), eq(1L), eq("t"), eq("c"), eq(List.of(1L)),
-                isNull(), isNull(), isNull(), isNull(), isNull(), isNull())).thenReturn(post);
+                isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull())).thenReturn(post);
         when(postService.viewPost(eq(1L), any())).thenReturn(post);
         when(commentService.getCommentsForPost(eq(1L), any())).thenReturn(List.of());
         when(commentService.getParticipants(anyLong(), anyInt())).thenReturn(List.of());
@@ -187,7 +187,7 @@ class PostControllerTest {
                 .andExpect(status().isBadRequest());
 
         verify(postService, never()).createPost(any(), any(), any(), any(), any(),
-                any(), any(), any(), any(), any(), any());
+                any(), any(), any(), any(), any(), any(), any());
     }
 
     @Test

--- a/backend/src/test/java/com/openisle/service/PostServiceTest.java
+++ b/backend/src/test/java/com/openisle/service/PostServiceTest.java
@@ -146,7 +146,7 @@ class PostServiceTest {
 
         assertThrows(RateLimitException.class,
                 () -> service.createPost("alice", 1L, "t", "c", List.of(1L),
-                        null, null, null, null, null, null));
+                        null, null, null, null, null, null, null));
     }
 
     @Test

--- a/frontend_nuxt/pages/new-post.vue
+++ b/frontend_nuxt/pages/new-post.vue
@@ -66,6 +66,18 @@
             />
           </div>
         </div>
+        <div class="prize-point-row">
+          <span class="prize-row-title">参与所需积分</span>
+          <div class="prize-count-input">
+            <input
+              class="prize-count-input-field"
+              type="number"
+              v-model.number="pointCost"
+              min="0"
+              max="100"
+            />
+          </div>
+        </div>
         <div class="prize-time-row">
           <span class="prize-row-title">抽奖结束时间</span>
           <client-only>
@@ -105,6 +117,7 @@ const showPrizeCropper = ref(false)
 const prizeName = ref('')
 const prizeCount = ref(1)
 const prizeDescription = ref('')
+const pointCost = ref(0)
 const endTime = ref(null)
 const startTime = ref(null)
 const dateConfig = { enableTime: true, time_24hr: true, dateFormat: 'Y-m-d H:i' }
@@ -131,6 +144,11 @@ const onPrizeCropped = ({ file, url }) => {
 
 watch(prizeCount, (val) => {
   if (!val || val < 1) prizeCount.value = 1
+})
+
+watch(pointCost, (val) => {
+  if (val === undefined || val === null || val < 0) pointCost.value = 0
+  if (val > 100) pointCost.value = 100
 })
 
 const loadDraft = async () => {
@@ -168,6 +186,7 @@ const clearPost = async () => {
   showPrizeCropper.value = false
   prizeDescription.value = ''
   prizeCount.value = 1
+  pointCost.value = 0
   endTime.value = null
   startTime.value = null
 
@@ -315,6 +334,10 @@ const submitPost = async () => {
       toast.error('请选择抽奖结束时间')
       return
     }
+    if (pointCost.value < 0 || pointCost.value > 100) {
+      toast.error('参与积分需在0到100之间')
+      return
+    }
   }
   try {
     const token = getToken()
@@ -354,6 +377,7 @@ const submitPost = async () => {
         prizeDescription: postType.value === 'LOTTERY' ? prizeDescription.value : undefined,
         startTime:
           postType.value === 'LOTTERY' ? new Date(startTime.value).toISOString() : undefined,
+        pointCost: postType.value === 'LOTTERY' ? pointCost.value : undefined,
         // 将时间转换为 UTC+8.5 时区 todo: 需要优化
         endTime:
           postType.value === 'LOTTERY'

--- a/frontend_nuxt/pages/points.vue
+++ b/frontend_nuxt/pages/points.vue
@@ -146,6 +146,24 @@
               <template v-else-if="item.type === 'REDEEM'">
                 兑换商品，消耗 {{ -item.amount }} 积分
               </template>
+              <template v-else-if="item.type === 'LOTTERY_JOIN'">
+                参与抽奖帖
+                <NuxtLink :to="`/posts/${item.postId}`" class="timeline-link">{{
+                  item.postTitle
+                }}</NuxtLink>
+                ，消耗 {{ -item.amount }} 积分
+              </template>
+              <template v-else-if="item.type === 'LOTTERY_REWARD'">
+                你的抽奖帖
+                <NuxtLink :to="`/posts/${item.postId}`" class="timeline-link">{{
+                  item.postTitle
+                }}</NuxtLink>
+                被
+                <NuxtLink :to="`/users/${item.fromUserId}`" class="timeline-link">{{
+                  item.fromUserName
+                }}</NuxtLink>
+                参与，获得 {{ item.amount }} 积分
+              </template>
               <template v-else-if="item.type === 'SYSTEM_ONLINE'"> 积分历史系统上线 </template>
               <i class="fas fa-coins"></i> 你目前的积分是 {{ item.balance }}
             </div>

--- a/frontend_nuxt/pages/posts/[id]/index.vue
+++ b/frontend_nuxt/pages/posts/[id]/index.vue
@@ -119,7 +119,7 @@
                   class="join-prize-button"
                   @click="joinLottery"
                 >
-                  <div class="join-prize-button-text">参与抽奖</div>
+                  <div class="join-prize-button-text">参与抽奖（{{ lottery.pointCost }}积分）</div>
                 </div>
                 <div v-else-if="hasJoined" class="join-prize-button-disabled">
                   <div class="join-prize-button-text">已参与</div>
@@ -134,7 +134,7 @@
               class="join-prize-button"
               @click="joinLottery"
             >
-              <div class="join-prize-button-text">参与抽奖</div>
+              <div class="join-prize-button-text">参与抽奖（{{ lottery.pointCost }}积分）</div>
             </div>
             <div v-else-if="hasJoined" class="join-prize-button-disabled">
               <div class="join-prize-button-text">已参与</div>
@@ -810,11 +810,12 @@ const joinLottery = async () => {
     method: 'POST',
     headers: { Authorization: `Bearer ${token}` },
   })
+  const data = await res.json().catch(() => ({}))
   if (res.ok) {
     toast.success('已参与抽奖')
     await refreshPost()
   } else {
-    toast.error('操作失败')
+    toast.error(data.error || '操作失败')
   }
 }
 


### PR DESCRIPTION
## Summary
- allow lottery posts to specify participant point cost (0-100)
- record point transfers when joining a lottery post
- display lottery point cost in UI and history

## Testing
- `npx prettier -w frontend_nuxt/pages/points.vue frontend_nuxt/pages/new-post.vue frontend_nuxt/pages/posts/[id]/index.vue`
- `cd backend && mvn -q test` *(fails: Non-resolvable parent POM)*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68ad240df2888327b3248525fa5a3c64