### PR TITLE
Run docs deployment after staging deploy

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,7 +1,11 @@
 name: Deploy Documentation
 
 on:
-  push:
+  workflow_call:
+    inputs:
+      build-id:
+        required: false
+        type: string
   workflow_dispatch:
 
 permissions:
@@ -15,6 +19,9 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
+
+      - name: Log build
+        run: echo "Running documentation deployment from build ${{ inputs.build-id }}"
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -21,3 +21,11 @@ jobs:
           key: ${{ secrets.SSH_KEY }}
           script: bash /opt/openisle/deploy-staging.sh
 
+  deploy-docs:
+    needs: build-and-deploy
+    if: ${{ success() }}
+    uses: ./.github/workflows/deploy-docs.yml
+    secrets: inherit
+    with:
+      build-id: ${{ github.run_id }}
+


### PR DESCRIPTION
## Summary
- make docs workflow reusable with `workflow_call` and manual dispatch
- call docs deployment after staging deploy completes

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bf8cbed31083278561f6ba1ec5b7aa