### PR TITLE
主页列表接口优化,优化帖子评论统计性能

### DIFF
--- a/backend/src/main/java/com/openisle/mapper/PostMapper.java
+++ b/backend/src/main/java/com/openisle/mapper/PostMapper.java
@@ -67,7 +67,7 @@ public class PostMapper {
         dto.setCategory(categoryMapper.toDto(post.getCategory()));
         dto.setTags(post.getTags().stream().map(tagMapper::toDto).collect(Collectors.toList()));
         dto.setViews(post.getViews());
-        dto.setCommentCount(commentService.countComments(post.getId()));
+        dto.setCommentCount(post.getCommentCount());
         dto.setStatus(post.getStatus());
         dto.setPinnedAt(post.getPinnedAt());
         dto.setRssExcluded(post.getRssExcluded() == null || post.getRssExcluded());
@@ -82,7 +82,7 @@ public class PostMapper {
         List<User> participants = commentService.getParticipants(post.getId(), 5);
         dto.setParticipants(participants.stream().map(userMapper::toAuthorDto).collect(Collectors.toList()));
 
-        LocalDateTime last = commentService.getLastCommentTime(post.getId());
+        LocalDateTime last = post.getLastReplyAt();
         dto.setLastReplyAt(last != null ? last : post.getCreatedAt());
         dto.setReward(0);
         dto.setSubscribed(false);

--- a/backend/src/main/java/com/openisle/mapper/PostMapper.java
+++ b/backend/src/main/java/com/openisle/mapper/PostMapper.java
@@ -83,7 +83,10 @@ public class PostMapper {
         dto.setParticipants(participants.stream().map(userMapper::toAuthorDto).collect(Collectors.toList()));
 
         LocalDateTime last = post.getLastReplyAt();
-        dto.setLastReplyAt(last != null ? last : post.getCreatedAt());
+        if (last == null) {
+            commentService.updatePostCommentStats(post);
+        }
+        dto.setLastReplyAt(post.getLastReplyAt());
         dto.setReward(0);
         dto.setSubscribed(false);
         dto.setType(post.getType());

--- a/backend/src/main/java/com/openisle/mapper/PostMapper.java
+++ b/backend/src/main/java/com/openisle/mapper/PostMapper.java
@@ -67,7 +67,6 @@ public class PostMapper {
         dto.setCategory(categoryMapper.toDto(post.getCategory()));
         dto.setTags(post.getTags().stream().map(tagMapper::toDto).collect(Collectors.toList()));
         dto.setViews(post.getViews());
-        dto.setCommentCount(post.getCommentCount());
         dto.setStatus(post.getStatus());
         dto.setPinnedAt(post.getPinnedAt());
         dto.setRssExcluded(post.getRssExcluded() == null || post.getRssExcluded());
@@ -86,6 +85,7 @@ public class PostMapper {
         if (last == null) {
             commentService.updatePostCommentStats(post);
         }
+        dto.setCommentCount(post.getCommentCount());
         dto.setLastReplyAt(post.getLastReplyAt());
         dto.setReward(0);
         dto.setSubscribed(false);

--- a/backend/src/main/java/com/openisle/model/Post.java
+++ b/backend/src/main/java/com/openisle/model/Post.java
@@ -72,4 +72,10 @@ public class Post {
 
     @Column(nullable = true)
     private Boolean rssExcluded = true;
+
+    @Column(nullable = false)
+    private long commentCount = 0;
+
+    @Column(nullable = true)
+    private LocalDateTime lastReplyAt;
 }

--- a/backend/src/main/java/com/openisle/service/CommentService.java
+++ b/backend/src/main/java/com/openisle/service/CommentService.java
@@ -346,12 +346,16 @@ public class CommentService {
     /**
      * Update post comment statistics (comment count and last reply time)
      */
-    private void updatePostCommentStats(Post post) {
+    public void updatePostCommentStats(Post post) {
         long commentCount = commentRepository.countByPostId(post.getId());
-        LocalDateTime lastReplyAt = commentRepository.findLastCommentTime(post);
-        
         post.setCommentCount(commentCount);
-        post.setLastReplyAt(lastReplyAt);
+
+        LocalDateTime lastReplyAt = commentRepository.findLastCommentTime(post);
+        if (lastReplyAt == null) {
+            post.setLastReplyAt(post.getCreatedAt());
+        } else {
+            post.setLastReplyAt(lastReplyAt);
+        }
         postRepository.save(post);
         
         log.debug("Updated post {} stats: commentCount={}, lastReplyAt={}", 

--- a/backend/src/main/resources/db/migration/V5__add_comment_stats_to_posts.sql
+++ b/backend/src/main/resources/db/migration/V5__add_comment_stats_to_posts.sql
@@ -1,0 +1,19 @@
+-- Add comment count and last reply time fields to posts table for performance optimization
+ALTER TABLE posts ADD COLUMN comment_count BIGINT NOT NULL DEFAULT 0;
+ALTER TABLE posts ADD COLUMN last_reply_at DATETIME(6) NULL;
+
+-- Add index on last_reply_at for sorting by latest reply
+CREATE INDEX idx_posts_last_reply_at ON posts(last_reply_at);
+
+-- Initialize comment_count and last_reply_at with existing data
+UPDATE posts p SET 
+    comment_count = (
+        SELECT COUNT(*) 
+        FROM comments c 
+        WHERE c.post_id = p.id AND c.deleted_at IS NULL
+    ),
+    last_reply_at = (
+        SELECT MAX(c.created_at) 
+        FROM comments c 
+        WHERE c.post_id = p.id AND c.deleted_at IS NULL
+    );

--- a/backend/src/test/java/com/openisle/controller/PostControllerTest.java
+++ b/backend/src/test/java/com/openisle/controller/PostControllerTest.java
@@ -55,6 +55,10 @@ class PostControllerTest {
     private UserVisitService userVisitService;
     @MockBean
     private PostReadService postReadService;
+    @MockBean
+    private MedalService medalService;
+    @MockBean
+    private com.openisle.repository.PollVoteRepository pollVoteRepository;
 
     @Test
     void createAndGetPost() throws Exception {
@@ -63,9 +67,13 @@ class PostControllerTest {
         Category cat = new Category();
         cat.setId(1L);
         cat.setName("tech");
+        cat.setDescription("Technology category");
+        cat.setIcon("tech-icon");
         Tag tag = new Tag();
         tag.setId(1L);
         tag.setName("java");
+        tag.setDescription("Java programming language");
+        tag.setIcon("java-icon");
         Post post = new Post();
         post.setId(1L);
         post.setTitle("t");
@@ -111,9 +119,13 @@ class PostControllerTest {
         Category cat = new Category();
         cat.setId(1L);
         cat.setName("tech");
+        cat.setDescription("Technology category");
+        cat.setIcon("tech-icon");
         Tag tag = new Tag();
         tag.setId(1L);
         tag.setName("java");
+        tag.setDescription("Java programming language");
+        tag.setIcon("java-icon");
         Post post = new Post();
         post.setId(1L);
         post.setTitle("t2");
@@ -147,9 +159,13 @@ class PostControllerTest {
         Category cat = new Category();
         cat.setId(1L);
         cat.setName("tech");
+        cat.setDescription("Technology category");
+        cat.setIcon("tech-icon");
         Tag tag = new Tag();
         tag.setId(1L);
         tag.setName("java");
+        tag.setDescription("Java programming language");
+        tag.setIcon("java-icon");
         Post post = new Post();
         post.setId(2L);
         post.setTitle("hello");
@@ -197,9 +213,13 @@ class PostControllerTest {
         Category cat = new Category();
         cat.setId(1L);
         cat.setName("tech");
+        cat.setDescription("Technology category");
+        cat.setIcon("tech-icon");
         Tag tag = new Tag();
         tag.setId(1L);
         tag.setName("java");
+        tag.setDescription("Java programming language");
+        tag.setIcon("java-icon");
         Post post = new Post();
         post.setId(1L);
         post.setTitle("t");
@@ -262,6 +282,8 @@ class PostControllerTest {
         Category cat = new Category();
         cat.setId(1L);
         cat.setName("tech");
+        cat.setDescription("Technology category");
+        cat.setIcon("tech-icon");
         Post post = new Post();
         post.setId(1L);
         post.setTitle("t");

--- a/backend/src/test/java/com/openisle/service/PostCommentStatsTest.java
+++ b/backend/src/test/java/com/openisle/service/PostCommentStatsTest.java
@@ -1,0 +1,90 @@
+package com.openisle.service;
+
+import com.openisle.model.*;
+import com.openisle.repository.*;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@TestPropertySource(locations = "classpath:application.properties")
+@Transactional
+public class PostCommentStatsTest {
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private TagRepository tagRepository;
+
+    @Autowired
+    private CommentService commentService;
+
+    @Test
+    public void testPostCommentStatsUpdate() {
+        // Create test user
+        User user = new User();
+        user.setUsername("testuser");
+        user.setEmail("test@example.com");
+        user.setPassword("hash");
+        user = userRepository.save(user);
+
+        // Create test category
+        Category category = new Category();
+        category.setName("Test Category");
+        category.setDescription("Test Category Description");
+        category.setIcon("test-icon");
+        category = categoryRepository.save(category);
+
+        // Create test tag
+        Tag tag = new Tag();
+        tag.setName("Test Tag");
+        tag.setDescription("Test Tag Description");
+        tag.setIcon("test-tag-icon");
+        tag = tagRepository.save(tag);
+
+        // Create test post
+        Post post = new Post();
+        post.setTitle("Test Post");
+        post.setContent("Test content");
+        post.setAuthor(user);
+        post.setCategory(category);
+        post.getTags().add(tag);
+        post.setStatus(PostStatus.PUBLISHED);
+        post.setCommentCount(0L);
+        post = postRepository.save(post);
+
+        // Verify initial state
+        assertEquals(0L, post.getCommentCount());
+        assertNull(post.getLastReplyAt());
+
+        // Add a comment
+        commentService.addComment("testuser", post.getId(), "Test comment");
+
+        // Refresh post from database
+        post = postRepository.findById(post.getId()).orElseThrow();
+
+        // Verify comment count and last reply time are updated
+        assertEquals(1L, post.getCommentCount());
+        assertNotNull(post.getLastReplyAt());
+
+        // Add another comment
+        commentService.addComment("testuser", post.getId(), "Another comment");
+
+        // Refresh post again
+        post = postRepository.findById(post.getId()).orElseThrow();
+
+        // Verify comment count is updated
+        assertEquals(2L, post.getCommentCount());
+    }
+}

--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -4,7 +4,18 @@ spring.datasource.username=sa
 spring.datasource.password=
 spring.jpa.hibernate.ddl-auto=create-drop
 
+springdoc.info.title=openisle
+springdoc.info.description=Test API documentation
+springdoc.info.version=1.0.0
+springdoc.info.scheme=Bearer
+springdoc.info.header=Authorization
+
+
+rabbitmq.queue.durable=true
+rabbitmq.sharding.enabled=true
+
 resend.api.key=dummy
+resend.from.email=dummy@example.com
 cos.base-url=http://test.example.com
 cos.secret-id=dummy
 cos.secret-key=dummy
@@ -18,6 +29,7 @@ app.upload.max-size=1048576
 app.jwt.secret=TestSecret
 app.jwt.reason-secret=TestReasonSecret
 app.jwt.reset-secret=TestResetSecret
+app.jwt.invite-secret=TestInviteSecret
 app.jwt.expiration=3600000
 
 # Default publish mode for tests


### PR DESCRIPTION
- 在 Post 模型中添加 commentCount 和 lastReplyAt 字段
- 在 CommentService 中实现更新帖子评论统计的方法
- 在 PostMapper 中使用 Post 模型中的评论统计字段
- 新增数据库迁移脚本，添加评论统计字段和索引
- 更新相关测试用例

#554 