### PR TITLE
feat: add paginated tag loading

### DIFF
--- a/backend/src/main/java/com/openisle/repository/TagRepository.java
+++ b/backend/src/main/java/com/openisle/repository/TagRepository.java
@@ -4,6 +4,7 @@ import com.openisle.model.Tag;
 import com.openisle.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Page;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,6 +14,9 @@ public interface TagRepository extends JpaRepository<Tag, Long> {
     List<Tag> findByApproved(boolean approved);
     List<Tag> findByApprovedTrue();
     List<Tag> findByNameContainingIgnoreCaseAndApprovedTrue(String keyword);
+
+    Page<Tag> findByApprovedTrue(Pageable pageable);
+    Page<Tag> findByNameContainingIgnoreCaseAndApprovedTrue(String keyword, Pageable pageable);
 
     List<Tag> findByCreatorOrderByCreatedAtDesc(User creator, Pageable pageable);
     List<Tag> findByCreator(User creator);

--- a/backend/src/main/java/com/openisle/service/TagService.java
+++ b/backend/src/main/java/com/openisle/service/TagService.java
@@ -9,6 +9,7 @@ import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Page;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -106,6 +107,14 @@ public class TagService {
         }
 
         return tagRepository.findByNameContainingIgnoreCaseAndApprovedTrue(keyword);
+    }
+
+    public Page<Tag> searchTags(String keyword, int page, int pageSize) {
+        Pageable pageable = PageRequest.of(page, pageSize);
+        if (keyword == null || keyword.isBlank()) {
+            return tagRepository.findByApprovedTrue(pageable);
+        }
+        return tagRepository.findByNameContainingIgnoreCaseAndApprovedTrue(keyword, pageable);
     }
 
     public List<Tag> getRecentTagsByUser(String username, int limit) {

--- a/frontend_nuxt/components/InfiniteLoadMore.vue
+++ b/frontend_nuxt/components/InfiniteLoadMore.vue
@@ -25,6 +25,8 @@ const props = defineProps({
   rootMargin: { type: String, default: '200px 0px' },
   /** 触发阈值 */
   threshold: { type: Number, default: 0 },
+  /** 可选：指定滚动容器 */
+  root: { type: [Object, Function], default: null },
 })
 
 const isLoading = ref(false)
@@ -42,6 +44,13 @@ const stopObserver = () => {
 const startObserver = () => {
   if (!import.meta.client || props.pause || done.value) return
   stopObserver()
+  const getRoot = () => {
+    if (!props.root) return null
+    if (typeof props.root === 'function') return props.root()
+    if (props.root && 'value' in props.root) return props.root.value
+    return props.root
+  }
+
   io = new IntersectionObserver(
     async (entries) => {
       const e = entries[0]
@@ -58,7 +67,7 @@ const startObserver = () => {
         isLoading.value = false
       }
     },
-    { root: null, rootMargin: props.rootMargin, threshold: props.threshold },
+    { root: getRoot(), rootMargin: props.rootMargin, threshold: props.threshold },
   )
   if (sentinel.value) io.observe(sentinel.value)
 }


### PR DESCRIPTION
## Summary
- add backend pagination for tag listing
- enable paginated dropdowns and tag selection
- load menu tags incrementally with infinite scroll

## Testing
- `npm test` *(fails: Missing script "test")*
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c3bb01b9608327ae80b6acea579d19