### PR TITLE
Create system user for internal logging

### DIFF
--- a/backend/src/main/java/com/openisle/config/SystemUserInitializer.java
+++ b/backend/src/main/java/com/openisle/config/SystemUserInitializer.java
@@ -1,0 +1,34 @@
+package com.openisle.config;
+
+import com.openisle.model.Role;
+import com.openisle.model.User;
+import com.openisle.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+/**
+ * Ensure a dedicated "system" user exists for internal operations.
+ */
+@Component
+@RequiredArgsConstructor
+public class SystemUserInitializer implements CommandLineRunner {
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public void run(String... args) {
+        userRepository.findByUsername("system").orElseGet(() -> {
+            User system = new User();
+            system.setUsername("system");
+            system.setEmail("system@openisle.local");
+            system.setPassword(passwordEncoder.encode("system"));
+            system.setRole(Role.ADMIN);
+            system.setVerified(true);
+            system.setApproved(true);
+            return userRepository.save(system);
+        });
+    }
+}
+

--- a/backend/src/main/java/com/openisle/service/PostChangeLogService.java
+++ b/backend/src/main/java/com/openisle/service/PostChangeLogService.java
@@ -3,6 +3,7 @@ package com.openisle.service;
 import com.openisle.model.*;
 import com.openisle.repository.PostChangeLogRepository;
 import com.openisle.repository.PostRepository;
+import com.openisle.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -15,6 +16,12 @@ import java.util.stream.Collectors;
 public class PostChangeLogService {
     private final PostChangeLogRepository logRepository;
     private final PostRepository  postRepository;
+    private final UserRepository userRepository;
+
+    private User getSystemUser() {
+        return userRepository.findByUsername("system")
+                .orElseThrow(() -> new IllegalStateException("System user not found"));
+    }
 
     public void recordContentChange(Post post, User user, String oldContent, String newContent) {
         PostContentChangeLog log = new PostContentChangeLog();
@@ -89,6 +96,7 @@ public class PostChangeLogService {
     public void recordVoteResult(Post post) {
         PostVoteResultChangeLog log = new PostVoteResultChangeLog();
         log.setPost(post);
+        log.setUser(getSystemUser());
         log.setType(PostChangeType.VOTE_RESULT);
         logRepository.save(log);
     }
@@ -96,6 +104,7 @@ public class PostChangeLogService {
     public void recordLotteryResult(Post post) {
         PostLotteryResultChangeLog log = new PostLotteryResultChangeLog();
         log.setPost(post);
+        log.setUser(getSystemUser());
         log.setType(PostChangeType.LOTTERY_RESULT);
         logRepository.save(log);
     }


### PR DESCRIPTION
## Summary
- Add startup initializer to create a dedicated `system` user
- Attribute vote and lottery result change logs to the `system` user

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.openisle:openisle:0.0.1-SNAPSHOT: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.1.1)*

------
https://chatgpt.com/codex/tasks/task_e_68be8227357c8327bdd8f19b0607250d