### PR TITLE
fix: resolve repeated reaction issues

### DIFF
--- a/backend/src/main/java/com/openisle/controller/ReactionController.java
+++ b/backend/src/main/java/com/openisle/controller/ReactionController.java
@@ -36,6 +36,7 @@ public class ReactionController {
                                                    Authentication auth) {
         Reaction reaction = reactionService.reactToPost(auth.getName(), postId, req.getType());
         if (reaction == null) {
+            pointService.deductForReactionOfPost(auth.getName(), postId);
             return ResponseEntity.noContent().build();
         }
         ReactionDto dto = reactionMapper.toDto(reaction);
@@ -50,6 +51,7 @@ public class ReactionController {
                                                       Authentication auth) {
         Reaction reaction = reactionService.reactToComment(auth.getName(), commentId, req.getType());
         if (reaction == null) {
+            pointService.deductForReactionOfComment(auth.getName(), commentId);
             return ResponseEntity.noContent().build();
         }
         ReactionDto dto = reactionMapper.toDto(reaction);

--- a/backend/src/main/java/com/openisle/model/PointHistoryType.java
+++ b/backend/src/main/java/com/openisle/model/PointHistoryType.java
@@ -5,6 +5,8 @@ public enum PointHistoryType {
     COMMENT,
     POST_LIKED,
     COMMENT_LIKED,
+    POST_LIKE_CANCELLED,
+    COMMENT_LIKE_CANCELLED,
     INVITE,
     FEATURE,
     SYSTEM_ONLINE,

--- a/backend/src/main/java/com/openisle/repository/NotificationRepository.java
+++ b/backend/src/main/java/com/openisle/repository/NotificationRepository.java
@@ -5,6 +5,7 @@ import com.openisle.model.User;
 import com.openisle.model.Post;
 import com.openisle.model.Comment;
 import com.openisle.model.NotificationType;
+import com.openisle.model.ReactionType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -29,4 +30,8 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     List<Notification> findByTypeAndFromUser(NotificationType type, User fromUser);
 
     void deleteByTypeAndFromUserAndPost(NotificationType type, User fromUser, Post post);
+
+    void deleteByTypeAndFromUserAndPostAndReactionType(NotificationType type, User fromUser, Post post, ReactionType reactionType);
+
+    void deleteByTypeAndFromUserAndCommentAndReactionType(NotificationType type, User fromUser, Comment comment, ReactionType reactionType);
 }

--- a/backend/src/main/java/com/openisle/service/NotificationService.java
+++ b/backend/src/main/java/com/openisle/service/NotificationService.java
@@ -114,6 +114,14 @@ public class NotificationService {
         return n;
     }
 
+    public void deleteReactionNotification(User fromUser, Post post, Comment comment, ReactionType reactionType) {
+        if (post != null) {
+            notificationRepository.deleteByTypeAndFromUserAndPostAndReactionType(NotificationType.REACTION, fromUser, post, reactionType);
+        } else if (comment != null) {
+            notificationRepository.deleteByTypeAndFromUserAndCommentAndReactionType(NotificationType.REACTION, fromUser, comment, reactionType);
+        }
+    }
+
     /**
      * Create notifications for all admins when a user submits a register request.
      * Old register request notifications from the same applicant are removed first.

--- a/backend/src/main/java/com/openisle/service/PointService.java
+++ b/backend/src/main/java/com/openisle/service/PointService.java
@@ -150,6 +150,16 @@ public class PointService {
         return addPoint(poster, 10, PointHistoryType.POST_LIKED, post, null, reactioner);
     }
 
+    public int deductForReactionOfPost(String reactionerName, Long postId) {
+        User poster = postRepository.findById(postId).orElseThrow().getAuthor();
+        User reactioner = userRepository.findByUsername(reactionerName).orElseThrow();
+        if (poster.getId().equals(reactioner.getId())) {
+            return 0;
+        }
+        Post post = postRepository.findById(postId).orElseThrow();
+        return addPoint(poster, -10, PointHistoryType.POST_LIKE_CANCELLED, post, null, reactioner);
+    }
+
     // 考虑点赞者和评论者是同一个的情况
     public int awardForReactionOfComment(String reactionerName, Long commentId) {
         // 根据帖子id找到评论者
@@ -167,6 +177,17 @@ public class PointService {
         Comment comment = commentRepository.findById(commentId).orElseThrow();
         Post post = comment.getPost();
         return addPoint(commenter, 10, PointHistoryType.COMMENT_LIKED, post, comment, reactioner);
+    }
+
+    public int deductForReactionOfComment(String reactionerName, Long commentId) {
+        User commenter = commentRepository.findById(commentId).orElseThrow().getAuthor();
+        User reactioner = userRepository.findByUsername(reactionerName).orElseThrow();
+        if (commenter.getId().equals(reactioner.getId())) {
+            return 0;
+        }
+        Comment comment = commentRepository.findById(commentId).orElseThrow();
+        Post post = comment.getPost();
+        return addPoint(commenter, -10, PointHistoryType.COMMENT_LIKE_CANCELLED, post, comment, reactioner);
     }
 
     public java.util.List<PointHistory> listHistory(String userName) {

--- a/backend/src/main/java/com/openisle/service/ReactionService.java
+++ b/backend/src/main/java/com/openisle/service/ReactionService.java
@@ -42,6 +42,7 @@ public class ReactionService {
         java.util.Optional<Reaction> existing =
                 reactionRepository.findByUserAndPostAndType(user, post, type);
         if (existing.isPresent()) {
+            notificationService.deleteReactionNotification(user, post, null, type);
             reactionRepository.delete(existing.get());
             return null;
         }
@@ -65,6 +66,7 @@ public class ReactionService {
         java.util.Optional<Reaction> existing =
                 reactionRepository.findByUserAndCommentAndType(user, comment, type);
         if (existing.isPresent()) {
+            notificationService.deleteReactionNotification(user, null, comment, type);
             reactionRepository.delete(existing.get());
             return null;
         }


### PR DESCRIPTION
## Summary
- prevent duplicate reaction notifications by removing existing entries when a reaction is toggled
- deduct points when reactions on posts or comments are cancelled
- add point history types for reaction cancellations

## Testing
- `mvn -q -f backend/pom.xml test` *(failed: The following artifacts could not be resolved: org.springframework.boot:spring-boot-starter-parent:pom:3.1.1 (absent))*


------
https://chatgpt.com/codex/tasks/task_e_68aef626041483278b8c7fc53d993366