### PR TITLE
feat: show featured marker only for RSS posts

### DIFF
--- a/frontend_nuxt/pages/index.vue
+++ b/frontend_nuxt/pages/index.vue
@@ -74,7 +74,7 @@
                 v-else-if="article.type === 'POLL'"
                 class="fa-solid fa-square-poll-vertical poll-icon"
               ></i>
-              <i class="fa-solid fa-star featured-icon"></i>
+              <i v-if="!article.rssExcluded" class="fa-solid fa-star featured-icon"></i>
               {{ article.title }}
             </NuxtLink>
             <NuxtLink class="article-item-description main-item" :to="`/posts/${article.id}`">

--- a/frontend_nuxt/pages/posts/[id]/index.vue
+++ b/frontend_nuxt/pages/posts/[id]/index.vue
@@ -15,7 +15,7 @@
         <div class="article-title-container-right">
           <div v-if="status === 'PENDING'" class="article-pending-button">审核中</div>
           <div v-if="status === 'REJECTED'" class="article-block-button">已拒绝</div>
-          <div class="article-featured-button">精品</div>
+          <div v-if="!rssExcluded" class="article-featured-button">精品</div>
           <div v-if="closed" class="article-closed-button">已关闭</div>
           <div
             v-if="!closed && loggedIn && !isAuthor && !subscribed"


### PR DESCRIPTION
## Summary
- show star icon only when post is RSS-recommended
- display "精品" badge only for RSS-recommended posts

## Testing
- `npm test` *(fails: Missing script "test" in package.json)*
- `mvn -q test` *(fails: Non-resolvable parent POM; network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5978d4d608327b6c7d08f1d04f66b