### PR TITLE
Fix poll multiple property null handling

### DIFF
--- a/backend/src/main/java/com/openisle/mapper/PostMapper.java
+++ b/backend/src/main/java/com/openisle/mapper/PostMapper.java
@@ -111,7 +111,7 @@ public class PostMapper {
                     .collect(Collectors.groupingBy(PollVote::getOptionIndex,
                             Collectors.mapping(v -> userMapper.toAuthorDto(v.getUser()), Collectors.toList())));
             p.setOptionParticipants(optionParticipants);
-            p.setMultiple(pp.isMultiple());
+            p.setMultiple(Boolean.TRUE.equals(pp.getMultiple()));
             dto.setPoll(p);
         }
     }

--- a/backend/src/main/java/com/openisle/model/PollPost.java
+++ b/backend/src/main/java/com/openisle/model/PollPost.java
@@ -33,7 +33,7 @@ public class PollPost extends Post {
     private Set<User> participants = new HashSet<>();
 
     @Column
-    private boolean multiple = false;
+    private Boolean multiple = false;
 
     @Column
     private LocalDateTime endTime;


### PR DESCRIPTION
## Summary
- Avoid assigning null to primitive poll field by using `Boolean` in `PollPost`
- Map poll posts safely by converting nullable `multiple` flag to boolean

## Testing
- ⚠️ `mvn -q test` *(failed: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b3e9650c8c832786320ddb1b7d77a9