### PR TITLE
Delete post change logs before removing posts

### DIFF
--- a/backend/src/main/java/com/openisle/repository/PostChangeLogRepository.java
+++ b/backend/src/main/java/com/openisle/repository/PostChangeLogRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 
 public interface PostChangeLogRepository extends JpaRepository<PostChangeLog, Long> {
     List<PostChangeLog> findByPostOrderByCreatedAtAsc(Post post);
+
+    void deleteByPost(Post post);
 }

--- a/backend/src/main/java/com/openisle/service/PostChangeLogService.java
+++ b/backend/src/main/java/com/openisle/service/PostChangeLogService.java
@@ -109,6 +109,10 @@ public class PostChangeLogService {
         logRepository.save(log);
     }
 
+    public void deleteLogsForPost(Post post) {
+        logRepository.deleteByPost(post);
+    }
+
     public List<PostChangeLog> listLogs(Long postId) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new com.openisle.exception.NotFoundException("Post not found"));

--- a/backend/src/main/java/com/openisle/service/PostService.java
+++ b/backend/src/main/java/com/openisle/service/PostService.java
@@ -888,6 +888,7 @@ public class PostService {
             }
         }
         String title = post.getTitle();
+        postChangeLogService.deleteLogsForPost(post);
         postRepository.delete(post);
         if (adminDeleting) {
             notificationService.createNotification(author, NotificationType.POST_DELETED,

--- a/backend/src/test/java/com/openisle/service/PostServiceTest.java
+++ b/backend/src/test/java/com/openisle/service/PostServiceTest.java
@@ -71,6 +71,7 @@ class PostServiceTest {
 
         verify(postReadService).deleteByPost(post);
         verify(postRepo).delete(post);
+        verify(postChangeLogService).deleteLogsForPost(post);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add a repository shortcut and service helper to purge change logs for a post
- delete change logs as part of post removal to avoid foreign key violations
- extend the post deletion unit test to cover the change log cleanup

## Testing
- mvn test *(fails: network is unreachable while resolving spring boot parent)*

------
https://chatgpt.com/codex/tasks/task_e_68ca39cdc4488327990ca866cea18358