### PR TITLE
Fix post cache keys to include pagination parameters

### DIFF
--- a/backend/src/main/java/com/openisle/service/CommentService.java
+++ b/backend/src/main/java/com/openisle/service/CommentService.java
@@ -52,7 +52,7 @@ public class CommentService {
 
     @CacheEvict(
             value = CachingConfig.POST_CACHE_NAME,
-            key = "'latest_reply'"
+            allEntries = true
     )
     @Transactional
     public Comment addComment(String username, Long postId, String content) {
@@ -104,7 +104,7 @@ public class CommentService {
 
     @CacheEvict(
             value = CachingConfig.POST_CACHE_NAME,
-            key = "'latest_reply'"
+            allEntries = true
     )
     @Transactional
     public Comment addReply(String username, Long parentId, String content) {
@@ -241,7 +241,7 @@ public class CommentService {
 
     @CacheEvict(
             value = CachingConfig.POST_CACHE_NAME,
-            key = "'latest_reply'"
+            allEntries = true
     )
     @Transactional
     public void deleteComment(String username, Long id) {
@@ -260,7 +260,7 @@ public class CommentService {
 
     @CacheEvict(
             value = CachingConfig.POST_CACHE_NAME,
-            key = "'latest_reply'"
+            allEntries = true
     )
     @Transactional
     public void deleteCommentCascade(Comment comment) {

--- a/backend/src/main/java/com/openisle/service/PostService.java
+++ b/backend/src/main/java/com/openisle/service/PostService.java
@@ -509,7 +509,7 @@ public class PostService {
 
     @Cacheable(
             value = CachingConfig.POST_CACHE_NAME,
-            key = "'latest_reply'"
+            key = "new org.springframework.cache.interceptor.SimpleKey('latest_reply', #categoryIds, #tagIds, #page, #pageSize)"
     )
     public List<Post> listPostsByLatestReply(java.util.List<Long> categoryIds,
                                              java.util.List<Long> tagIds,
@@ -648,7 +648,7 @@ public class PostService {
      */
     @Cacheable(
             value = CachingConfig.POST_CACHE_NAME,
-            key = "'default'"
+            key = "new org.springframework.cache.interceptor.SimpleKey('default', #ids, #tids, #page, #pageSize)"
     )
     public List<Post> defaultListPosts(List<Long> ids, List<Long> tids, Integer page, Integer pageSize){
         boolean hasCategories = !CollectionUtils.isEmpty(ids);
@@ -673,7 +673,7 @@ public class PostService {
 
     @CacheEvict(
             value = CachingConfig.POST_CACHE_NAME,
-            key = "'default'"
+            allEntries = true
     )
     public Post approvePost(Long id) {
         Post post = postRepository.findById(id)
@@ -713,7 +713,7 @@ public class PostService {
 
     @CacheEvict(
             value = CachingConfig.POST_CACHE_NAME,
-            key = "'default'"
+            allEntries = true
     )
     public Post pinPost(Long id, String username) {
         Post post = postRepository.findById(id)
@@ -729,7 +729,7 @@ public class PostService {
 
     @CacheEvict(
             value = CachingConfig.POST_CACHE_NAME,
-            key = "'default'"
+            allEntries = true
     )
     public Post unpinPost(Long id, String username) {
         Post post = postRepository.findById(id)
@@ -745,7 +745,7 @@ public class PostService {
 
     @CacheEvict(
             value = CachingConfig.POST_CACHE_NAME,
-            key = "'default'"
+            allEntries = true
     )
     public Post closePost(Long id, String username) {
         Post post = postRepository.findById(id)
@@ -764,7 +764,7 @@ public class PostService {
 
     @CacheEvict(
             value = CachingConfig.POST_CACHE_NAME,
-            key = "'default'"
+            allEntries = true
     )
     public Post reopenPost(Long id, String username) {
         Post post = postRepository.findById(id)
@@ -783,7 +783,7 @@ public class PostService {
 
     @CacheEvict(
             value = CachingConfig.POST_CACHE_NAME,
-            key = "'default'"
+            allEntries = true
     )
     @Transactional
     public Post updatePost(Long id,
@@ -840,7 +840,7 @@ public class PostService {
 
     @CacheEvict(
             value = CachingConfig.POST_CACHE_NAME,
-            key = "'default'"
+            allEntries = true
     )
     @Transactional
     public void deletePost(Long id, String username) {


### PR DESCRIPTION
## Summary
- include pagination attributes in the cache keys for the post listing endpoints
- clear the cached post listings whenever posts or comments mutate so pagination variants stay fresh

## Testing
- mvn -f backend/pom.xml test *(fails: unable to download parent POM because external network access is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68ca2e8590c88327884ea3d4593a746b