### PR TITLE
feat(docs): show API routes on overview

### DIFF
--- a/docs/components/api-overview.tsx
+++ b/docs/components/api-overview.tsx
@@ -1,0 +1,65 @@
+import Link from "next/link";
+
+import { getOpenAPIOperations } from "@/lib/openapi-operations";
+
+const methodColors: Record<string, string> = {
+  GET: "bg-emerald-100 text-emerald-700",
+  POST: "bg-blue-100 text-blue-700",
+  PUT: "bg-amber-100 text-amber-700",
+  PATCH: "bg-purple-100 text-purple-700",
+  DELETE: "bg-rose-100 text-rose-700",
+};
+
+function MethodBadge({ method }: { method: string }) {
+  const color = methodColors[method] ?? "bg-slate-100 text-slate-700";
+
+  return (
+    <span
+      className={`font-semibold uppercase tracking-wide text-xs px-2 py-1 rounded ${color}`}
+    >
+      {method}
+    </span>
+  );
+}
+
+export function APIOverviewTable() {
+  const operations = getOpenAPIOperations();
+
+  if (operations.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="not-prose mt-6 overflow-x-auto">
+      <table className="w-full border-separate border-spacing-y-2 text-sm">
+        <thead className="text-left text-muted-foreground">
+          <tr>
+            <th className="px-3 py-2 font-medium">路径</th>
+            <th className="px-3 py-2 font-medium">方法</th>
+            <th className="px-3 py-2 font-medium">摘要</th>
+          </tr>
+        </thead>
+        <tbody>
+          {operations.map((operation) => (
+            <tr
+              key={`${operation.method}-${operation.route}`}
+              className="bg-muted/30"
+            >
+              <td className="px-3 py-2 align-top font-mono">
+                <Link className="hover:underline" href={operation.href}>
+                  {operation.route}
+                </Link>
+              </td>
+              <td className="px-3 py-2 align-top">
+                <MethodBadge method={operation.method} />
+              </td>
+              <td className="px-3 py-2 align-top text-muted-foreground">
+                {operation.summary || "—"}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/docs/content/docs/openapi/index.mdx
+++ b/docs/content/docs/openapi/index.mdx
@@ -2,3 +2,11 @@
 title: API 概览
 description: Open API 接口文档
 ---
+
+import { APIOverviewTable } from "@/components/api-overview";
+
+# 接口列表
+
+以下列表聚合了所有已生成的接口页面，展示对应的路径、请求方法以及摘要，便于快速检索和跳转。
+
+<APIOverviewTable />

--- a/docs/lib/openapi-operations.ts
+++ b/docs/lib/openapi-operations.ts
@@ -1,0 +1,68 @@
+import matter from "gray-matter";
+
+import { source } from "@/lib/source";
+
+interface OperationFrontmatter {
+  title?: string;
+  description?: string;
+  _openapi?: {
+    method?: string;
+    route?: string;
+  };
+}
+
+export interface OpenAPIOperation {
+  href: string;
+  method: string;
+  route: string;
+  summary: string;
+}
+
+function parseFrontmatter(content: string): OperationFrontmatter {
+  const result = matter(content);
+
+  return result.data as OperationFrontmatter;
+}
+
+function normalizeSummary(frontmatter: OperationFrontmatter): string {
+  return frontmatter.title ?? frontmatter.description ?? "";
+}
+
+export function getOpenAPIOperations(): OpenAPIOperation[] {
+  return source
+    .getPages()
+    .filter((page) =>
+      page.url.startsWith("/openapi/") && page.url !== "/openapi"
+    )
+    .map((page) => {
+      if (typeof page.data.content !== "string") {
+        return undefined;
+      }
+
+      const frontmatter = parseFrontmatter(page.data.content);
+
+      const method = frontmatter._openapi?.method?.toUpperCase();
+      const route = frontmatter._openapi?.route;
+      const summary = normalizeSummary(frontmatter);
+
+      if (!method || !route) {
+        return undefined;
+      }
+
+      return {
+        href: page.url,
+        method,
+        route,
+        summary,
+      } satisfies OpenAPIOperation;
+    })
+    .filter((operation): operation is OpenAPIOperation => Boolean(operation))
+    .sort((a, b) => {
+      const routeCompare = a.route.localeCompare(b.route);
+      if (routeCompare !== 0) {
+        return routeCompare;
+      }
+
+      return a.method.localeCompare(b.method);
+    });
+}

--- a/docs/scripts/generate-docs.ts
+++ b/docs/scripts/generate-docs.ts
@@ -1,10 +1,18 @@
+import { rmSync } from "node:fs";
+
 import { generateFiles } from "fumadocs-openapi";
 import { openapi } from "@/lib/openapi";
 
+const outputDir = "./content/docs/openapi/(generated)";
+
+rmSync(outputDir, { recursive: true, force: true });
+
 void generateFiles({
   input: openapi,
-  output: "./content/docs/openapi/(generated)",
+  output: outputDir,
   // we recommend to enable it
   // make sure your endpoint description doesn't break MDX syntax.
   includeDescription: true,
+  per: "operation",
+  groupBy: "route",
 });


### PR DESCRIPTION
## Summary
- configure the OpenAPI generator to group operations by route and reset stale output
- add helpers and UI to surface OpenAPI operation metadata
- render the path/method/summary table on the API overview page

## Testing
- bun run generate
- bunx --bun fumadocs-mdx

------
https://chatgpt.com/codex/tasks/task_e_68cd270fd6d4832795c55fbd84f419dd