### PR TITLE
feat: expand post change log details

### DIFF
--- a/backend/src/main/java/com/openisle/dto/PostChangeLogDto.java
+++ b/backend/src/main/java/com/openisle/dto/PostChangeLogDto.java
@@ -11,6 +11,7 @@ import java.time.LocalDateTime;
 public class PostChangeLogDto {
     private Long id;
     private String username;
+    private String userAvatar;
     private PostChangeType type;
     private LocalDateTime time;
     private String oldTitle;

--- a/backend/src/main/java/com/openisle/mapper/PostChangeLogMapper.java
+++ b/backend/src/main/java/com/openisle/mapper/PostChangeLogMapper.java
@@ -9,7 +9,10 @@ public class PostChangeLogMapper {
     public PostChangeLogDto toDto(PostChangeLog log) {
         PostChangeLogDto dto = new PostChangeLogDto();
         dto.setId(log.getId());
-        dto.setUsername(log.getUser().getUsername());
+        if (log.getUser() != null) {
+            dto.setUsername(log.getUser().getUsername());
+            dto.setUserAvatar(log.getUser().getAvatar());
+        }
         dto.setType(log.getType());
         dto.setTime(log.getCreatedAt());
         if (log instanceof PostTitleChangeLog t) {

--- a/backend/src/main/java/com/openisle/model/PostChangeLog.java
+++ b/backend/src/main/java/com/openisle/model/PostChangeLog.java
@@ -23,7 +23,7 @@ public abstract class PostChangeLog {
     @JoinColumn(name = "post_id")
     private Post post;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @ManyToOne(fetch = FetchType.LAZY, optional = true)
     @JoinColumn(name = "user_id")
     private User user;
 

--- a/backend/src/main/java/com/openisle/model/PostChangeType.java
+++ b/backend/src/main/java/com/openisle/model/PostChangeType.java
@@ -7,5 +7,7 @@ public enum PostChangeType {
     TAG,
     CLOSED,
     PINNED,
-    FEATURED
+    FEATURED,
+    VOTE_RESULT,
+    LOTTERY_RESULT
 }

--- a/backend/src/main/java/com/openisle/model/PostLotteryResultChangeLog.java
+++ b/backend/src/main/java/com/openisle/model/PostLotteryResultChangeLog.java
@@ -1,0 +1,16 @@
+package com.openisle.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+@Table(name = "post_lottery_result_change_logs")
+public class PostLotteryResultChangeLog extends PostChangeLog {
+}
+

--- a/backend/src/main/java/com/openisle/model/PostVoteResultChangeLog.java
+++ b/backend/src/main/java/com/openisle/model/PostVoteResultChangeLog.java
@@ -1,0 +1,16 @@
+package com.openisle.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+@Table(name = "post_vote_result_change_logs")
+public class PostVoteResultChangeLog extends PostChangeLog {
+}
+

--- a/backend/src/main/java/com/openisle/service/PostChangeLogService.java
+++ b/backend/src/main/java/com/openisle/service/PostChangeLogService.java
@@ -86,6 +86,20 @@ public class PostChangeLogService {
         logRepository.save(log);
     }
 
+    public void recordVoteResult(Post post) {
+        PostVoteResultChangeLog log = new PostVoteResultChangeLog();
+        log.setPost(post);
+        log.setType(PostChangeType.VOTE_RESULT);
+        logRepository.save(log);
+    }
+
+    public void recordLotteryResult(Post post) {
+        PostLotteryResultChangeLog log = new PostLotteryResultChangeLog();
+        log.setPost(post);
+        log.setType(PostChangeType.LOTTERY_RESULT);
+        logRepository.save(log);
+    }
+
     public List<PostChangeLog> listLogs(Long postId) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new com.openisle.exception.NotFoundException("Post not found"));

--- a/frontend_nuxt/components/PostChangeLogItem.vue
+++ b/frontend_nuxt/components/PostChangeLogItem.vue
@@ -1,7 +1,13 @@
 <template>
   <div :id="`change-log-${log.id}`" class="change-log-container">
     <div class="change-log-text">
-      <span class="change-log-user">{{ log.username }}</span>
+      <BaseImage
+        v-if="log.userAvatar"
+        class="change-log-avatar"
+        :src="log.userAvatar"
+        alt="avatar"
+      />
+      <span v-if="log.username" class="change-log-user">{{ log.username }}</span>
       <span v-if="log.type === 'CONTENT'">变更了文章内容</span>
       <span v-else-if="log.type === 'TITLE'">变更了文章标题</span>
       <span v-else-if="log.type === 'CATEGORY'">变更了文章分类</span>
@@ -18,6 +24,8 @@
         <template v-if="log.newFeatured">将文章设为精选</template>
         <template v-else>取消精选文章</template>
       </span>
+      <span v-else-if="log.type === 'VOTE_RESULT'">投票已出结果</span>
+      <span v-else-if="log.type === 'LOTTERY_RESULT'">抽奖已开奖</span>
     </div>
     <div class="change-log-time">{{ log.time }}</div>
     <div
@@ -34,6 +42,7 @@ import { html } from 'diff2html'
 import { createTwoFilesPatch } from 'diff'
 import { useIsMobile } from '~/utils/screen'
 import 'diff2html/bundles/css/diff2html.min.css'
+import BaseImage from '~/components/BaseImage.vue'
 const props = defineProps({
   log: Object,
   title: String,
@@ -76,8 +85,18 @@ const diffHtml = computed(() => {
   opacity: 0.7;
   font-size: 14px;
 }
+.change-log-text {
+  display: flex;
+  align-items: center;
+}
 .change-log-user {
   font-weight: bold;
+  margin-right: 4px;
+}
+.change-log-avatar {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
   margin-right: 4px;
 }
 .change-log-time {

--- a/frontend_nuxt/pages/posts/[id]/index.vue
+++ b/frontend_nuxt/pages/posts/[id]/index.vue
@@ -363,6 +363,10 @@ const changeLogIcon = (l) => {
     } else {
       return 'dislike'
     }
+  } else if (l.type === 'VOTE_RESULT') {
+    return 'check-one'
+  } else if (l.type === 'LOTTERY_RESULT') {
+    return 'gift'
   } else {
     return 'info'
   }
@@ -371,6 +375,7 @@ const changeLogIcon = (l) => {
 const mapChangeLog = (l) => ({
   id: l.id,
   username: l.username,
+  userAvatar: l.userAvatar,
   type: l.type,
   createdAt: l.time,
   time: TimeManager.format(l.time),


### PR DESCRIPTION
## Summary
- include user avatars in post change log responses
- allow system-generated change log entries for poll and lottery results
- show change log avatars and messages for new types on frontend

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*
- `npm test` *(fails: Missing script "test")*
- `cd frontend_nuxt && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68be6e409b2883279fbe2f5f3d6ad415