### PR TITLE
fix: scroll to bottom when entering channel

### DIFF
--- a/frontend_nuxt/pages/message-box/[id].vue
+++ b/frontend_nuxt/pages/message-box/[id].vue
@@ -371,11 +371,12 @@ watch(isConnected, (newValue) => {
 })
 
 onActivated(async () => {
-  // 返回页面时：刷新数据与已读，不做强制滚动，保持用户当前位置
+  // 返回页面时：刷新数据与已读，并滚动到底部
   if (currentUser.value) {
     await fetchMessages(0)
     await markConversationAsRead()
     await nextTick()
+    scrollToBottomSmooth()
     updateNearBottom()
     if (!isConnected.value) {
       const token = getToken()


### PR DESCRIPTION
## Summary
- Scroll the message list to the bottom whenever re-entering a channel, ensuring new sessions start at latest messages.

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68b560536c648327808e6f25eb034eed