### PR TITLE
feat: add email notification settings

### DIFF
--- a/backend/src/main/java/com/openisle/controller/NotificationController.java
+++ b/backend/src/main/java/com/openisle/controller/NotificationController.java
@@ -62,4 +62,14 @@ public class NotificationController {
     public void updatePref(@RequestBody NotificationPreferenceUpdateRequest req, Authentication auth) {
         notificationService.updatePreference(auth.getName(), req.getType(), req.isEnabled());
     }
+
+    @GetMapping("/email-prefs")
+    public List<NotificationPreferenceDto> emailPrefs(Authentication auth) {
+        return notificationService.listEmailPreferences(auth.getName());
+    }
+
+    @PostMapping("/email-prefs")
+    public void updateEmailPref(@RequestBody NotificationPreferenceUpdateRequest req, Authentication auth) {
+        notificationService.updateEmailPreference(auth.getName(), req.getType(), req.isEnabled());
+    }
 }

--- a/backend/src/main/java/com/openisle/model/User.java
+++ b/backend/src/main/java/com/openisle/model/User.java
@@ -74,6 +74,12 @@ public class User {
             NotificationType.USER_ACTIVITY
     );
 
+    @ElementCollection(targetClass = NotificationType.class)
+    @CollectionTable(name = "user_disabled_email_notification_types", joinColumns = @JoinColumn(name = "user_id"))
+    @Column(name = "notification_type")
+    @Enumerated(EnumType.STRING)
+    private Set<NotificationType> disabledEmailNotificationTypes = EnumSet.noneOf(NotificationType.class);
+
     @CreationTimestamp
     @Column(nullable = false, updatable = false,
             columnDefinition = "DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6)")

--- a/backend/src/main/java/com/openisle/service/PostService.java
+++ b/backend/src/main/java/com/openisle/service/PostService.java
@@ -374,14 +374,16 @@ public class PostService {
             lp.setWinners(winners);
             lotteryPostRepository.save(lp);
             for (User w : winners) {
-                if (w.getEmail() != null) {
+                if (w.getEmail() != null &&
+                        !w.getDisabledEmailNotificationTypes().contains(NotificationType.LOTTERY_WIN)) {
                     emailSender.sendEmail(w.getEmail(), "你中奖了", "恭喜你在抽奖贴 \"" + lp.getTitle() + "\" 中获奖");
                 }
                 notificationService.createNotification(w, NotificationType.LOTTERY_WIN, lp, null, null, lp.getAuthor(), null, null);
                 notificationService.sendCustomPush(w, "你中奖了", String.format("%s/posts/%d", websiteUrl, lp.getId()));
             }
             if (lp.getAuthor() != null) {
-                if (lp.getAuthor().getEmail() != null) {
+                if (lp.getAuthor().getEmail() != null &&
+                        !lp.getAuthor().getDisabledEmailNotificationTypes().contains(NotificationType.LOTTERY_DRAW)) {
                     emailSender.sendEmail(lp.getAuthor().getEmail(), "抽奖已开奖", "您的抽奖贴 \"" + lp.getTitle() + "\" 已开奖");
                 }
                 notificationService.createNotification(lp.getAuthor(), NotificationType.LOTTERY_DRAW, lp, null, null, null, null, null);

--- a/frontend_nuxt/pages/message.vue
+++ b/frontend_nuxt/pages/message.vue
@@ -23,6 +23,18 @@
             </div>
           </div>
         </div>
+        <div class="message-control-container">
+          <div class="message-control-title">邮件通知设置</div>
+          <div class="message-control-item-container">
+            <div v-for="pref in emailPrefs" :key="pref.type" class="message-control-item">
+              <div class="message-control-item-label">{{ formatType(pref.type) }}</div>
+              <BaseSwitch
+                :model-value="pref.enabled"
+                @update:modelValue="(val) => toggleEmailPref(pref, val)"
+              />
+            </div>
+          </div>
+        </div>
       </div>
 
       <template v-else>
@@ -579,6 +591,8 @@ import {
   hasMore,
   fetchNotificationPreferences,
   updateNotificationPreference,
+  fetchEmailNotificationPreferences,
+  updateEmailNotificationPreference,
 } from '~/utils/notification'
 import TimeManager from '~/utils/time'
 import BaseSwitch from '~/components/BaseSwitch.vue'
@@ -595,6 +609,7 @@ const tabs = [
   { key: 'control', label: '消息设置' },
 ]
 const notificationPrefs = ref([])
+const emailPrefs = ref([])
 const page = ref(0)
 const pageSize = 30
 
@@ -619,6 +634,10 @@ const fetchPrefs = async () => {
   notificationPrefs.value = await fetchNotificationPreferences()
 }
 
+const fetchEmailPrefs = async () => {
+  emailPrefs.value = await fetchEmailNotificationPreferences()
+}
+
 const togglePref = async (pref, value) => {
   const ok = await updateNotificationPreference(pref.type, value)
   if (ok) {
@@ -629,6 +648,15 @@ const togglePref = async (pref, value) => {
       unread: selectedTab.value === 'unread',
     })
     await fetchUnreadCount()
+  } else {
+    toast.error('操作失败')
+  }
+}
+
+const toggleEmailPref = async (pref, value) => {
+  const ok = await updateEmailNotificationPreference(pref.type, value)
+  if (ok) {
+    pref.enabled = value
   } else {
     toast.error('操作失败')
   }
@@ -729,6 +757,7 @@ onActivated(async () => {
   page.value = 0
   await fetchNotifications({ page: 0, size: pageSize, unread: selectedTab.value === 'unread' })
   fetchPrefs()
+  fetchEmailPrefs()
 })
 </script>
 

--- a/frontend_nuxt/utils/notification.js
+++ b/frontend_nuxt/utils/notification.js
@@ -116,6 +116,43 @@ export async function updateNotificationPreference(type, enabled) {
   }
 }
 
+export async function fetchEmailNotificationPreferences() {
+  try {
+    const config = useRuntimeConfig()
+    const API_BASE_URL = config.public.apiBaseUrl
+
+    const token = getToken()
+    if (!token) return []
+    const res = await fetch(`${API_BASE_URL}/api/notifications/email-prefs`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    if (!res.ok) return []
+    return await res.json()
+  } catch (e) {
+    return []
+  }
+}
+
+export async function updateEmailNotificationPreference(type, enabled) {
+  try {
+    const config = useRuntimeConfig()
+    const API_BASE_URL = config.public.apiBaseUrl
+    const token = getToken()
+    if (!token) return false
+    const res = await fetch(`${API_BASE_URL}/api/notifications/email-prefs`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ type, enabled }),
+    })
+    return res.ok
+  } catch (e) {
+    return false
+  }
+}
+
 /**
  * 处理信息的高阶函数
  * @returns


### PR DESCRIPTION
## Summary
- add per-type email notification preferences and endpoints
- respect email settings for comment reply and lottery emails
- expose email notification toggles in message settings UI

## Testing
- `npm test` (fails: Missing script: "test")
- `cd backend && mvn -q test` (fails: Non-resolvable parent POM)

------
https://chatgpt.com/codex/tasks/task_e_68b50d0f7e4c8327bf5f65832f08c210