### PR TITLE
feat: return poll option participants

### DIFF
--- a/backend/src/main/java/com/openisle/dto/PollDto.java
+++ b/backend/src/main/java/com/openisle/dto/PollDto.java
@@ -13,4 +13,5 @@ public class PollDto {
     private Map<Integer, Integer> votes;
     private LocalDateTime endTime;
     private List<AuthorDto> participants;
+    private Map<Integer, List<AuthorDto>> optionParticipants;
 }

--- a/backend/src/main/java/com/openisle/mapper/PostMapper.java
+++ b/backend/src/main/java/com/openisle/mapper/PostMapper.java
@@ -6,19 +6,23 @@ import com.openisle.dto.PostSummaryDto;
 import com.openisle.dto.ReactionDto;
 import com.openisle.dto.LotteryDto;
 import com.openisle.dto.PollDto;
+import com.openisle.dto.AuthorDto;
 import com.openisle.model.CommentSort;
 import com.openisle.model.Post;
 import com.openisle.model.LotteryPost;
 import com.openisle.model.PollPost;
 import com.openisle.model.User;
+import com.openisle.model.PollVote;
 import com.openisle.service.CommentService;
 import com.openisle.service.ReactionService;
 import com.openisle.service.SubscriptionService;
+import com.openisle.repository.PollVoteRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /** Mapper responsible for converting posts into DTOs. */
@@ -34,6 +38,7 @@ public class PostMapper {
     private final UserMapper userMapper;
     private final TagMapper tagMapper;
     private final CategoryMapper categoryMapper;
+    private final PollVoteRepository pollVoteRepository;
 
     public PostSummaryDto toSummaryDto(Post post) {
         PostSummaryDto dto = new PostSummaryDto();
@@ -103,6 +108,10 @@ public class PostMapper {
             p.setVotes(pp.getVotes());
             p.setEndTime(pp.getEndTime());
             p.setParticipants(pp.getParticipants().stream().map(userMapper::toAuthorDto).collect(Collectors.toList()));
+            Map<Integer, List<AuthorDto>> optionParticipants = pollVoteRepository.findByPostId(pp.getId()).stream()
+                    .collect(Collectors.groupingBy(PollVote::getOptionIndex,
+                            Collectors.mapping(v -> userMapper.toAuthorDto(v.getUser()), Collectors.toList())));
+            p.setOptionParticipants(optionParticipants);
             dto.setPoll(p);
         }
     }

--- a/backend/src/main/java/com/openisle/model/PollVote.java
+++ b/backend/src/main/java/com/openisle/model/PollVote.java
@@ -1,0 +1,28 @@
+package com.openisle.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "poll_votes", uniqueConstraints = @UniqueConstraint(columnNames = {"post_id", "user_id"}))
+@Getter
+@Setter
+@NoArgsConstructor
+public class PollVote {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "post_id")
+    private PollPost post;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(name = "option_index", nullable = false)
+    private int optionIndex;
+}

--- a/backend/src/main/java/com/openisle/repository/PollVoteRepository.java
+++ b/backend/src/main/java/com/openisle/repository/PollVoteRepository.java
@@ -1,0 +1,10 @@
+package com.openisle.repository;
+
+import com.openisle.model.PollVote;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PollVoteRepository extends JpaRepository<PollVote, Long> {
+    List<PollVote> findByPostId(Long postId);
+}

--- a/backend/src/main/java/com/openisle/service/PostService.java
+++ b/backend/src/main/java/com/openisle/service/PostService.java
@@ -10,6 +10,7 @@ import com.openisle.model.Comment;
 import com.openisle.model.NotificationType;
 import com.openisle.model.LotteryPost;
 import com.openisle.model.PollPost;
+import com.openisle.model.PollVote;
 import com.openisle.repository.PostRepository;
 import com.openisle.repository.LotteryPostRepository;
 import com.openisle.repository.PollPostRepository;
@@ -22,6 +23,7 @@ import com.openisle.repository.CommentRepository;
 import com.openisle.repository.ReactionRepository;
 import com.openisle.repository.PostSubscriptionRepository;
 import com.openisle.repository.NotificationRepository;
+import com.openisle.repository.PollVoteRepository;
 import com.openisle.model.Role;
 import com.openisle.exception.RateLimitException;
 import lombok.extern.slf4j.Slf4j;
@@ -57,6 +59,7 @@ public class PostService {
     private final TagRepository tagRepository;
     private final LotteryPostRepository lotteryPostRepository;
     private final PollPostRepository pollPostRepository;
+    private final PollVoteRepository pollVoteRepository;
     private PublishMode publishMode;
     private final NotificationService notificationService;
     private final SubscriptionService subscriptionService;
@@ -82,6 +85,7 @@ public class PostService {
                        TagRepository tagRepository,
                        LotteryPostRepository lotteryPostRepository,
                        PollPostRepository pollPostRepository,
+                       PollVoteRepository pollVoteRepository,
                        NotificationService notificationService,
                        SubscriptionService subscriptionService,
                        CommentService commentService,
@@ -102,6 +106,7 @@ public class PostService {
         this.tagRepository = tagRepository;
         this.lotteryPostRepository = lotteryPostRepository;
         this.pollPostRepository = pollPostRepository;
+        this.pollVoteRepository = pollVoteRepository;
         this.notificationService = notificationService;
         this.subscriptionService = subscriptionService;
         this.commentService = commentService;
@@ -301,6 +306,11 @@ public class PostService {
         }
         post.getParticipants().add(user);
         post.getVotes().merge(optionIndex, 1, Integer::sum);
+        PollVote vote = new PollVote();
+        vote.setPost(post);
+        vote.setUser(user);
+        vote.setOptionIndex(optionIndex);
+        pollVoteRepository.save(vote);
         return pollPostRepository.save(post);
     }
 


### PR DESCRIPTION
## Summary
- track individual poll votes
- expose participants for each poll option in API

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d1a652f08327b939901fb6450c0c