### PR TITLE
feat: add poll post type

### DIFF
--- a/backend/src/main/java/com/openisle/controller/PostController.java
+++ b/backend/src/main/java/com/openisle/controller/PostController.java
@@ -3,6 +3,7 @@ package com.openisle.controller;
 import com.openisle.dto.PostDetailDto;
 import com.openisle.dto.PostRequest;
 import com.openisle.dto.PostSummaryDto;
+import com.openisle.dto.PollDto;
 import com.openisle.mapper.PostMapper;
 import com.openisle.model.Post;
 import com.openisle.service.*;
@@ -42,7 +43,8 @@ public class PostController {
                 req.getTitle(), req.getContent(), req.getTagIds(),
                 req.getType(), req.getPrizeDescription(), req.getPrizeIcon(),
                 req.getPrizeCount(), req.getPointCost(),
-                req.getStartTime(), req.getEndTime());
+                req.getStartTime(), req.getEndTime(),
+                req.getQuestion(), req.getOptions());
         draftService.deleteDraft(auth.getName());
         PostDetailDto dto = postMapper.toDetailDto(post, auth.getName());
         dto.setReward(levelService.awardForPost(auth.getName()));
@@ -83,6 +85,17 @@ public class PostController {
     @PostMapping("/{id}/lottery/join")
     public ResponseEntity<Void> joinLottery(@PathVariable Long id, Authentication auth) {
         postService.joinLottery(id, auth.getName());
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/{id}/poll/progress")
+    public ResponseEntity<PollDto> pollProgress(@PathVariable Long id) {
+        return ResponseEntity.ok(postMapper.toSummaryDto(postService.getPoll(id)).getPoll());
+    }
+
+    @PostMapping("/{id}/poll/vote")
+    public ResponseEntity<Void> vote(@PathVariable Long id, @RequestParam("option") int option, Authentication auth) {
+        postService.votePoll(id, auth.getName(), option);
         return ResponseEntity.ok().build();
     }
 

--- a/backend/src/main/java/com/openisle/dto/PollDto.java
+++ b/backend/src/main/java/com/openisle/dto/PollDto.java
@@ -1,0 +1,16 @@
+package com.openisle.dto;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+@Data
+public class PollDto {
+    private String question;
+    private List<String> options;
+    private Map<Integer, Integer> votes;
+    private LocalDateTime endTime;
+    private List<AuthorDto> participants;
+}

--- a/backend/src/main/java/com/openisle/dto/PostRequest.java
+++ b/backend/src/main/java/com/openisle/dto/PostRequest.java
@@ -26,5 +26,8 @@ public class PostRequest {
     private Integer pointCost;
     private LocalDateTime startTime;
     private LocalDateTime endTime;
+    // fields for poll posts
+    private String question;
+    private List<String> options;
 }
 

--- a/backend/src/main/java/com/openisle/dto/PostSummaryDto.java
+++ b/backend/src/main/java/com/openisle/dto/PostSummaryDto.java
@@ -31,6 +31,7 @@ public class PostSummaryDto {
     private int pointReward;
     private PostType type;
     private LotteryDto lottery;
+    private PollDto poll;
     private boolean rssExcluded;
     private boolean closed;
 }

--- a/backend/src/main/java/com/openisle/mapper/PostMapper.java
+++ b/backend/src/main/java/com/openisle/mapper/PostMapper.java
@@ -5,9 +5,11 @@ import com.openisle.dto.PostDetailDto;
 import com.openisle.dto.PostSummaryDto;
 import com.openisle.dto.ReactionDto;
 import com.openisle.dto.LotteryDto;
+import com.openisle.dto.PollDto;
 import com.openisle.model.CommentSort;
 import com.openisle.model.Post;
 import com.openisle.model.LotteryPost;
+import com.openisle.model.PollPost;
 import com.openisle.model.User;
 import com.openisle.service.CommentService;
 import com.openisle.service.ReactionService;
@@ -92,6 +94,16 @@ public class PostMapper {
             l.setParticipants(lp.getParticipants().stream().map(userMapper::toAuthorDto).collect(Collectors.toList()));
             l.setWinners(lp.getWinners().stream().map(userMapper::toAuthorDto).collect(Collectors.toList()));
             dto.setLottery(l);
+        }
+
+        if (post instanceof PollPost pp) {
+            PollDto p = new PollDto();
+            p.setQuestion(pp.getQuestion());
+            p.setOptions(pp.getOptions());
+            p.setVotes(pp.getVotes());
+            p.setEndTime(pp.getEndTime());
+            p.setParticipants(pp.getParticipants().stream().map(userMapper::toAuthorDto).collect(Collectors.toList()));
+            dto.setPoll(p);
         }
     }
 }

--- a/backend/src/main/java/com/openisle/model/PollPost.java
+++ b/backend/src/main/java/com/openisle/model/PollPost.java
@@ -1,0 +1,41 @@
+package com.openisle.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.*;
+
+@Entity
+@Table(name = "poll_posts")
+@Getter
+@Setter
+@NoArgsConstructor
+@PrimaryKeyJoinColumn(name = "post_id")
+public class PollPost extends Post {
+
+    @Column(nullable = false)
+    private String question;
+
+    @ElementCollection
+    @CollectionTable(name = "poll_post_options", joinColumns = @JoinColumn(name = "post_id"))
+    @Column(name = "option_text")
+    private List<String> options = new ArrayList<>();
+
+    @ElementCollection
+    @CollectionTable(name = "poll_post_votes", joinColumns = @JoinColumn(name = "post_id"))
+    @MapKeyColumn(name = "option_index")
+    @Column(name = "vote_count")
+    private Map<Integer, Integer> votes = new HashMap<>();
+
+    @ManyToMany
+    @JoinTable(name = "poll_participants",
+            joinColumns = @JoinColumn(name = "post_id"),
+            inverseJoinColumns = @JoinColumn(name = "user_id"))
+    private Set<User> participants = new HashSet<>();
+
+    @Column
+    private LocalDateTime endTime;
+}

--- a/backend/src/main/java/com/openisle/model/PostType.java
+++ b/backend/src/main/java/com/openisle/model/PostType.java
@@ -2,5 +2,6 @@ package com.openisle.model;
 
 public enum PostType {
     NORMAL,
-    LOTTERY
+    LOTTERY,
+    POLL
 }

--- a/backend/src/main/java/com/openisle/repository/PollPostRepository.java
+++ b/backend/src/main/java/com/openisle/repository/PollPostRepository.java
@@ -1,0 +1,7 @@
+package com.openisle.repository;
+
+import com.openisle.model.PollPost;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PollPostRepository extends JpaRepository<PollPost, Long> {
+}


### PR DESCRIPTION
## Summary
- support new `POLL` post type with question, options, and vote tracking
- allow creating poll posts and expose progress and voting endpoints
- map poll data into post DTOs for clients

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b1aa915a948327ac092178915a6a9c