### PR TITLE
Expose category and tag changes as DTOs

### DIFF
--- a/backend/src/main/java/com/openisle/dto/PostChangeLogDto.java
+++ b/backend/src/main/java/com/openisle/dto/PostChangeLogDto.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Setter
@@ -18,10 +19,10 @@ public class PostChangeLogDto {
     private String newTitle;
     private String oldContent;
     private String newContent;
-    private String oldCategory;
-    private String newCategory;
-    private String oldTags;
-    private String newTags;
+    private CategoryDto oldCategory;
+    private CategoryDto newCategory;
+    private List<TagDto> oldTags;
+    private List<TagDto> newTags;
     private Boolean oldClosed;
     private Boolean newClosed;
     private LocalDateTime oldPinnedAt;

--- a/backend/src/main/java/com/openisle/mapper/PostChangeLogMapper.java
+++ b/backend/src/main/java/com/openisle/mapper/PostChangeLogMapper.java
@@ -1,11 +1,28 @@
 package com.openisle.mapper;
 
+import com.openisle.dto.CategoryDto;
 import com.openisle.dto.PostChangeLogDto;
+import com.openisle.dto.TagDto;
 import com.openisle.model.*;
+import com.openisle.repository.CategoryRepository;
+import com.openisle.repository.TagRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component
+@RequiredArgsConstructor
 public class PostChangeLogMapper {
+
+    private final CategoryRepository categoryRepository;
+    private final TagRepository tagRepository;
+    private final CategoryMapper categoryMapper;
+    private final TagMapper tagMapper;
+
     public PostChangeLogDto toDto(PostChangeLog log) {
         PostChangeLogDto dto = new PostChangeLogDto();
         dto.setId(log.getId());
@@ -22,11 +39,11 @@ public class PostChangeLogMapper {
             dto.setOldContent(c.getOldContent());
             dto.setNewContent(c.getNewContent());
         } else if (log instanceof PostCategoryChangeLog cat) {
-            dto.setOldCategory(cat.getOldCategory());
-            dto.setNewCategory(cat.getNewCategory());
+            dto.setOldCategory(mapCategory(cat.getOldCategory()));
+            dto.setNewCategory(mapCategory(cat.getNewCategory()));
         } else if (log instanceof PostTagChangeLog tag) {
-            dto.setOldTags(tag.getOldTags());
-            dto.setNewTags(tag.getNewTags());
+            dto.setOldTags(mapTags(tag.getOldTags()));
+            dto.setNewTags(mapTags(tag.getNewTags()));
         } else if (log instanceof PostClosedChangeLog cl) {
             dto.setOldClosed(cl.isOldClosed());
             dto.setNewClosed(cl.isNewClosed());
@@ -38,5 +55,38 @@ public class PostChangeLogMapper {
             dto.setNewFeatured(f.isNewFeatured());
         }
         return dto;
+    }
+
+    private CategoryDto mapCategory(String name) {
+        if (name == null) {
+            return null;
+        }
+        return categoryRepository.findByName(name)
+                .map(categoryMapper::toDto)
+                .orElseGet(() -> {
+                    CategoryDto dto = new CategoryDto();
+                    dto.setName(name);
+                    return dto;
+                });
+    }
+
+    private List<TagDto> mapTags(String tags) {
+        if (tags == null || tags.isBlank()) {
+            return Collections.emptyList();
+        }
+        return Arrays.stream(tags.split(","))
+                .map(String::trim)
+                .map(this::mapTag)
+                .collect(Collectors.toList());
+    }
+
+    private TagDto mapTag(String name) {
+        return tagRepository.findByName(name)
+                .map(tagMapper::toDto)
+                .orElseGet(() -> {
+                    TagDto dto = new TagDto();
+                    dto.setName(name);
+                    return dto;
+                });
     }
 }

--- a/backend/src/main/java/com/openisle/repository/CategoryRepository.java
+++ b/backend/src/main/java/com/openisle/repository/CategoryRepository.java
@@ -4,7 +4,10 @@ import com.openisle.model.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
     List<Category> findByNameContainingIgnoreCase(String keyword);
+
+    Optional<Category> findByName(String name);
 }

--- a/backend/src/main/java/com/openisle/repository/TagRepository.java
+++ b/backend/src/main/java/com/openisle/repository/TagRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
     List<Tag> findByNameContainingIgnoreCase(String keyword);
@@ -15,4 +16,6 @@ public interface TagRepository extends JpaRepository<Tag, Long> {
 
     List<Tag> findByCreatorOrderByCreatedAtDesc(User creator, Pageable pageable);
     List<Tag> findByCreator(User creator);
+
+    Optional<Tag> findByName(String name);
 }


### PR DESCRIPTION
## Summary
- return category and tag change log entries using `CategoryDto` and `TagDto`
- map change log strings to DTOs via repositories and mappers
- add repository helpers to look up categories and tags by name

## Testing
- `mvn -f backend/pom.xml test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68be71d76b408327809d1170a3e0712e