### PR TITLE
docs: serve docs at root path

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,6 @@ bun dev
 
 使用以下路由：
 
-- `docs/frontend/` 前端技术文档
-- `docs/backend/` 后端技术文档
-- `docs/openapi/` 后端 API 文档
+- `frontend/` 前端技术文档
+- `backend/` 后端技术文档
+- `openapi/` 后端 API 文档

--- a/docs/app/(home)/[[...slug]]/page.tsx
+++ b/docs/app/(home)/[[...slug]]/page.tsx
@@ -19,7 +19,7 @@ function DocsCategory({ url }: { url: string }) {
   );
 }
 
-export default async function Page(props: PageProps<'/docs/[[...slug]]'>) {
+export default async function Page(props: PageProps<'/[[...slug]]'>) {
   const params = await props.params;
   const page = source.getPage(params.slug);
   if (!page) notFound();
@@ -48,7 +48,7 @@ export async function generateStaticParams() {
 }
 
 export async function generateMetadata(
-  props: PageProps<'/docs/[[...slug]]'>
+  props: PageProps<'/[[...slug]]'>
 ): Promise<Metadata> {
   const params = await props.params;
   const page = source.getPage(params.slug);

--- a/docs/app/(home)/layout.tsx
+++ b/docs/app/(home)/layout.tsx
@@ -28,7 +28,7 @@ function TabTitle({ children }: { children: React.ReactNode }) {
   return <span className="text-[11px]">{children}</span>;
 }
 
-export default function Layout({ children }: LayoutProps<'/docs'>) {
+export default function Layout({ children }: LayoutProps<'/'>) {
   return (
     // @ts-ignore
     <DocsLayout
@@ -40,7 +40,7 @@ export default function Layout({ children }: LayoutProps<'/docs'>) {
           {
             title: 'OpenIsle 前端',
             description: <TabTitle>前端开发文档</TabTitle>,
-            url: '/docs/frontend',
+            url: '/frontend',
             icon: (
               <TabIcon color="#4ca154">
                 <CompassIcon />
@@ -50,7 +50,7 @@ export default function Layout({ children }: LayoutProps<'/docs'>) {
           {
             title: 'OpenIsle 后端',
             description: <TabTitle>后端开发文档</TabTitle>,
-            url: '/docs/backend',
+            url: '/backend',
             icon: (
               <TabIcon color="#1f66f4">
                 <ServerIcon />
@@ -60,7 +60,7 @@ export default function Layout({ children }: LayoutProps<'/docs'>) {
           {
             title: 'OpenIsle API',
             description: <TabTitle>后端 API 文档</TabTitle>,
-            url: '/docs/openapi',
+            url: '/openapi',
             icon: (
               <TabIcon color="#677489">
                 <CodeXmlIcon />

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -6,7 +6,7 @@ const inter = Inter({
   subsets: ['latin'],
 });
 
-export default function Layout({ children }: LayoutProps<'/docs'>) {
+export default function Layout({ children }: LayoutProps<'/'>) {
   return (
     <html lang="zh" className={inter.className} suppressHydrationWarning>
       <body className="flex flex-col min-h-screen">

--- a/docs/content/docs/backend/index.mdx
+++ b/docs/content/docs/backend/index.mdx
@@ -40,4 +40,4 @@ backend/
 
 ## API 接口
 
-详细的 API 接口文档请查看 [API 文档](/docs/openapi)。
+详细的 API 接口文档请查看 [API 文档](/openapi)。

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -9,6 +9,6 @@ OpenIsle 是一个现代化的社区平台，提供完整的社交功能。
 
 ## 快速开始
 
-- [后端开发指南](/docs/backend) - 了解后端架构和开发
-- [前端开发指南](/docs/frontend) - 了解前端技术栈和组件
-- [API 文档](/docs/openapi) - 查看完整的 API 接口文档
+- [后端开发指南](/backend) - 了解后端架构和开发
+- [前端开发指南](/frontend) - 了解前端技术栈和组件
+- [API 文档](/openapi) - 查看完整的 API 接口文档

--- a/docs/lib/layout.shared.tsx
+++ b/docs/lib/layout.shared.tsx
@@ -8,7 +8,7 @@ export function baseOptions(): BaseLayoutProps {
     githubUrl: 'https://github.com/nagisa77/OpenIsle',
     nav: {
       title: 'OpenIsle Docs',
-      url: '/docs',
+      url: '/',
     },
     searchToggle: {
       enabled: false,

--- a/docs/lib/source.ts
+++ b/docs/lib/source.ts
@@ -10,7 +10,7 @@ import * as ClientAdapters from './media-adapter.client';
 // See https://fumadocs.vercel.app/docs/headless/source-api for more info
 export const source = loader({
   // it assigns a URL to your pages
-  baseUrl: '/docs',
+  baseUrl: '/',
   source: docs.toFumadocsSource(),
   pageTree: {
     transformers: [transformerOpenAPI()],


### PR DESCRIPTION
## Summary
- serve documentation at root by moving app/docs content to top level
- adjust base URL and navigation links to drop `/docs` prefix
- update internal links and README to match new routes

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bfbdb875f083278fd1e586e2854ec7