### PR TITLE
fix: gray out unearned medals

### DIFF
--- a/frontend_nuxt/components/BaseImage.vue
+++ b/frontend_nuxt/components/BaseImage.vue
@@ -59,7 +59,7 @@ function onError() {
 }
 
 .base-image.is-loaded {
-  filter: none;
+  /* Allow filters from parent classes (e.g. grayscale for unfinished medals) */
   transform: none;
   opacity: 1;
 }


### PR DESCRIPTION
## Summary
- allow parent-specified filters to persist on loaded images so incomplete medals remain grey

## Testing
- `npx prettier frontend_nuxt/components/BaseImage.vue --write`
- `cd backend && mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aef664a260832780b50502299964a0