### PR TITLE
feat: log poll and lottery results

### DIFF
--- a/backend/src/main/java/com/openisle/service/PostService.java
+++ b/backend/src/main/java/com/openisle/service/PostService.java
@@ -368,6 +368,7 @@ public class PostService {
             for (User participant : pp.getParticipants()) {
                 notificationService.createNotification(participant, NotificationType.POLL_RESULT_PARTICIPANT, pp, null, null, null, null, null);
             }
+            postChangeLogService.recordVoteResult(pp);
         });
     }
 
@@ -402,6 +403,7 @@ public class PostService {
                 notificationService.createNotification(lp.getAuthor(), NotificationType.LOTTERY_DRAW, lp, null, null, null, null, null);
                 notificationService.sendCustomPush(lp.getAuthor(), "抽奖已开奖", String.format("%s/posts/%d", websiteUrl, lp.getId()));
             }
+            postChangeLogService.recordLotteryResult(lp);
         });
     }
 


### PR DESCRIPTION
## Summary
- log poll result announcements via PostChangeLogService
- record lottery results when winners are finalized

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - network is unreachable)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68be7e7a08f08327b98c58cf6b672ef0