### PR TITLE
Adjust mobile post icon position and add close button to message box

### DIFF
--- a/frontend_nuxt/app.vue
+++ b/frontend_nuxt/app.vue
@@ -138,7 +138,7 @@ const goToNewPost = () => {
   height: 60px;
   border-radius: 50%;
   position: fixed;
-  bottom: 40px;
+  bottom: 70px;
   right: 20px;
   font-size: 20px;
   cursor: pointer;

--- a/frontend_nuxt/components/MessageFloatWindow.vue
+++ b/frontend_nuxt/components/MessageFloatWindow.vue
@@ -16,6 +16,7 @@
         @click="reboundToDefault"
       ></i>
       <i class="fas fa-expand" title="在页面中打开" @click="expand"></i>
+      <i class="fas fa-times" title="关闭" @click="close"></i>
     </div>
   </div>
 </template>
@@ -46,6 +47,10 @@ function expand() {
   const target = floatRoute.value
   floatRoute.value = null
   navigateTo(target)
+}
+
+function close() {
+  floatRoute.value = null
 }
 
 function injectBaseTag() {


### PR DESCRIPTION
## Summary
- Move homepage floating new post icon up 30px on mobile
- Add close button to message float window

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68aefa840a7c8327a21f567d2f7f03ab