### PR TITLE
Fix PostServiceTest constructor parameters

### DIFF
--- a/backend/src/test/java/com/openisle/service/PostServiceTest.java
+++ b/backend/src/test/java/com/openisle/service/PostServiceTest.java
@@ -268,12 +268,14 @@ class PostServiceTest {
         ApplicationContext context = mock(ApplicationContext.class);
         PointService pointService = mock(PointService.class);
         PostChangeLogService postChangeLogService = mock(PostChangeLogService.class);
+        PointHistoryRepository pointHistoryRepository = mock(PointHistoryRepository.class);
         RedisTemplate redisTemplate = mock(RedisTemplate.class);
 
         PostService service = new PostService(postRepo, userRepo, catRepo, tagRepo, lotteryRepo,
                 pollPostRepo, pollVoteRepo, notifService, subService, commentService, commentRepo,
                 reactionRepo, subRepo, notificationRepo, postReadService,
-                imageUploader, taskScheduler, emailSender, context, pointService, postChangeLogService, PublishMode.DIRECT, redisTemplate);
+                imageUploader, taskScheduler, emailSender, context, pointService, postChangeLogService,
+                pointHistoryRepository, PublishMode.DIRECT, redisTemplate);
         when(context.getBean(PostService.class)).thenReturn(service);
 
         User author = new User();


### PR DESCRIPTION
## Summary
- add the missing PointHistoryRepository mock to PostServiceTest
- update the PostService instantiation to pass the repository mock

## Testing
- `mvn -DskipITs test` *(fails: cannot resolve parent POM because Maven Central is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca52d19a808327aa3d3c9478283ac2