### PR TITLE
Adapt BaseTimeline for IconPark icons

### DIFF
--- a/frontend_nuxt/components/BaseTimeline.vue
+++ b/frontend_nuxt/components/BaseTimeline.vue
@@ -7,6 +7,11 @@
         @click="item.iconClick && item.iconClick()"
       >
         <BaseImage v-if="item.src" :src="item.src" class="timeline-img" alt="timeline item" />
+        <component
+          v-else-if="item.icon && (typeof item.icon !== 'string' || !item.icon.includes(' '))"
+          :is="item.icon"
+          :size="20"
+        />
         <i v-else-if="item.icon" :class="item.icon"></i>
         <BaseImage v-else-if="item.emoji" :src="item.emoji" class="timeline-emoji" alt="emoji" />
       </div>


### PR DESCRIPTION
## Summary
- Allow BaseTimeline items to render IconPark icons via dynamic components

## Testing
- `npm test` *(fails: Missing script "test")*
- `cd frontend_nuxt && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bba9d5992c8327949a683c98679f8d