### PR TITLE
feat: log redis connection success

### DIFF
--- a/backend/src/main/java/com/openisle/config/RedisConnectionLogger.java
+++ b/backend/src/main/java/com/openisle/config/RedisConnectionLogger.java
@@ -1,0 +1,35 @@
+package com.openisle.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Logs a message when a Redis connection is successfully established.
+ */
+@Component
+@Slf4j
+public class RedisConnectionLogger implements InitializingBean {
+
+    private final RedisConnectionFactory connectionFactory;
+
+    public RedisConnectionLogger(RedisConnectionFactory connectionFactory) {
+        this.connectionFactory = connectionFactory;
+    }
+
+    @Override
+    public void afterPropertiesSet() {
+        try (var connection = connectionFactory.getConnection()) {
+            connection.ping();
+            if (connectionFactory instanceof LettuceConnectionFactory lettuce) {
+                log.info("Redis connection established at {}:{}", lettuce.getHostName(), lettuce.getPort());
+            } else {
+                log.info("Redis connection established");
+            }
+        } catch (Exception e) {
+            log.error("Failed to connect to Redis", e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add RedisConnectionLogger to log successful connections

## Testing
- `mvn test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ba4f974a00832791933087e24573ca