### PR TITLE
feat: support multi-option polls

### DIFF
--- a/backend/src/main/java/com/openisle/controller/PostController.java
+++ b/backend/src/main/java/com/openisle/controller/PostController.java
@@ -44,7 +44,7 @@ public class PostController {
                 req.getType(), req.getPrizeDescription(), req.getPrizeIcon(),
                 req.getPrizeCount(), req.getPointCost(),
                 req.getStartTime(), req.getEndTime(),
-                req.getOptions());
+                req.getOptions(), req.getMultiple());
         draftService.deleteDraft(auth.getName());
         PostDetailDto dto = postMapper.toDetailDto(post, auth.getName());
         dto.setReward(levelService.awardForPost(auth.getName()));
@@ -94,7 +94,7 @@ public class PostController {
     }
 
     @PostMapping("/{id}/poll/vote")
-    public ResponseEntity<Void> vote(@PathVariable Long id, @RequestParam("option") int option, Authentication auth) {
+    public ResponseEntity<Void> vote(@PathVariable Long id, @RequestParam("option") List<Integer> option, Authentication auth) {
         postService.votePoll(id, auth.getName(), option);
         return ResponseEntity.ok().build();
     }

--- a/backend/src/main/java/com/openisle/dto/PollDto.java
+++ b/backend/src/main/java/com/openisle/dto/PollDto.java
@@ -13,4 +13,5 @@ public class PollDto {
     private LocalDateTime endTime;
     private List<AuthorDto> participants;
     private Map<Integer, List<AuthorDto>> optionParticipants;
+    private boolean multiple;
 }

--- a/backend/src/main/java/com/openisle/dto/PostRequest.java
+++ b/backend/src/main/java/com/openisle/dto/PostRequest.java
@@ -28,5 +28,6 @@ public class PostRequest {
     private LocalDateTime endTime;
     // fields for poll posts
     private List<String> options;
+    private Boolean multiple;
 }
 

--- a/backend/src/main/java/com/openisle/mapper/PostMapper.java
+++ b/backend/src/main/java/com/openisle/mapper/PostMapper.java
@@ -111,6 +111,7 @@ public class PostMapper {
                     .collect(Collectors.groupingBy(PollVote::getOptionIndex,
                             Collectors.mapping(v -> userMapper.toAuthorDto(v.getUser()), Collectors.toList())));
             p.setOptionParticipants(optionParticipants);
+            p.setMultiple(pp.isMultiple());
             dto.setPoll(p);
         }
     }

--- a/backend/src/main/java/com/openisle/model/PollPost.java
+++ b/backend/src/main/java/com/openisle/model/PollPost.java
@@ -33,6 +33,9 @@ public class PollPost extends Post {
     private Set<User> participants = new HashSet<>();
 
     @Column
+    private boolean multiple = false;
+
+    @Column
     private LocalDateTime endTime;
 
     @Column

--- a/backend/src/main/java/com/openisle/model/PollVote.java
+++ b/backend/src/main/java/com/openisle/model/PollVote.java
@@ -6,7 +6,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Entity
-@Table(name = "poll_votes", uniqueConstraints = @UniqueConstraint(columnNames = {"post_id", "user_id"}))
+@Table(name = "poll_votes", uniqueConstraints = @UniqueConstraint(columnNames = {"post_id", "user_id", "option_index"}))
 @Getter
 @Setter
 @NoArgsConstructor

--- a/backend/src/test/java/com/openisle/controller/PostControllerTest.java
+++ b/backend/src/test/java/com/openisle/controller/PostControllerTest.java
@@ -76,7 +76,7 @@ class PostControllerTest {
         post.setTags(Set.of(tag));
 
         when(postService.createPost(eq("alice"), eq(1L), eq("t"), eq("c"), eq(List.of(1L)),
-                isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull())).thenReturn(post);
+                isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull())).thenReturn(post);
         when(postService.viewPost(eq(1L), any())).thenReturn(post);
         when(commentService.getCommentsForPost(eq(1L), any())).thenReturn(List.of());
         when(commentService.getParticipants(anyLong(), anyInt())).thenReturn(List.of());
@@ -187,7 +187,7 @@ class PostControllerTest {
                 .andExpect(status().isBadRequest());
 
         verify(postService, never()).createPost(any(), any(), any(), any(), any(),
-                any(), any(), any(), any(), any(), any(), any(), any());
+                any(), any(), any(), any(), any(), any(), any(), any(), any());
     }
 
     @Test

--- a/backend/src/test/java/com/openisle/service/PostServiceTest.java
+++ b/backend/src/test/java/com/openisle/service/PostServiceTest.java
@@ -146,7 +146,7 @@ class PostServiceTest {
 
         assertThrows(RateLimitException.class,
                 () -> service.createPost("alice", 1L, "t", "c", List.of(1L),
-                        null, null, null, null, null, null, null, null));
+                        null, null, null, null, null, null, null, null, null));
     }
 
     @Test

--- a/frontend_nuxt/components/PollForm.vue
+++ b/frontend_nuxt/components/PollForm.vue
@@ -18,6 +18,12 @@
         <flat-pickr v-model="data.endTime" :config="dateConfig" class="time-picker" />
       </client-only>
     </div>
+    <div class="poll-multiple-row">
+      <label class="poll-row-title">
+        <input type="checkbox" v-model="data.multiple" class="multiple-checkbox" />
+        多选
+      </label>
+    </div>
   </div>
 </template>
 
@@ -79,6 +85,13 @@ const removeOption = (idx) => {
 .poll-time-row {
   display: flex;
   flex-direction: column;
+}
+.poll-multiple-row {
+  display: flex;
+  align-items: center;
+}
+.multiple-checkbox {
+  margin-right: 5px;
 }
 .time-picker {
   max-width: 200px;

--- a/frontend_nuxt/pages/new-post.vue
+++ b/frontend_nuxt/pages/new-post.vue
@@ -74,6 +74,7 @@ const lottery = reactive({
 const poll = reactive({
   options: ['', ''],
   endTime: null,
+  multiple: false,
 })
 const startTime = ref(null)
 const isWaitingPosting = ref(false)
@@ -121,6 +122,7 @@ const clearPost = async () => {
   startTime.value = null
   poll.options = ['', '']
   poll.endTime = null
+  poll.multiple = false
 
   // 删除草稿
   const token = getToken()
@@ -318,6 +320,7 @@ const submitPost = async () => {
         prizeCount: postType.value === 'LOTTERY' ? lottery.prizeCount : undefined,
         prizeDescription: postType.value === 'LOTTERY' ? lottery.prizeDescription : undefined,
         options: postType.value === 'POLL' ? poll.options : undefined,
+        multiple: postType.value === 'POLL' ? poll.multiple : undefined,
         startTime:
           postType.value === 'LOTTERY' ? new Date(startTime.value).toISOString() : undefined,
         pointCost: postType.value === 'LOTTERY' ? lottery.pointCost : undefined,


### PR DESCRIPTION
## Summary
- allow creating polls with multi-select capability and persist multiple votes
- expose poll multi-select flag to clients and accept multiple vote indices
- update frontend poll components to render and submit multi-option votes

## Testing
- `mvn -q -f backend test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent due to network unreachable)*
- `npm test` *(fails: Missing script: "test"*)

------
https://chatgpt.com/codex/tasks/task_e_68b3c0b70f98832780b3412389735d0c