### PR TITLE
Fix duplicate WebSocket broadcasts

### DIFF
--- a/websocket_service/src/main/java/com/openisle/websocket/listener/NotificationListener.java
+++ b/websocket_service/src/main/java/com/openisle/websocket/listener/NotificationListener.java
@@ -79,15 +79,16 @@ public class NotificationListener {
                             messagingTemplate.convertAndSend(userDestination, messageObj);
                             log.info("Message notification sent to destination: {}", userDestination);
 
-                            // 发送未读数量
-                            if (payloadMap.containsKey("unreadCount")) {
-                                messagingTemplate.convertAndSendToUser(participantUsername, "/queue/unread-count", payloadMap.get("unreadCount"));
+                            // 优先从 participant 中获取未读信息，兼容旧格式
+                            Object unreadCount = participant.getOrDefault("unreadCount", payloadMap.get("unreadCount"));
+                            if (unreadCount != null) {
+                                messagingTemplate.convertAndSendToUser(participantUsername, "/queue/unread-count", unreadCount);
                                 log.info("Sent unread count to user {} via /user/{}/queue/unread-count", participantUsername, participantUsername);
                             }
 
-                            // 发送频道未读数量（如果有）
-                            if (payloadMap.containsKey("channelUnread")) {
-                                messagingTemplate.convertAndSendToUser(participantUsername, "/queue/channel-unread", payloadMap.get("channelUnread"));
+                            Object channelUnread = participant.getOrDefault("channelUnread", payloadMap.get("channelUnread"));
+                            if (channelUnread != null) {
+                                messagingTemplate.convertAndSendToUser(participantUsername, "/queue/channel-unread", channelUnread);
                                 log.info("Sent channel-unread to {}", participantUsername);
                             }
                         }


### PR DESCRIPTION
## Summary
- Send a single RabbitMQ notification for channel messages to avoid duplicate conversation broadcasts
- Include per-participant unread counts in payload and consume them in WebSocket listener

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: org.springframework.boot:spring-boot-starter-parent:pom:3.1.1)*
- `mvn -q test` *(fails: Non-resolvable parent POM: org.springframework.boot:spring-boot-starter-parent:pom:3.1.1)*

------
https://chatgpt.com/codex/tasks/task_e_68b9209bb2fc8327a47aa8a714a83231