### PR TITLE
feat: add paginated tag loading

### DIFF
--- a/backend/src/main/java/com/openisle/controller/TagController.java
+++ b/backend/src/main/java/com/openisle/controller/TagController.java
@@ -80,18 +80,15 @@ public class TagController {
     @ApiResponse(responseCode = "200", description = "List of tags",
             content = @Content(array = @ArraySchema(schema = @Schema(implementation = TagDto.class))))
     public List<TagDto> list(@RequestParam(value = "keyword", required = false) String keyword,
-                             @RequestParam(value = "limit", required = false) Integer limit) {
-        List<Tag> tags = tagService.searchTags(keyword);
+                             @RequestParam(value = "page", required = false) Integer page,
+                             @RequestParam(value = "pageSize", required = false) Integer pageSize) {
+        List<Tag> tags = tagService.searchTags(keyword, page, pageSize);
         List<Long> tagIds = tags.stream().map(Tag::getId).toList();
         Map<Long, Long> postCntByTagIds = postService.countPostsByTagIds(tagIds);
-        List<TagDto> dtos = tags.stream()
+        return tags.stream()
                 .map(t -> tagMapper.toDto(t, postCntByTagIds.getOrDefault(t.getId(), 0L)))
                 .sorted((a, b) -> Long.compare(b.getCount(), a.getCount()))
                 .collect(Collectors.toList());
-        if (limit != null && limit > 0 && dtos.size() > limit) {
-            return dtos.subList(0, limit);
-        }
-        return dtos;
     }
 
     @GetMapping("/{id}")

--- a/backend/src/main/java/com/openisle/repository/TagRepository.java
+++ b/backend/src/main/java/com/openisle/repository/TagRepository.java
@@ -4,6 +4,7 @@ import com.openisle.model.Tag;
 import com.openisle.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Page;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,6 +14,8 @@ public interface TagRepository extends JpaRepository<Tag, Long> {
     List<Tag> findByApproved(boolean approved);
     List<Tag> findByApprovedTrue();
     List<Tag> findByNameContainingIgnoreCaseAndApprovedTrue(String keyword);
+    Page<Tag> findByApprovedTrue(Pageable pageable);
+    Page<Tag> findByNameContainingIgnoreCaseAndApprovedTrue(String keyword, Pageable pageable);
 
     List<Tag> findByCreatorOrderByCreatedAtDesc(User creator, Pageable pageable);
     List<Tag> findByCreator(User creator);

--- a/backend/src/main/java/com/openisle/service/TagService.java
+++ b/backend/src/main/java/com/openisle/service/TagService.java
@@ -108,6 +108,17 @@ public class TagService {
         return tagRepository.findByNameContainingIgnoreCaseAndApprovedTrue(keyword);
     }
 
+    public List<Tag> searchTags(String keyword, Integer page, Integer pageSize) {
+        if (page == null || pageSize == null) {
+            return searchTags(keyword);
+        }
+        Pageable pageable = PageRequest.of(page, pageSize);
+        if (keyword == null || keyword.isBlank()) {
+            return tagRepository.findByApprovedTrue(pageable).getContent();
+        }
+        return tagRepository.findByNameContainingIgnoreCaseAndApprovedTrue(keyword, pageable).getContent();
+    }
+
     public List<Tag> getRecentTagsByUser(String username, int limit) {
         User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> new com.openisle.exception.NotFoundException("User not found"));

--- a/backend/src/test/java/com/openisle/controller/TagControllerTest.java
+++ b/backend/src/test/java/com/openisle/controller/TagControllerTest.java
@@ -75,9 +75,9 @@ class TagControllerTest {
         t.setDescription("d2");
         t.setIcon("i2");
         t.setSmallIcon("s2");
-        Mockito.when(tagService.searchTags(null)).thenReturn(List.of(t));
+        Mockito.when(tagService.searchTags(null, 0, 10)).thenReturn(List.of(t));
 
-        mockMvc.perform(get("/api/tags"))
+        mockMvc.perform(get("/api/tags?page=0&pageSize=10"))
                 .andExpect(status().isOk())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].name").value("spring"))

--- a/frontend_nuxt/components/InfiniteLoadMore.vue
+++ b/frontend_nuxt/components/InfiniteLoadMore.vue
@@ -25,6 +25,8 @@ const props = defineProps({
   rootMargin: { type: String, default: '200px 0px' },
   /** 触发阈值 */
   threshold: { type: Number, default: 0 },
+  /** 自定义 IntersectionObserver 根元素（默认为视口） */
+  root: { type: Object, default: null },
 })
 
 const isLoading = ref(false)
@@ -58,7 +60,11 @@ const startObserver = () => {
         isLoading.value = false
       }
     },
-    { root: null, rootMargin: props.rootMargin, threshold: props.threshold },
+    {
+      root: props.root || null,
+      rootMargin: props.rootMargin,
+      threshold: props.threshold,
+    },
   )
   if (sentinel.value) io.observe(sentinel.value)
 }
@@ -73,6 +79,13 @@ watch(
   (p) => {
     if (p) stopObserver()
     else nextTick(startObserver)
+  },
+)
+
+watch(
+  () => props.root,
+  () => {
+    nextTick(startObserver)
   },
 )
 


### PR DESCRIPTION
## Summary
- support pageable tag queries on backend
- add infinite scrolling to dropdown tag selector and side menu

## Testing
- `npx prettier frontend_nuxt/components/InfiniteLoadMore.vue frontend_nuxt/components/Dropdown.vue frontend_nuxt/components/TagSelect.vue frontend_nuxt/components/MenuComponent.vue --check`
- `cd backend && mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.1.1: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c3bb01b9608327ae80b6acea579d19