### PR TITLE
feat: allow redis database override

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -12,7 +12,7 @@ spring.jpa.hibernate.ddl-auto=update
 # for redis
 spring.data.redis.host=${REDIS_HOST:localhost}
 spring.data.redis.port=${REDIS_PORT:6379}
-spring.data.redis.database=0
+spring.data.redis.database=${REDIS_DATABASE:0}
 
 # for jwt
 app.jwt.secret=${JWT_SECRET:jwt_sec}


### PR DESCRIPTION
## Summary
- allow REDIS_DATABASE env to override Redis DB index

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.1.1)*

------
https://chatgpt.com/codex/tasks/task_e_68ba58ba52208327a94228105f1cfb55