### PR TITLE
refactor: replace font awesome with iconpark in search dropdown

### DIFF
--- a/frontend_nuxt/components/SearchDropdown.vue
+++ b/frontend_nuxt/components/SearchDropdown.vue
@@ -24,7 +24,7 @@
       </template>
       <template #option="{ option }">
         <div class="search-option-item">
-          <i :class="['result-icon', iconMap[option.type]]"></i>
+          <component :is="iconMap[option.type]" class="result-icon" />
           <div class="result-body">
             <div class="result-main" v-html="highlight(option.text)"></div>
             <div v-if="option.subText" class="result-sub" v-html="highlight(option.subText)"></div>
@@ -83,11 +83,12 @@ const highlight = (text) => {
 }
 
 const iconMap = {
-  user: 'fas fa-user',
-  post: 'fas fa-file-alt',
-  comment: 'fas fa-comment',
-  category: 'fas fa-folder',
-  tag: 'fas fa-hashtag',
+  user: 'UserIcon',
+  post: 'FileText',
+  post_title: 'FileText',
+  comment: 'CommentIcon',
+  category: 'Inbox',
+  tag: 'TagOne',
 }
 
 watch(selected, (val) => {


### PR DESCRIPTION
## Summary
- use IconPark components in `SearchDropdown`
- map search result types to corresponding IconPark icons

## Testing
- `npx prettier --check frontend_nuxt/components/SearchDropdown.vue`
- `npm test` *(fails: Missing script "test")*
- `(cd frontend_nuxt && npm test)` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bba9e42a1883278b2cfe6b2663df76