### PR TITLE
Handle point history cleanup when deleting posts

### DIFF
--- a/backend/src/main/java/com/openisle/repository/PointHistoryRepository.java
+++ b/backend/src/main/java/com/openisle/repository/PointHistoryRepository.java
@@ -3,6 +3,7 @@ package com.openisle.repository;
 import com.openisle.model.PointHistory;
 import com.openisle.model.User;
 import com.openisle.model.Comment;
+import com.openisle.model.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDateTime;
@@ -14,6 +15,8 @@ public interface PointHistoryRepository extends JpaRepository<PointHistory, Long
     long countByUser(User user);
 
     List<PointHistory> findByUserAndCreatedAtAfterOrderByCreatedAtDesc(User user, LocalDateTime createdAt);
-    
+
     List<PointHistory> findByComment(Comment comment);
+
+    List<PointHistory> findByPost(Post post);
 }


### PR DESCRIPTION
## Summary
- add a repository helper to load point histories for a post
- remove a post's point history records and recalculate affected user balances during deletion to avoid foreign key violations

## Testing
- mvn test *(fails: unable to reach https://repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68ca336bf8e083278376bb45bd64bd8c