### PR TITLE
Fix CommentServiceTest compilation by mocking PointService

### DIFF
--- a/backend/src/test/java/com/openisle/service/CommentServiceTest.java
+++ b/backend/src/test/java/com/openisle/service/CommentServiceTest.java
@@ -7,6 +7,7 @@ import com.openisle.repository.ReactionRepository;
 import com.openisle.repository.CommentSubscriptionRepository;
 import com.openisle.repository.NotificationRepository;
 import com.openisle.repository.PointHistoryRepository;
+import com.openisle.service.PointService;
 import com.openisle.exception.RateLimitException;
 import org.junit.jupiter.api.Test;
 
@@ -26,10 +27,11 @@ class CommentServiceTest {
         CommentSubscriptionRepository subRepo = mock(CommentSubscriptionRepository.class);
         NotificationRepository nRepo = mock(NotificationRepository.class);
         PointHistoryRepository pointHistoryRepo = mock(PointHistoryRepository.class);
+        PointService pointService = mock(PointService.class);
         ImageUploader imageUploader = mock(ImageUploader.class);
 
         CommentService service = new CommentService(commentRepo, postRepo, userRepo,
-                notifService, subService, reactionRepo, subRepo, nRepo, pointHistoryRepo, imageUploader);
+                notifService, subService, reactionRepo, subRepo, nRepo, pointHistoryRepo, pointService, imageUploader);
 
         when(commentRepo.countByAuthorAfter(eq("alice"), any())).thenReturn(3L);
 


### PR DESCRIPTION
## Summary
- mock `PointService` in `CommentServiceTest`
- provide `PointService` to `CommentService` constructor

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.1.1: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b54390b2e08327b94e21aa30ffe467