### PR TITLE
feat: unify avatar rendering with BaseUserAvatar

### DIFF
--- a/frontend_nuxt/components/BaseTimeline.vue
+++ b/frontend_nuxt/components/BaseTimeline.vue
@@ -3,10 +3,19 @@
     <div class="timeline-item" v-for="(item, idx) in items" :key="idx">
       <div
         class="timeline-icon"
-        :class="{ clickable: !!item.iconClick }"
-        @click="item.iconClick && item.iconClick()"
+        :class="{ clickable: !!item.iconClick && !item.src }"
+        @click="!item.src && item.iconClick && item.iconClick()"
       >
-        <BaseImage v-if="item.src" :src="item.src" class="timeline-img" alt="timeline item" />
+        <BaseUserAvatar
+          v-if="item.src"
+          :class="['timeline-img', { 'is-clickable': !!item.iconClick }]"
+          :user-id="item.userId"
+          :avatar="item.src"
+          :username="item.userName || item.username"
+          :width="32"
+          :link="!item.iconClick"
+          @click.stop="item.iconClick && item.iconClick()"
+        />
         <component
           v-else-if="item.icon && (typeof item.icon !== 'string' || !item.icon.includes(' '))"
           :is="item.icon"
@@ -64,10 +73,12 @@ export default {
 }
 
 .timeline-img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  border-radius: 50%;
+  width: 32px;
+  height: 32px;
+}
+
+.timeline-img.is-clickable {
+  cursor: pointer;
 }
 
 .timeline-emoji {

--- a/frontend_nuxt/components/BaseUserAvatar.vue
+++ b/frontend_nuxt/components/BaseUserAvatar.vue
@@ -1,0 +1,116 @@
+<template>
+  <component :is="wrapperTag" v-bind="wrapperAttrs" :class="containerClass" :style="mergedStyle">
+    <BaseImage :src="currentSrc" :alt="altText" class="base-user-avatar-img" @error="handleError" />
+  </component>
+</template>
+
+<script setup>
+import { computed, ref, watch } from 'vue'
+import { useAttrs } from 'vue'
+
+const DEFAULT_AVATAR = '/default-avatar.svg'
+
+const props = defineProps({
+  userId: {
+    type: [String, Number],
+    required: true,
+  },
+  avatar: {
+    type: String,
+    default: '',
+  },
+  username: {
+    type: String,
+    default: '',
+  },
+  width: {
+    type: [Number, String],
+    default: 40,
+  },
+  alt: {
+    type: String,
+    default: '',
+  },
+  link: {
+    type: Boolean,
+    default: true,
+  },
+})
+
+const attrs = useAttrs()
+const currentSrc = ref(props.avatar || DEFAULT_AVATAR)
+
+watch(
+  () => props.avatar,
+  (newVal) => {
+    currentSrc.value = newVal || DEFAULT_AVATAR
+  },
+)
+
+const wrapperTag = computed(() => (props.link ? 'NuxtLink' : 'div'))
+const sizeStyle = computed(() => {
+  const value = typeof props.width === 'number' ? `${props.width}px` : props.width || '40px'
+  return {
+    width: value,
+    height: value,
+  }
+})
+
+const altText = computed(() => {
+  if (props.alt) return props.alt
+  if (props.username) return `${props.username}的头像`
+  return '用户头像'
+})
+
+const containerClass = computed(() => {
+  const classes = ['base-user-avatar']
+  if (props.link) classes.push('is-link')
+  if (attrs.class) classes.push(attrs.class)
+  return classes
+})
+
+const mergedStyle = computed(() => {
+  if (!attrs.style) return sizeStyle.value
+  return [sizeStyle.value, attrs.style]
+})
+
+const wrapperAttrs = computed(() => {
+  const { class: _class, style: _style, ...rest } = attrs
+  if (props.link) {
+    return {
+      ...rest,
+      to: `/users/${props.userId}`,
+    }
+  }
+  return rest
+})
+
+function handleError() {
+  if (currentSrc.value !== DEFAULT_AVATAR) {
+    currentSrc.value = DEFAULT_AVATAR
+  }
+}
+</script>
+
+<style scoped>
+.base-user-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  overflow: hidden;
+  background-color: var(--avatar-background, rgba(0, 0, 0, 0.05));
+}
+
+.base-user-avatar.is-link {
+  cursor: pointer;
+}
+
+.base-user-avatar-img {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  object-fit: cover;
+  display: block;
+}
+</style>

