### PR TITLE
Add configurable OpenAPI server URL

### DIFF
--- a/backend/src/main/java/com/openisle/config/OpenApiConfig.java
+++ b/backend/src/main/java/com/openisle/config/OpenApiConfig.java
@@ -5,6 +5,9 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+
+import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -27,6 +30,9 @@ public class OpenApiConfig {
     @Value("${springdoc.info.header}")
     private String header;
 
+    @Value("${springdoc.api-docs.server-url}")
+    private String serverUrl;
+
     @Bean
     public OpenAPI openAPI() {
         SecurityScheme securityScheme = new SecurityScheme()
@@ -37,12 +43,12 @@ public class OpenApiConfig {
 			.name(header);
 
         return new OpenAPI()
+                .servers(List.of(new Server().url(serverUrl)))
                 .info(new Info()
-					.title(title)
-					.description(description)
-					.version(version))
-                .components(new Components()
-					.addSecuritySchemes("JWT", securityScheme))
+                        .title(title)
+                        .description(description)
+                        .version(version))
+                .components(new Components().addSecuritySchemes("JWT", securityScheme))
                 .addSecurityItem(new SecurityRequirement().addList("JWT"));
     }
 }


### PR DESCRIPTION
## Summary
- allow setting OpenAPI server URL via `springdoc.api-docs.server-url`

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.1.1 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa7fc52348327b08f47b7c299fc82