### PR TITLE
Return structured category and tag data in change logs

### DIFF
--- a/backend/src/main/java/com/openisle/dto/PostChangeLogDto.java
+++ b/backend/src/main/java/com/openisle/dto/PostChangeLogDto.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Setter
@@ -18,10 +19,10 @@ public class PostChangeLogDto {
     private String newTitle;
     private String oldContent;
     private String newContent;
-    private String oldCategory;
-    private String newCategory;
-    private String oldTags;
-    private String newTags;
+    private CategoryDto oldCategory;
+    private CategoryDto newCategory;
+    private List<TagDto> oldTags;
+    private List<TagDto> newTags;
     private Boolean oldClosed;
     private Boolean newClosed;
     private LocalDateTime oldPinnedAt;

--- a/backend/src/main/java/com/openisle/mapper/PostChangeLogMapper.java
+++ b/backend/src/main/java/com/openisle/mapper/PostChangeLogMapper.java
@@ -1,8 +1,14 @@
 package com.openisle.mapper;
 
+import com.openisle.dto.CategoryDto;
 import com.openisle.dto.PostChangeLogDto;
+import com.openisle.dto.TagDto;
 import com.openisle.model.*;
 import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Component
 public class PostChangeLogMapper {
@@ -22,11 +28,41 @@ public class PostChangeLogMapper {
             dto.setOldContent(c.getOldContent());
             dto.setNewContent(c.getNewContent());
         } else if (log instanceof PostCategoryChangeLog cat) {
-            dto.setOldCategory(cat.getOldCategory());
-            dto.setNewCategory(cat.getNewCategory());
+            if (cat.getOldCategory() != null) {
+                CategoryDto oldCat = new CategoryDto();
+                oldCat.setName(cat.getOldCategory());
+                dto.setOldCategory(oldCat);
+            }
+            if (cat.getNewCategory() != null) {
+                CategoryDto newCat = new CategoryDto();
+                newCat.setName(cat.getNewCategory());
+                dto.setNewCategory(newCat);
+            }
         } else if (log instanceof PostTagChangeLog tag) {
-            dto.setOldTags(tag.getOldTags());
-            dto.setNewTags(tag.getNewTags());
+            if (tag.getOldTags() != null && !tag.getOldTags().isBlank()) {
+                List<TagDto> oldTags = Arrays.stream(tag.getOldTags().split(","))
+                        .map(String::trim)
+                        .filter(s -> !s.isEmpty())
+                        .map(name -> {
+                            TagDto t = new TagDto();
+                            t.setName(name);
+                            return t;
+                        })
+                        .collect(Collectors.toList());
+                dto.setOldTags(oldTags);
+            }
+            if (tag.getNewTags() != null && !tag.getNewTags().isBlank()) {
+                List<TagDto> newTags = Arrays.stream(tag.getNewTags().split(","))
+                        .map(String::trim)
+                        .filter(s -> !s.isEmpty())
+                        .map(name -> {
+                            TagDto t = new TagDto();
+                            t.setName(name);
+                            return t;
+                        })
+                        .collect(Collectors.toList());
+                dto.setNewTags(newTags);
+            }
         } else if (log instanceof PostClosedChangeLog cl) {
             dto.setOldClosed(cl.isOldClosed());
             dto.setNewClosed(cl.isNewClosed());


### PR DESCRIPTION
## Summary
- deliver post change log category changes as `CategoryDto`
- expose tag changes as lists of `TagDto`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.openisle:openisle:0.0.1-SNAPSHOT)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68be71d76b408327809d1170a3e0712e