### PR TITLE
Refactor poll module and add poll notifications

### DIFF
--- a/backend/src/main/java/com/openisle/controller/PostController.java
+++ b/backend/src/main/java/com/openisle/controller/PostController.java
@@ -44,7 +44,7 @@ public class PostController {
                 req.getType(), req.getPrizeDescription(), req.getPrizeIcon(),
                 req.getPrizeCount(), req.getPointCost(),
                 req.getStartTime(), req.getEndTime(),
-                req.getQuestion(), req.getOptions());
+                req.getOptions());
         draftService.deleteDraft(auth.getName());
         PostDetailDto dto = postMapper.toDetailDto(post, auth.getName());
         dto.setReward(levelService.awardForPost(auth.getName()));

--- a/backend/src/main/java/com/openisle/dto/PollDto.java
+++ b/backend/src/main/java/com/openisle/dto/PollDto.java
@@ -8,7 +8,6 @@ import java.util.Map;
 
 @Data
 public class PollDto {
-    private String question;
     private List<String> options;
     private Map<Integer, Integer> votes;
     private LocalDateTime endTime;

--- a/backend/src/main/java/com/openisle/dto/PostRequest.java
+++ b/backend/src/main/java/com/openisle/dto/PostRequest.java
@@ -27,7 +27,6 @@ public class PostRequest {
     private LocalDateTime startTime;
     private LocalDateTime endTime;
     // fields for poll posts
-    private String question;
     private List<String> options;
 }
 

--- a/backend/src/main/java/com/openisle/mapper/PostMapper.java
+++ b/backend/src/main/java/com/openisle/mapper/PostMapper.java
@@ -103,7 +103,6 @@ public class PostMapper {
 
         if (post instanceof PollPost pp) {
             PollDto p = new PollDto();
-            p.setQuestion(pp.getQuestion());
             p.setOptions(pp.getOptions());
             p.setVotes(pp.getVotes());
             p.setEndTime(pp.getEndTime());

--- a/backend/src/main/java/com/openisle/model/NotificationType.java
+++ b/backend/src/main/java/com/openisle/model/NotificationType.java
@@ -40,6 +40,12 @@ public enum NotificationType {
     LOTTERY_WIN,
     /** Your lottery post was drawn */
     LOTTERY_DRAW,
+    /** Someone participated in your poll */
+    POLL_VOTE,
+    /** Your poll post has concluded */
+    POLL_RESULT_OWNER,
+    /** A poll you participated in has concluded */
+    POLL_RESULT_PARTICIPANT,
     /** Your post was featured */
     POST_FEATURED,
     /** You were mentioned in a post or comment */

--- a/backend/src/main/java/com/openisle/model/PollPost.java
+++ b/backend/src/main/java/com/openisle/model/PollPost.java
@@ -15,10 +15,6 @@ import java.util.*;
 @NoArgsConstructor
 @PrimaryKeyJoinColumn(name = "post_id")
 public class PollPost extends Post {
-
-    @Column(nullable = false)
-    private String question;
-
     @ElementCollection
     @CollectionTable(name = "poll_post_options", joinColumns = @JoinColumn(name = "post_id"))
     @Column(name = "option_text")
@@ -38,4 +34,7 @@ public class PollPost extends Post {
 
     @Column
     private LocalDateTime endTime;
+
+    @Column
+    private boolean resultAnnounced = false;
 }

--- a/backend/src/main/java/com/openisle/repository/PollPostRepository.java
+++ b/backend/src/main/java/com/openisle/repository/PollPostRepository.java
@@ -3,5 +3,11 @@ package com.openisle.repository;
 import com.openisle.model.PollPost;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 public interface PollPostRepository extends JpaRepository<PollPost, Long> {
+    List<PollPost> findByEndTimeAfterAndResultAnnouncedFalse(LocalDateTime now);
+
+    List<PollPost> findByEndTimeBeforeAndResultAnnouncedFalse(LocalDateTime now);
 }

--- a/backend/src/test/java/com/openisle/controller/PostControllerTest.java
+++ b/backend/src/test/java/com/openisle/controller/PostControllerTest.java
@@ -76,7 +76,7 @@ class PostControllerTest {
         post.setTags(Set.of(tag));
 
         when(postService.createPost(eq("alice"), eq(1L), eq("t"), eq("c"), eq(List.of(1L)),
-                isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull())).thenReturn(post);
+                isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull())).thenReturn(post);
         when(postService.viewPost(eq(1L), any())).thenReturn(post);
         when(commentService.getCommentsForPost(eq(1L), any())).thenReturn(List.of());
         when(commentService.getParticipants(anyLong(), anyInt())).thenReturn(List.of());
@@ -187,7 +187,7 @@ class PostControllerTest {
                 .andExpect(status().isBadRequest());
 
         verify(postService, never()).createPost(any(), any(), any(), any(), any(),
-                any(), any(), any(), any(), any(), any(), any());
+                any(), any(), any(), any(), any(), any(), any(), any());
     }
 
     @Test

--- a/backend/src/test/java/com/openisle/service/PostServiceTest.java
+++ b/backend/src/test/java/com/openisle/service/PostServiceTest.java
@@ -146,7 +146,7 @@ class PostServiceTest {
 
         assertThrows(RateLimitException.class,
                 () -> service.createPost("alice", 1L, "t", "c", List.of(1L),
-                        null, null, null, null, null, null, null));
+                        null, null, null, null, null, null, null, null));
     }
 
     @Test

--- a/frontend_nuxt/components/LotteryForm.vue
+++ b/frontend_nuxt/components/LotteryForm.vue
@@ -1,0 +1,189 @@
+<template>
+  <div class="lottery-section">
+    <AvatarCropper
+      :src="data.tempPrizeIcon"
+      :show="data.showPrizeCropper"
+      @close="data.showPrizeCropper = false"
+      @crop="onPrizeCropped"
+    />
+    <div class="prize-row">
+      <span class="prize-row-title">奖品图片</span>
+      <label class="prize-container">
+        <BaseImage v-if="data.prizeIcon" :src="data.prizeIcon" class="prize-preview" alt="prize" />
+        <i v-else class="fa-solid fa-image default-prize-icon"></i>
+        <div class="prize-overlay">上传奖品图片</div>
+        <input type="file" class="prize-input" accept="image/*" @change="onPrizeIconChange" />
+      </label>
+    </div>
+    <div class="prize-name-row">
+      <span class="prize-row-title">奖品描述</span>
+      <BaseInput v-model="data.prizeDescription" placeholder="奖品描述" />
+    </div>
+    <div class="prize-count-row">
+      <span class="prize-row-title">奖品数量</span>
+      <div class="prize-count-input">
+        <input
+          class="prize-count-input-field"
+          type="number"
+          v-model.number="data.prizeCount"
+          min="1"
+        />
+      </div>
+    </div>
+    <div class="prize-point-row">
+      <span class="prize-row-title">参与所需积分</span>
+      <div class="prize-count-input">
+        <input
+          class="prize-count-input-field"
+          type="number"
+          v-model.number="data.pointCost"
+          min="0"
+          max="100"
+        />
+      </div>
+    </div>
+    <div class="prize-time-row">
+      <span class="prize-row-title">抽奖结束时间</span>
+      <client-only>
+        <flat-pickr v-model="data.endTime" :config="dateConfig" class="time-picker" />
+      </client-only>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import 'flatpickr/dist/flatpickr.css'
+import FlatPickr from 'vue-flatpickr-component'
+import AvatarCropper from '~/components/AvatarCropper.vue'
+import BaseImage from '~/components/BaseImage.vue'
+import BaseInput from '~/components/BaseInput.vue'
+import { watch } from 'vue'
+
+const props = defineProps({
+  data: {
+    type: Object,
+    required: true,
+  },
+})
+
+const dateConfig = { enableTime: true, time_24hr: true, dateFormat: 'Y-m-d H:i' }
+
+const onPrizeIconChange = (e) => {
+  const file = e.target.files[0]
+  if (file) {
+    const reader = new FileReader()
+    reader.onload = () => {
+      props.data.tempPrizeIcon = reader.result
+      props.data.showPrizeCropper = true
+    }
+    reader.readAsDataURL(file)
+  }
+}
+
+const onPrizeCropped = ({ file, url }) => {
+  props.data.prizeIconFile = file
+  props.data.prizeIcon = url
+}
+
+watch(
+  () => props.data.prizeCount,
+  (val) => {
+    if (!val || val < 1) props.data.prizeCount = 1
+  },
+)
+
+watch(
+  () => props.data.pointCost,
+  (val) => {
+    if (val === undefined || val === null || val < 0) props.data.pointCost = 0
+    if (val > 100) props.data.pointCost = 100
+  },
+)
+</script>
+
+<style scoped>
+.lottery-section {
+  margin-top: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  margin-bottom: 200px;
+}
+.prize-row-title {
+  font-size: 16px;
+  color: var(--text-color);
+  font-weight: bold;
+  margin-bottom: 10px;
+}
+.prize-row,
+.prize-name-row,
+.prize-count-row,
+.prize-point-row,
+.prize-time-row {
+  display: flex;
+  flex-direction: column;
+}
+.prize-container {
+  position: relative;
+  width: 100px;
+  height: 100px;
+  border-radius: 10px;
+  overflow: hidden;
+  cursor: pointer;
+  background-color: var(--lottery-background-color);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.default-prize-icon {
+  font-size: 30px;
+  opacity: 0.1;
+  color: var(--text-color);
+}
+.prize-preview {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.prize-input {
+  display: none;
+}
+.prize-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.4);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+.prize-container:hover .prize-overlay {
+  opacity: 1;
+}
+.prize-count-input {
+  display: flex;
+  align-items: center;
+}
+.prize-count-input-field {
+  width: 50px;
+  height: 30px;
+  border-radius: 5px;
+  border: 1px solid var(--border-color);
+  padding: 0 10px;
+  font-size: 16px;
+  color: var(--text-color);
+  background-color: var(--lottery-background-color);
+}
+.time-picker {
+  max-width: 200px;
+  height: 30px;
+  background-color: var(--lottery-background-color);
+  border-radius: 5px;
+  border: 1px solid var(--border-color);
+}
+</style>

--- a/frontend_nuxt/components/PollForm.vue
+++ b/frontend_nuxt/components/PollForm.vue
@@ -1,0 +1,90 @@
+<template>
+  <div class="poll-section">
+    <div class="poll-options-row">
+      <span class="poll-row-title">投票选项</span>
+      <div class="poll-option-item" v-for="(opt, idx) in data.options" :key="idx">
+        <BaseInput v-model="data.options[idx]" placeholder="选项内容" />
+        <i
+          v-if="data.options.length > 2"
+          class="fa-solid fa-xmark remove-option-icon"
+          @click="removeOption(idx)"
+        ></i>
+      </div>
+      <div class="add-option" @click="addOption">添加选项</div>
+    </div>
+    <div class="poll-time-row">
+      <span class="poll-row-title">投票结束时间</span>
+      <client-only>
+        <flat-pickr v-model="data.endTime" :config="dateConfig" class="time-picker" />
+      </client-only>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import 'flatpickr/dist/flatpickr.css'
+import FlatPickr from 'vue-flatpickr-component'
+import BaseInput from '~/components/BaseInput.vue'
+
+const props = defineProps({
+  data: {
+    type: Object,
+    required: true,
+  },
+})
+
+const dateConfig = { enableTime: true, time_24hr: true, dateFormat: 'Y-m-d H:i' }
+
+const addOption = () => {
+  props.data.options.push('')
+}
+
+const removeOption = (idx) => {
+  if (props.data.options.length > 2) {
+    props.data.options.splice(idx, 1)
+  }
+}
+</script>
+
+<style scoped>
+.poll-section {
+  margin-top: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  margin-bottom: 200px;
+}
+.poll-row-title {
+  font-size: 16px;
+  color: var(--text-color);
+  font-weight: bold;
+  margin-bottom: 10px;
+}
+.poll-option-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+.remove-option-icon {
+  cursor: pointer;
+}
+.add-option {
+  color: var(--primary-color);
+  cursor: pointer;
+  width: fit-content;
+  margin-top: 5px;
+}
+.poll-options-row,
+.poll-time-row {
+  display: flex;
+  flex-direction: column;
+}
+.time-picker {
+  max-width: 200px;
+  height: 30px;
+  background-color: var(--lottery-background-color);
+  border-radius: 5px;
+  border: 1px solid var(--border-color);
+}
+</style>

--- a/frontend_nuxt/pages/message.vue
+++ b/frontend_nuxt/pages/message.vue
@@ -195,6 +195,44 @@
                       已开奖
                     </NotificationContainer>
                   </template>
+                  <template v-else-if="item.type === 'POLL_VOTE'">
+                    <NotificationContainer :item="item" :markRead="markRead">
+                      有用户参与了你的投票贴
+                      <NuxtLink
+                        class="notif-content-text"
+                        @click="markRead(item.id)"
+                        :to="`/posts/${item.post.id}`"
+                      >
+                        {{ stripMarkdownLength(item.post.title, 100) }}
+                      </NuxtLink>
+                    </NotificationContainer>
+                  </template>
+                  <template v-else-if="item.type === 'POLL_RESULT_OWNER'">
+                    <NotificationContainer :item="item" :markRead="markRead">
+                      你的投票帖
+                      <NuxtLink
+                        class="notif-content-text"
+                        @click="markRead(item.id)"
+                        :to="`/posts/${item.post.id}`"
+                      >
+                        {{ stripMarkdownLength(item.post.title, 100) }}
+                      </NuxtLink>
+                      已出结果
+                    </NotificationContainer>
+                  </template>
+                  <template v-else-if="item.type === 'POLL_RESULT_PARTICIPANT'">
+                    <NotificationContainer :item="item" :markRead="markRead">
+                      你参与的投票帖
+                      <NuxtLink
+                        class="notif-content-text"
+                        @click="markRead(item.id)"
+                        :to="`/posts/${item.post.id}`"
+                      >
+                        {{ stripMarkdownLength(item.post.title, 100) }}
+                      </NuxtLink>
+                      已出结果
+                    </NotificationContainer>
+                  </template>
                   <template v-else-if="item.type === 'POST_UPDATED'">
                     <NotificationContainer :item="item" :markRead="markRead">
                       您关注的帖子

--- a/frontend_nuxt/utils/notification.js
+++ b/frontend_nuxt/utils/notification.js
@@ -25,6 +25,9 @@ const iconMap = {
   POINT_REDEEM: 'fas fa-gift',
   LOTTERY_WIN: 'fas fa-trophy',
   LOTTERY_DRAW: 'fas fa-bullhorn',
+  POLL_VOTE: 'fas fa-square-poll-vertical',
+  POLL_RESULT_OWNER: 'fas fa-flag-checkered',
+  POLL_RESULT_PARTICIPANT: 'fas fa-flag-checkered',
   MENTION: 'fas fa-at',
   POST_DELETED: 'fas fa-trash',
   POST_FEATURED: 'fas fa-star',
@@ -200,6 +203,21 @@ function createFetchNotifications() {
             },
           })
         } else if (n.type === 'LOTTERY_WIN' || n.type === 'LOTTERY_DRAW') {
+          arr.push({
+            ...n,
+            icon: iconMap[n.type],
+            iconClick: () => {
+              if (n.post) {
+                markNotificationRead(n.id)
+                navigateTo(`/posts/${n.post.id}`)
+              }
+            },
+          })
+        } else if (
+          n.type === 'POLL_VOTE' ||
+          n.type === 'POLL_RESULT_OWNER' ||
+          n.type === 'POLL_RESULT_PARTICIPANT'
+        ) {
           arr.push({
             ...n,
             icon: iconMap[n.type],


### PR DESCRIPTION
## Summary
- remove unused poll question field from backend models and APIs
- extract lottery and poll creation UI into dedicated components
- add poll participation and result notification types with frontend handling

## Testing
- `npx prettier --write frontend_nuxt/components/PollForm.vue frontend_nuxt/components/LotteryForm.vue frontend_nuxt/pages/new-post.vue`
- `npx prettier --write frontend_nuxt/pages/message.vue frontend_nuxt/utils/notification.js`
- `mvn -q test` *(fails: Non-resolvable parent POM for com.openisle:openisle:0.0.1-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_68b3337f395c8327bca4d1b1cf696ad0