### PR TITLE
feat: shorten invite links

### DIFF
--- a/backend/src/main/java/com/openisle/model/InviteToken.java
+++ b/backend/src/main/java/com/openisle/model/InviteToken.java
@@ -14,6 +14,13 @@ public class InviteToken {
     @Id
     private String token;
 
+    /**
+     * Short token used in invite links. Existing records may have this field null
+     * and fall back to {@link #token} for backward compatibility.
+     */
+    @Column(unique = true)
+    private String shortToken;
+
     @ManyToOne
     private User inviter;
 

--- a/backend/src/main/java/com/openisle/repository/InviteTokenRepository.java
+++ b/backend/src/main/java/com/openisle/repository/InviteTokenRepository.java
@@ -9,4 +9,8 @@ import java.util.Optional;
 
 public interface InviteTokenRepository extends JpaRepository<InviteToken, String> {
     Optional<InviteToken> findByInviterAndCreatedDate(User inviter, LocalDate createdDate);
+
+    Optional<InviteToken> findByShortToken(String shortToken);
+
+    boolean existsByShortToken(String shortToken);
 }

--- a/backend/src/main/java/com/openisle/service/InviteService.java
+++ b/backend/src/main/java/com/openisle/service/InviteService.java
@@ -30,33 +30,53 @@ public class InviteService {
         LocalDate today = LocalDate.now();
         Optional<InviteToken> existing = inviteTokenRepository.findByInviterAndCreatedDate(inviter, today);
         if (existing.isPresent()) {
-            return existing.get().getToken();
+            InviteToken inviteToken = existing.get();
+            return inviteToken.getShortToken() != null ? inviteToken.getShortToken() : inviteToken.getToken();
         }
+
         String token = jwtService.generateInviteToken(username);
+        String shortToken;
+        do {
+            shortToken = java.util.UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+        } while (inviteTokenRepository.existsByShortToken(shortToken));
+
         InviteToken inviteToken = new InviteToken();
         inviteToken.setToken(token);
+        inviteToken.setShortToken(shortToken);
         inviteToken.setInviter(inviter);
         inviteToken.setCreatedDate(today);
         inviteToken.setUsageCount(0);
         inviteTokenRepository.save(inviteToken);
-        return token;
+        return shortToken;
     }
 
     public InviteValidateResult validate(String token) {
         if (token == null || token.isEmpty()) {
             return new InviteValidateResult(null, false);
         }
+
+        InviteToken invite = inviteTokenRepository.findById(token).orElse(null);
+        String realToken = token;
+        if (invite == null) {
+            invite = inviteTokenRepository.findByShortToken(token).orElse(null);
+            if (invite == null) {
+                return new InviteValidateResult(null, false);
+            }
+            realToken = invite.getToken();
+        }
+
         try {
-            jwtService.validateAndGetSubjectForInvite(token);
+            jwtService.validateAndGetSubjectForInvite(realToken);
         } catch (Exception e) {
             return new InviteValidateResult(null, false);
         }
-        InviteToken invite = inviteTokenRepository.findById(token).orElse(null);
-        return new InviteValidateResult(invite, invite != null && invite.getUsageCount() < 3);
+
+        return new InviteValidateResult(invite, invite.getUsageCount() < 3);
     }
 
     public void consume(String token, String newUserName) {
-        InviteToken invite = inviteTokenRepository.findById(token).orElseThrow();
+        InviteToken invite = inviteTokenRepository.findById(token)
+                .orElseGet(() -> inviteTokenRepository.findByShortToken(token).orElseThrow());
         invite.setUsageCount(invite.getUsageCount() + 1);
         inviteTokenRepository.save(invite);
         pointService.awardForInvite(invite.getInviter().getUsername(), newUserName);


### PR DESCRIPTION
## Summary
- generate shorter invite codes and return them in invite links
- validate both short and legacy invite tokens
- ensure invite consumption works for short codes

## Testing
- `mvn test -e` *(fails: Non-resolvable parent POM... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b50caf211c8327aa1a9a3c53b41417