### PR TITLE
feat: expose poll option participants

### DIFF
--- a/backend/src/main/java/com/openisle/dto/PollDto.java
+++ b/backend/src/main/java/com/openisle/dto/PollDto.java
@@ -12,5 +12,5 @@ public class PollDto {
     private List<String> options;
     private Map<Integer, Integer> votes;
     private LocalDateTime endTime;
-    private List<AuthorDto> participants;
+    private Map<Integer, List<AuthorDto>> participants;
 }

--- a/backend/src/main/java/com/openisle/mapper/PostMapper.java
+++ b/backend/src/main/java/com/openisle/mapper/PostMapper.java
@@ -6,10 +6,12 @@ import com.openisle.dto.PostSummaryDto;
 import com.openisle.dto.ReactionDto;
 import com.openisle.dto.LotteryDto;
 import com.openisle.dto.PollDto;
+import com.openisle.dto.AuthorDto;
 import com.openisle.model.CommentSort;
 import com.openisle.model.Post;
 import com.openisle.model.LotteryPost;
 import com.openisle.model.PollPost;
+import com.openisle.model.PollParticipant;
 import com.openisle.model.User;
 import com.openisle.service.CommentService;
 import com.openisle.service.ReactionService;
@@ -19,6 +21,7 @@ import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /** Mapper responsible for converting posts into DTOs. */
@@ -102,7 +105,10 @@ public class PostMapper {
             p.setOptions(pp.getOptions());
             p.setVotes(pp.getVotes());
             p.setEndTime(pp.getEndTime());
-            p.setParticipants(pp.getParticipants().stream().map(userMapper::toAuthorDto).collect(Collectors.toList()));
+            Map<Integer, List<AuthorDto>> participants = pp.getParticipants().stream()
+                    .collect(Collectors.groupingBy(PollParticipant::getOptionIndex,
+                            Collectors.mapping(ppart -> userMapper.toAuthorDto(ppart.getUser()), Collectors.toList())));
+            p.setParticipants(participants);
             dto.setPoll(p);
         }
     }

--- a/backend/src/main/java/com/openisle/model/PollParticipant.java
+++ b/backend/src/main/java/com/openisle/model/PollParticipant.java
@@ -1,0 +1,33 @@
+package com.openisle.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Represents a single vote in a poll, capturing which user selected which option.
+ */
+@Entity
+@Table(name = "poll_participants")
+@Getter
+@Setter
+@NoArgsConstructor
+public class PollParticipant {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private PollPost post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "option_index", nullable = false)
+    private int optionIndex;
+}
+

--- a/backend/src/main/java/com/openisle/model/PollPost.java
+++ b/backend/src/main/java/com/openisle/model/PollPost.java
@@ -30,11 +30,8 @@ public class PollPost extends Post {
     @Column(name = "vote_count")
     private Map<Integer, Integer> votes = new HashMap<>();
 
-    @ManyToMany
-    @JoinTable(name = "poll_participants",
-            joinColumns = @JoinColumn(name = "post_id"),
-            inverseJoinColumns = @JoinColumn(name = "user_id"))
-    private Set<User> participants = new HashSet<>();
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<PollParticipant> participants = new HashSet<>();
 
     @Column
     private LocalDateTime endTime;


### PR DESCRIPTION
## Summary
- track poll votes per option using new `PollParticipant` entity
- include participant lists for each option in poll DTOs
- record option selection when users vote in polls

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d1a652f08327b939901fb6450c0c