### PR TITLE
feat: switch dropdown icons to IconPark

### DIFF
--- a/frontend_nuxt/components/Dropdown.vue
+++ b/frontend_nuxt/components/Dropdown.vue
@@ -45,7 +45,7 @@
           </span>
           <span v-else class="placeholder">{{ placeholder }}</span>
         </template>
-        <i class="fas fa-caret-down dropdown-caret"></i>
+        <down class="dropdown-caret" />
       </slot>
     </div>
     <div
@@ -54,7 +54,7 @@
       v-click-outside="close"
     >
       <div v-if="showSearch" class="dropdown-search">
-        <i class="fas fa-search search-icon"></i>
+        <search-icon class="search-icon" />
         <input type="text" v-model="search" placeholder="搜索" />
       </div>
       <div v-if="loading" class="dropdown-loading">
@@ -85,12 +85,12 @@
     <Teleport to="body">
       <div v-if="open && isMobile" class="dropdown-mobile-page">
         <div class="dropdown-mobile-header">
-          <i class="fas fa-arrow-left" @click="close"></i>
+          <left class="back-icon" @click="close" />
           <span class="mobile-title">{{ placeholder }}</span>
         </div>
         <div class="dropdown-mobile-menu">
           <div v-if="showSearch" class="dropdown-search">
-            <i class="fas fa-search search-icon"></i>
+            <search-icon class="search-icon" />
             <input type="text" v-model="search" placeholder="搜索" />
           </div>
           <div v-if="loading" class="dropdown-loading">
@@ -374,6 +374,10 @@ export default {
   gap: 10px;
   padding: 10px;
   border-bottom: 1px solid var(--normal-border-color);
+}
+
+.back-icon {
+  cursor: pointer;
 }
 
 .dropdown-mobile-menu {

--- a/frontend_nuxt/plugins/iconpark.client.ts
+++ b/frontend_nuxt/plugins/iconpark.client.ts
@@ -16,6 +16,7 @@ import {
   TagOne,
   MedalOne,
   Next,
+  Left,
   DropDownList,
   MoreOne,
   SunOne,
@@ -55,6 +56,7 @@ export default defineNuxtPlugin((nuxtApp) => {
   nuxtApp.vueApp.component('TagOne', TagOne)
   nuxtApp.vueApp.component('MedalOne', MedalOne)
   nuxtApp.vueApp.component('Next', Next)
+  nuxtApp.vueApp.component('Left', Left)
   nuxtApp.vueApp.component('DropDownList', DropDownList)
   nuxtApp.vueApp.component('MoreOne', MoreOne)
   nuxtApp.vueApp.component('SunOne', SunOne)


### PR DESCRIPTION
## Summary
- replace FontAwesome icons in dropdown with IconPark components
- register Left icon in IconPark plugin and add back icon styling

## Testing
- `npx prettier frontend_nuxt/plugins/iconpark.client.ts frontend_nuxt/components/Dropdown.vue --write`
- `npm --prefix frontend_nuxt run build` *(fails: Rollup failed to resolve import "@icon-park/vue-next/styles/index.css")*


------
https://chatgpt.com/codex/tasks/task_e_68bb232f46fc8327ad14f8a208c9abbb