### PR TITLE
Fix Resend email environment variable placeholder

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -56,7 +56,7 @@ app.captcha.comment-enabled=${CAPTCHA_COMMENT_ENABLED:false}
 # ========= Optional =========
 # for resend email send service, you can improve your service by yourself
 resend.api.key=${RESEND_API_KEY:}
-resend.from.email=${RESEND.FROM.EMAIL}
+resend.from.email=${RESEND_FROM_EMAIL:}
 # your email services: ...
 
 # for tencent cloud image upload service, you can improve your service by yourself


### PR DESCRIPTION
## Summary
- fix `resend.from.email` config to read `RESEND_FROM_EMAIL`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.1.1)*

------
https://chatgpt.com/codex/tasks/task_e_68bc39b42ab08327ba9800d82b708614