--- a/frontend_nuxt/components/CommentItem.vue
+++ b/frontend_nuxt/components/CommentItem.vue
@@ -26,10 +26,14 @@
           <span v-if="level >= 2" class="reply-item">
             <next class="reply-icon" />
             <span class="reply-info">
-              <BaseImage
+              <BaseUserAvatar
+                v-if="comment.parentUserName"
                 class="reply-avatar"
-                :src="comment.parentUserAvatar || '/default-avatar.svg'"
-                alt="avatar"
+                :user-id="comment.parentUserId"
+                :avatar="comment.parentUserAvatar"
+                :username="comment.parentUserName"
+                :width="20"
+                :link="Boolean(comment.parentUserId)"
                 @click="comment.parentUserClick && comment.parentUserClick()"
               />
               <span class="reply-user-name">{{ comment.parentUserName }}</span>
@@ -253,16 +257,19 @@ const submitReply = async (parentUserName, text, clear) => {
       replyList.push({
         id: data.id,
         userName: data.author.username,
+        userId: data.author.id,
         time: TimeManager.format(data.createdAt),
         avatar: data.author.avatar,
         medal: data.author.displayMedal,
         text: data.content,
         parentUserName: parentUserName,
         parentUserAvatar: props.comment.avatar,
+        parentUserId: props.comment.userId,
         reactions: [],
         reply: (data.replies || []).map((r) => ({
           id: r.id,
           userName: r.author.username,
+          userId: r.author.id,
           time: TimeManager.format(r.createdAt),
           avatar: r.author.avatar,
           text: r.content,
@@ -394,9 +401,7 @@ const handleContentClick = (e) => {
 .reply-avatar {
   width: 20px;
   height: 20px;
-  border-radius: 50%;
   margin-right: 5px;
-  cursor: pointer;
 }
 
 .reply-icon {

--- a/frontend_nuxt/components/HeaderComponent.vue
+++ b/frontend_nuxt/components/HeaderComponent.vue
@@ -70,7 +70,14 @@
           <DropdownMenu v-if="isLogin" ref="userMenu" :items="headerMenuItems">
             <template #trigger>
               <div class="avatar-container">
-                <img class="avatar-img" :src="avatar" alt="avatar" />
+                <BaseUserAvatar
+                  class="avatar-img"
+                  :user-id="authState.userId"
+                  :avatar="avatar"
+                  :username="authState.username"
+                  :width="32"
+                  :link="false"
+                />
                 <down />
               </div>
             </template>
@@ -434,7 +441,6 @@ onMounted(async () => {
   height: 32px;
   border-radius: 50%;
   background-color: lightgray;
-  object-fit: cover;
 }
 
 .dropdown-icon {

--- a/frontend_nuxt/components/PostChangeLogItem.vue
+++ b/frontend_nuxt/components/PostChangeLogItem.vue
@@ -1,12 +1,13 @@
 <template>
   <div :id="`change-log-${log.id}`" class="change-log-container">
     <div class="change-log-text">
-      <BaseImage
+      <BaseUserAvatar
         v-if="log.userAvatar"
         class="change-log-avatar"
-        :src="log.userAvatar"
-        alt="avatar"
-        @click="() => navigateTo(`/users/${log.username}`)"
+        :user-id="log.userId"
+        :avatar="log.userAvatar"
+        :username="log.username"
+        :width="20"
       />
       <span v-if="log.username" class="change-log-user">{{ log.username }}</span>
       <span v-if="log.type === 'CONTENT'" class="change-log-content">变更了文章内容</span>
@@ -57,8 +58,6 @@ import { html } from 'diff2html'
 import { createTwoFilesPatch } from 'diff'
 import { useIsMobile } from '~/utils/screen'
 import 'diff2html/bundles/css/diff2html.min.css'
-import BaseImage from '~/components/BaseImage.vue'
-import { navigateTo } from 'nuxt/app'
 import { themeState } from '~/utils/theme'
 import ArticleCategory from '~/components/ArticleCategory.vue'
 import ArticleTags from '~/components/ArticleTags.vue'

--- a/frontend_nuxt/components/PostLottery.vue
+++ b/frontend_nuxt/components/PostLottery.vue
@@ -53,24 +53,26 @@
       </div>
     </div>
     <div class="prize-member-container">
-      <BaseImage
+      <BaseUserAvatar
         v-for="p in lotteryParticipants"
         :key="p.id"
         class="prize-member-avatar"
-        :src="p.avatar"
-        alt="avatar"
-        @click="gotoUser(p.id)"
+        :user-id="p.id"
+        :avatar="p.avatar"
+        :username="p.username"
+        :width="30"
       />
       <div v-if="lotteryEnded && lotteryWinners.length" class="prize-member-winner">
         <medal-one class="medal-icon"></medal-one>
         <span class="prize-member-winner-name">获奖者: </span>
-        <BaseImage
+        <BaseUserAvatar
           v-for="w in lotteryWinners"
           :key="w.id"
           class="prize-member-avatar"
-          :src="w.avatar"
-          alt="avatar"
-          @click="gotoUser(w.id)"
+          :user-id="w.id"
+          :avatar="w.avatar"
+          :username="w.username"
+          :width="30"
         />
         <div v-if="lotteryWinners.length === 1" class="prize-member-winner-name">
           {{ lotteryWinners[0].username }}
@@ -105,8 +107,6 @@ const hasJoined = computed(() => {
   if (!loggedIn.value) return false
   return lotteryParticipants.value.some((p) => p.id === Number(authState.userId))
 })
-
-const gotoUser = (id) => navigateTo(`/users/${id}`, { replace: true })
 
 const config = useRuntimeConfig()
 const API_BASE_URL = config.public.apiBaseUrl
@@ -246,8 +246,6 @@ const joinLottery = async () => {
   width: 30px;
   height: 30px;
   margin-left: 3px;
-  border-radius: 50%;
-  object-fit: cover;
   cursor: pointer;
 }
 

--- a/frontend_nuxt/components/PostPoll.vue
+++ b/frontend_nuxt/components/PostPoll.vue
@@ -17,13 +17,14 @@
               ></div>
             </div>
             <div class="poll-participants">
-              <BaseImage
+              <BaseUserAvatar
                 v-for="p in pollOptionParticipants[idx] || []"
                 :key="p.id"
                 class="poll-participant-avatar"
-                :src="p.avatar"
-                alt="avatar"
-                @click="gotoUser(p.id)"
+                :user-id="p.id"
+                :avatar="p.avatar"
+                :username="p.username"
+                :width="30"
               />
             </div>
           </div>
@@ -151,8 +152,6 @@ const hasVoted = computed(() => {
 watch([hasVoted, pollEnded], ([voted, ended]) => {
   if (voted || ended) showPollResult.value = true
 })
-
-const gotoUser = (id) => navigateTo(`/users/${id}`, { replace: true })
 
 const config = useRuntimeConfig()
 const API_BASE_URL = config.public.apiBaseUrl
@@ -426,7 +425,6 @@ const submitMultiPoll = async () => {
 .poll-participant-avatar {
   width: 30px;
   height: 30px;
-  border-radius: 50%;
   cursor: pointer;
 }
 </style>

--- a/frontend_nuxt/components/SearchPersonDropdown.vue
+++ b/frontend_nuxt/components/SearchPersonDropdown.vue
@@ -24,10 +24,13 @@
       </template>
       <template #option="{ option }">
         <div class="search-option-item">
-          <BaseImage
-            :src="option.avatar || '/default-avatar.svg'"
+          <BaseUserAvatar
             class="avatar"
-            @error="handleAvatarError"
+            :user-id="option.id"
+            :avatar="option.avatar"
+            :username="option.username"
+            :width="32"
+            :link="false"
           />
           <div class="result-body">
             <div class="result-main" v-html="highlight(option.username)"></div>
@@ -85,10 +88,6 @@ const highlight = (text) => {
   if (!keyword.value) return text
   const reg = new RegExp(keyword.value, 'gi')
   return text.replace(reg, (m) => `<span class="highlight">${m}</span>`)
-}
-
-const handleAvatarError = (e) => {
-  e.target.src = '/default-avatar.svg'
 }
 
 watch(selected, async (val) => {
@@ -178,8 +177,6 @@ defineExpose({
 .avatar {
   width: 32px;
   height: 32px;
-  border-radius: 50%;
-  object-fit: cover;
 }
 
 .result-body {

--- a/frontend_nuxt/components/UserList.vue
+++ b/frontend_nuxt/components/UserList.vue
@@ -2,7 +2,14 @@
   <div class="user-list">
     <BasePlaceholder v-if="users.length === 0" text="暂无用户" icon="inbox" />
     <div v-for="u in users" :key="u.id" class="user-item" @click="handleUserClick(u)">
-      <BaseImage :src="u.avatar" alt="avatar" class="user-avatar" />
+      <BaseUserAvatar
+        class="user-avatar"
+        :user-id="u.id"
+        :avatar="u.avatar"
+        :username="u.username"
+        :width="50"
+        :link="false"
+      />
       <div class="user-info">
         <div class="user-name">{{ u.username }}</div>
         <div v-if="u.introduction" class="user-intro">{{ u.introduction }}</div>
@@ -41,9 +48,7 @@ const handleUserClick = (user) => {
 .user-avatar {
   width: 50px;
   height: 50px;
-  border-radius: 50%;
   flex-shrink: 0;
-  object-fit: cover;
 }
 .user-info {
   display: flex;

--- a/frontend_nuxt/pages/index.vue
+++ b/frontend_nuxt/pages/index.vue
@@ -85,14 +85,15 @@
           </div>
 
           <div class="article-member-avatars-container">
-            <NuxtLink
+            <BaseUserAvatar
               v-for="member in article.members"
               :key="`${article.id}-${member.id}`"
               class="article-member-avatar-item"
-              :to="`/users/${member.id}`"
-            >
-              <BaseImage class="article-member-avatar-item-img" :src="member.avatar" alt="avatar" />
-            </NuxtLink>
+              :user-id="member.id"
+              :avatar="member.avatar"
+              :username="member.username"
+              :width="25"
+            />
           </div>
 
           <div class="article-comments main-info-text">
@@ -291,7 +292,11 @@ const {
       description: p.content,
       category: p.category,
       tags: p.tags || [],
-      members: (p.participants || []).map((m) => ({ id: m.id, avatar: m.avatar })),
+      members: (p.participants || []).map((m) => ({
+        id: m.id,
+        avatar: m.avatar,
+        username: m.username,
+      })),
       comments: p.commentCount,
       views: p.views,
       rssExcluded: p.rssExcluded || false,
@@ -333,7 +338,11 @@ const fetchNextPage = async () => {
     description: p.content,
     category: p.category,
     tags: p.tags || [],
-    members: (p.participants || []).map((m) => ({ id: m.id, avatar: m.avatar })),
+    members: (p.participants || []).map((m) => ({
+      id: m.id,
+      avatar: m.avatar,
+      username: m.username,
+    })),
     comments: p.commentCount,
     views: p.views,
     rssExcluded: p.rssExcluded || false,
@@ -383,7 +392,6 @@ watch([selectedCategory, selectedTags], ([newCategory, newTags]) => {
   selectedCategoryGlobal.value = newCategory
   selectedTagsGlobal.value = newTags
 })
-
 </script>
 
 <style scoped>
@@ -631,14 +639,7 @@ watch([selectedCategory, selectedTags], ([newCategory, newTags]) => {
 .article-member-avatar-item {
   width: 25px;
   height: 25px;
-  border-radius: 50%;
-  overflow: hidden;
-}
-
-.article-member-avatar-item-img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
+  flex-shrink: 0;
 }
 
 .placeholder-container {

--- a/frontend_nuxt/pages/message-box/[id].vue
+++ b/frontend_nuxt/pages/message-box/[id].vue
@@ -44,7 +44,13 @@
             <div v-if="item.replyTo" class="reply-preview info-content-text">
               <div class="reply-header">
                 <next class="reply-icon" />
-                <BaseImage class="reply-avatar" :src="item.replyTo.sender.avatar" alt="avatar" />
+                <BaseUserAvatar
+                  class="reply-avatar"
+                  :user-id="item.replyTo.sender.id"
+                  :avatar="item.replyTo.sender.avatar"
+                  :username="item.replyTo.sender.username"
+                  :width="20"
+                />
                 <div class="reply-author">{{ item.replyTo.sender.username }}:</div>
               </div>
               <div class="reply-content" v-html="renderMarkdown(item.replyTo.content)"></div>
@@ -242,6 +248,8 @@ async function fetchMessages(page = 0) {
 
     const newMessages = pageData.content.reverse().map((item) => ({
       ...item,
+      userId: item.sender.id,
+      userName: item.sender.username,
       src: item.sender.avatar,
       iconClick: () => {
         openUser(item.sender.id)
@@ -327,6 +335,8 @@ async function sendMessage(content, clearInput) {
     const newMessage = await response.json()
     messages.value.push({
       ...newMessage,
+      userId: newMessage.sender.id,
+      userName: newMessage.sender.username,
       src: newMessage.sender.avatar,
       iconClick: () => {
         openUser(newMessage.sender.id)
@@ -402,6 +412,8 @@ const subscribeToConversation = () => {
 
       messages.value.push({
         ...parsedMessage,
+        userId: parsedMessage.sender.id,
+        userName: parsedMessage.sender.username,
         src: parsedMessage.sender.avatar,
         iconClick: () => openUser(parsedMessage.sender.id),
       })

--- a/frontend_nuxt/pages/message-box/index.vue
+++ b/frontend_nuxt/pages/message-box/index.vue
@@ -33,11 +33,23 @@
           @click="goToConversation(convo.id)"
         >
           <div class="conversation-avatar">
-            <BaseImage
-              :src="getOtherParticipant(convo)?.avatar || '/default-avatar.svg'"
-              :alt="getOtherParticipant(convo)?.username || '用户'"
+            <BaseUserAvatar
+              v-if="getOtherParticipant(convo)"
               class="avatar-img"
-              @error="handleAvatarError"
+              :user-id="getOtherParticipant(convo).id"
+              :avatar="getOtherParticipant(convo).avatar"
+              :username="getOtherParticipant(convo).username"
+              :width="40"
+              @click.stop
+            />
+            <BaseUserAvatar
+              v-else
+              class="avatar-img"
+              :user-id="convo.id"
+              :avatar="''"
+              username="用户"
+              :width="40"
+              :link="false"
             />
           </div>
 
@@ -431,7 +443,6 @@ function minimize() {
   width: 40px;
   height: 40px;
   border-radius: 50%;
-  object-fit: cover;
 }
 
 .conversation-content {

--- a/frontend_nuxt/pages/posts/[id]/index.vue
+++ b/frontend_nuxt/pages/posts/[id]/index.vue
@@ -46,10 +46,14 @@
       </div>
 
       <div class="info-content-container author-info-container">
-        <div class="user-avatar-container" @click="gotoProfile">
-          <div class="user-avatar-item">
-            <BaseImage class="user-avatar-item-img" :src="author.avatar" alt="avatar" />
-          </div>
+        <div class="user-avatar-container">
+          <BaseUserAvatar
+            class="user-avatar-item"
+            :user-id="author.id"
+            :avatar="author.avatar"
+            :username="author.username"
+            :width="50"
+          />
           <div v-if="isMobile" class="info-content-header">
             <div class="user-name">
               {{ author.username }}
@@ -340,6 +344,7 @@ const mapComment = (
   iconClick: () => navigateTo(`/users/${c.author.id}`),
   parentUserName: parentUserName,
   parentUserAvatar: parentUserAvatar,
+  parentUserId: parentUserId,
   parentUserClick: parentUserId ? () => navigateTo(`/users/${parentUserId}`) : null,
 })
 
@@ -379,6 +384,7 @@ const mapChangeLog = (l) => ({
   id: l.id,
   kind: 'log',
   username: l.username,
+  userId: l.userId ?? l.username,
   userAvatar: l.userAvatar,
   type: l.type,
   createdAt: l.time,
@@ -863,10 +869,6 @@ const jumpToHashComment = async () => {
   }
 }
 
-const gotoProfile = () => {
-  navigateTo(`/users/${author.value.id}`, { replace: true })
-}
-
 const initPage = async () => {
   scrollTo(0, 0)
   await fetchTimeline()
@@ -960,6 +962,8 @@ onMounted(async () => {
 .user-avatar-container {
   display: flex;
   flex-direction: row;
+  align-items: center;
+  gap: 10px;
 }
 
 .scroller-middle {
@@ -1172,18 +1176,13 @@ onMounted(async () => {
 }
 
 .user-avatar-container {
-  cursor: pointer;
+  cursor: default;
 }
 
 .user-avatar-item {
   width: 50px;
   height: 50px;
-}
-
-.user-avatar-item-img {
-  width: 100%;
-  height: 100%;
-  border-radius: 50%;
+  flex-shrink: 0;
 }
 
 .info-content {

--- a/frontend_nuxt/pages/users/[id].vue
+++ b/frontend_nuxt/pages/users/[id].vue
@@ -7,7 +7,13 @@
     <div v-else>
       <div class="profile-page-header">
         <div class="profile-page-header-avatar">
-          <BaseImage :src="user.avatar" alt="avatar" class="profile-page-header-avatar-img" />
+          <BaseUserAvatar
+            class="profile-page-header-avatar-img"
+            :user-id="user.id"
+            :avatar="user.avatar"
+            :username="user.username"
+            :width="200"
+          />
         </div>
         <div class="profile-page-header-user-info">
           <div class="profile-page-header-user-info-name">{{ user.username }}</div>
@@ -651,8 +657,6 @@ watch(selectedTab, async (val) => {
 .profile-page-header-avatar-img {
   width: 200px;
   height: 200px;
-  border-radius: 50%;
-  object-fit: cover;
 }
 
 .profile-page-header-user-info {

--- a/frontend_nuxt/utils/notification.js
+++ b/frontend_nuxt/utils/notification.js
@@ -199,6 +199,8 @@ function createFetchNotifications() {
           arr.push({
             ...n,
             src: n.comment.author.avatar,
+            userId: n.comment.author.id,
+            userName: n.comment.author.username,
             iconClick: () => {
               markNotificationRead(n.id)
               navigateTo(`/users/${n.comment.author.id}`, { replace: true })
@@ -219,6 +221,8 @@ function createFetchNotifications() {
           arr.push({
             ...n,
             src: n.fromUser ? n.fromUser.avatar : null,
+            userId: n.fromUser ? n.fromUser.id : undefined,
+            userName: n.fromUser ? n.fromUser.username : undefined,
             icon: n.fromUser ? undefined : iconMap[n.type],
             iconClick: () => {
               if (n.fromUser) {
@@ -231,6 +235,8 @@ function createFetchNotifications() {
           arr.push({
             ...n,
             src: n.fromUser ? n.fromUser.avatar : null,
+            userId: n.fromUser ? n.fromUser.id : undefined,
+            userName: n.fromUser ? n.fromUser.username : undefined,
             icon: n.fromUser ? undefined : iconMap[n.type],
             iconClick: () => {
               if (n.fromUser) {
@@ -269,6 +275,8 @@ function createFetchNotifications() {
           arr.push({
             ...n,
             src: n.comment.author.avatar,
+            userId: n.comment.author.id,
+            userName: n.comment.author.username,
             iconClick: () => {
               markNotificationRead(n.id)
               navigateTo(`/users/${n.comment.author.id}`, { replace: true })
@@ -315,6 +323,8 @@ function createFetchNotifications() {
           arr.push({
             ...n,
             src: n.fromUser ? n.fromUser.avatar : null,
+            userId: n.fromUser ? n.fromUser.id : undefined,
+            userName: n.fromUser ? n.fromUser.username : undefined,
             icon: n.fromUser ? undefined : iconMap[n.type],
             iconClick: () => {
               if (n.post) {


### PR DESCRIPTION
## Summary
- add a BaseUserAvatar component with configurable sizing, fallback handling, and optional profile navigation
- replace scattered avatar usages across post details, the home feed, messaging, and related components to share the new base styling
- update timeline/comment data to provide user identifiers so BaseTimeline can render avatars with profile links

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2c3d163848327a1c962dfc61f61f9