### PR TITLE
docs: use https for OpenAPI base URL

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -108,7 +108,7 @@ rabbitmq.sharding.enabled=true
 # see https://springdoc.org/#springdoc-openapi-core-properties
 springdoc.api-docs.path=/api/v3/api-docs
 springdoc.api-docs.enabled=true
-springdoc.api-docs.server-url=https://staging.open-isle.com
+springdoc.api-docs.server-url=${WEBSITE_URL:https://www.open-isle.com}
 springdoc.info.title=OpenIsle
 springdoc.info.description=OpenIsle Open API Documentation
 springdoc.info.version=0.0.1


### PR DESCRIPTION
## Summary
- ensure OpenAPI documentation uses HTTPS base URL

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa1ee8c188327bbaea58a75013b13