### PR TITLE
fix: restrict image preview to markdown images

### DIFF
--- a/frontend_nuxt/components/CommentItem.vue
+++ b/frontend_nuxt/components/CommentItem.vue
@@ -342,7 +342,7 @@ const copyCommentLink = () => {
 
 const handleContentClick = (e) => {
   handleMarkdownClick(e)
-  if (e.target.tagName === 'IMG') {
+  if (e.target.tagName === 'IMG' && !e.target.classList.contains('emoji')) {
     const container = e.target.parentNode
     const imgs = [...container.querySelectorAll('img')].map((i) => i.src)
     lightboxImgs.value = imgs

--- a/frontend_nuxt/pages/message-box/[id].vue
+++ b/frontend_nuxt/pages/message-box/[id].vue
@@ -463,7 +463,11 @@ function minimize() {
 
 function handleContentClick(e) {
   handleMarkdownClick(e)
-  if (e.target.tagName === 'IMG') {
+  if (
+    e.target.tagName === 'IMG' &&
+    !e.target.classList.contains('emoji') &&
+    !e.target.closest('.reactions-container')
+  ) {
     const container = e.target.parentNode
     const imgs = [...container.querySelectorAll('img')].map((i) => i.src)
     lightboxImgs.value = imgs

--- a/frontend_nuxt/pages/posts/[id]/index.vue
+++ b/frontend_nuxt/pages/posts/[id]/index.vue
@@ -434,7 +434,7 @@ const removeCommentFromList = (id, list) => {
 
 const handleContentClick = (e) => {
   handleMarkdownClick(e)
-  if (e.target.tagName === 'IMG') {
+  if (e.target.tagName === 'IMG' && !e.target.classList.contains('emoji')) {
     const container = e.target.parentNode
     const imgs = [...container.querySelectorAll('img')].map((i) => i.src)
     lightboxImgs.value = imgs


### PR DESCRIPTION
## Summary
- avoid lightbox preview when clicking reaction emojis in chat
- skip tieba emojis when determining lightbox images

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Cannot find native binding for oxc-parser)*

------
https://chatgpt.com/codex/tasks/task_e_68c384a25af48327b935f09134c91107