### PR TITLE
test: fix PostServiceTest for new PostService deps

### DIFF
--- a/backend/src/test/java/com/openisle/service/PostServiceTest.java
+++ b/backend/src/test/java/com/openisle/service/PostServiceTest.java
@@ -22,6 +22,8 @@ class PostServiceTest {
         CategoryRepository catRepo = mock(CategoryRepository.class);
         TagRepository tagRepo = mock(TagRepository.class);
         LotteryPostRepository lotteryRepo = mock(LotteryPostRepository.class);
+        PollPostRepository pollPostRepo = mock(PollPostRepository.class);
+        PollVoteRepository pollVoteRepo = mock(PollVoteRepository.class);
         NotificationService notifService = mock(NotificationService.class);
         SubscriptionService subService = mock(SubscriptionService.class);
         CommentService commentService = mock(CommentService.class);
@@ -37,7 +39,7 @@ class PostServiceTest {
         PointService pointService = mock(PointService.class);
 
         PostService service = new PostService(postRepo, userRepo, catRepo, tagRepo, lotteryRepo,
-                notifService, subService, commentService, commentRepo,
+                pollPostRepo, pollVoteRepo, notifService, subService, commentService, commentRepo,
                 reactionRepo, subRepo, notificationRepo, postReadService,
                 imageUploader, taskScheduler, emailSender, context, pointService, PublishMode.DIRECT);
         when(context.getBean(PostService.class)).thenReturn(service);
@@ -69,6 +71,8 @@ class PostServiceTest {
         CategoryRepository catRepo = mock(CategoryRepository.class);
         TagRepository tagRepo = mock(TagRepository.class);
         LotteryPostRepository lotteryRepo = mock(LotteryPostRepository.class);
+        PollPostRepository pollPostRepo = mock(PollPostRepository.class);
+        PollVoteRepository pollVoteRepo = mock(PollVoteRepository.class);
         NotificationService notifService = mock(NotificationService.class);
         SubscriptionService subService = mock(SubscriptionService.class);
         CommentService commentService = mock(CommentService.class);
@@ -84,7 +88,7 @@ class PostServiceTest {
         PointService pointService = mock(PointService.class);
 
         PostService service = new PostService(postRepo, userRepo, catRepo, tagRepo, lotteryRepo,
-                notifService, subService, commentService, commentRepo,
+                pollPostRepo, pollVoteRepo, notifService, subService, commentService, commentRepo,
                 reactionRepo, subRepo, notificationRepo, postReadService,
                 imageUploader, taskScheduler, emailSender, context, pointService, PublishMode.DIRECT);
         when(context.getBean(PostService.class)).thenReturn(service);
@@ -122,6 +126,8 @@ class PostServiceTest {
         CategoryRepository catRepo = mock(CategoryRepository.class);
         TagRepository tagRepo = mock(TagRepository.class);
         LotteryPostRepository lotteryRepo = mock(LotteryPostRepository.class);
+        PollPostRepository pollPostRepo = mock(PollPostRepository.class);
+        PollVoteRepository pollVoteRepo = mock(PollVoteRepository.class);
         NotificationService notifService = mock(NotificationService.class);
         SubscriptionService subService = mock(SubscriptionService.class);
         CommentService commentService = mock(CommentService.class);
@@ -137,7 +143,7 @@ class PostServiceTest {
         PointService pointService = mock(PointService.class);
 
         PostService service = new PostService(postRepo, userRepo, catRepo, tagRepo, lotteryRepo,
-                notifService, subService, commentService, commentRepo,
+                pollPostRepo, pollVoteRepo, notifService, subService, commentService, commentRepo,
                 reactionRepo, subRepo, notificationRepo, postReadService,
                 imageUploader, taskScheduler, emailSender, context, pointService, PublishMode.DIRECT);
         when(context.getBean(PostService.class)).thenReturn(service);
@@ -156,6 +162,8 @@ class PostServiceTest {
         CategoryRepository catRepo = mock(CategoryRepository.class);
         TagRepository tagRepo = mock(TagRepository.class);
         LotteryPostRepository lotteryRepo = mock(LotteryPostRepository.class);
+        PollPostRepository pollPostRepo = mock(PollPostRepository.class);
+        PollVoteRepository pollVoteRepo = mock(PollVoteRepository.class);
         NotificationService notifService = mock(NotificationService.class);
         SubscriptionService subService = mock(SubscriptionService.class);
         CommentService commentService = mock(CommentService.class);
@@ -171,7 +179,7 @@ class PostServiceTest {
         PointService pointService = mock(PointService.class);
 
         PostService service = new PostService(postRepo, userRepo, catRepo, tagRepo, lotteryRepo,
-                notifService, subService, commentService, commentRepo,
+                pollPostRepo, pollVoteRepo, notifService, subService, commentService, commentRepo,
                 reactionRepo, subRepo, notificationRepo, postReadService,
                 imageUploader, taskScheduler, emailSender, context, pointService, PublishMode.DIRECT);
         when(context.getBean(PostService.class)).thenReturn(service);


### PR DESCRIPTION
## Summary
- update PostServiceTest to include PollPostRepository and PollVoteRepository mocks
- adjust PostService construction to match new dependencies

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_68b50905a6308327bab4cee3f739940a