### PR TITLE
feat: adapt TagSelect to IconPark icons

### DIFF
--- a/frontend_nuxt/components/TagSelect.vue
+++ b/frontend_nuxt/components/TagSelect.vue
@@ -10,14 +10,14 @@
     <template #option="{ option }">
       <div class="option-container">
         <div class="option-main">
-          <template v-if="option.icon">
+          <template v-if="option.smallIcon || option.icon">
             <BaseImage
-              v-if="isImageIcon(option.icon)"
-              :src="option.icon"
+              v-if="isImageIcon(option.smallIcon || option.icon)"
+              :src="option.smallIcon || option.icon"
               class="option-icon"
               :alt="option.name"
             />
-            <i v-else :class="['option-icon', option.icon]"></i>
+            <component v-else :is="option.smallIcon || option.icon" class="option-icon" />
           </template>
           <span>{{ option.name }}</span>
           <span class="option-count" v-if="option.count > 0"> x {{ option.count }}</span>


### PR DESCRIPTION
## Summary
- render IconPark components or images for tag icons in TagSelect

## Testing
- `npx prettier frontend_nuxt/components/TagSelect.vue -c`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bba9f705c883279d4f57052fe986f9