### PR TITLE
fix(frontend): scroll to bottom on channel entry

### DIFF
--- a/frontend_nuxt/pages/message-box/[id].vue
+++ b/frontend_nuxt/pages/message-box/[id].vue
@@ -334,6 +334,9 @@ onMounted(async () => {
   if (currentUser.value) {
     await fetchMessages(0)
     await markConversationAsRead()
+    await nextTick()
+    // 初次进入频道时，平滑滚动到底部
+    scrollToBottomSmooth()
     const token = getToken()
     if (token && !isConnected.value) {
       connect(token)


### PR DESCRIPTION
## Summary
- scroll conversation view to bottom when entering a channel

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b5128c0218832791028c5001730dac