### PR TITLE
Add paginated tag loading for API and UI components

### DIFF
--- a/backend/src/main/java/com/openisle/controller/TagController.java
+++ b/backend/src/main/java/com/openisle/controller/TagController.java
@@ -2,6 +2,7 @@ package com.openisle.controller;
 
 import com.openisle.dto.PostSummaryDto;
 import com.openisle.dto.TagDto;
+import com.openisle.dto.TagPageResponse;
 import com.openisle.dto.TagRequest;
 import com.openisle.mapper.PostMapper;
 import com.openisle.mapper.TagMapper;
@@ -19,8 +20,13 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -96,24 +102,45 @@ public class TagController {
   @ApiResponse(
     responseCode = "200",
     description = "List of tags",
-    content = @Content(array = @ArraySchema(schema = @Schema(implementation = TagDto.class)))
+    content = @Content(schema = @Schema(implementation = TagPageResponse.class))
   )
-  public List<TagDto> list(
+  public TagPageResponse list(
     @RequestParam(value = "keyword", required = false) String keyword,
-    @RequestParam(value = "limit", required = false) Integer limit
+    @RequestParam(value = "limit", required = false) Integer limit,
+    @RequestParam(value = "page", required = false) Integer page,
+    @RequestParam(value = "pageSize", required = false) Integer pageSize
   ) {
-    List<Tag> tags = tagService.searchTags(keyword);
+    int resolvedPageSize = Optional.ofNullable(pageSize)
+      .filter(s -> s > 0)
+      .or(() -> Optional.ofNullable(limit).filter(l -> l > 0))
+      .orElse(20);
+    int resolvedPage = Optional.ofNullable(page)
+      .filter(p -> p >= 0)
+      .orElse(0);
+
+    Pageable pageable = PageRequest.of(
+      resolvedPage,
+      resolvedPageSize,
+      Sort.by(Sort.Direction.DESC, "createdAt")
+    );
+    Page<Tag> tagPage = tagService.searchTags(keyword, pageable);
+    List<Tag> tags = tagPage.getContent();
     List<Long> tagIds = tags.stream().map(Tag::getId).toList();
-    Map<Long, Long> postCntByTagIds = postService.countPostsByTagIds(tagIds);
+    Map<Long, Long> postCntByTagIds = Optional.ofNullable(
+      postService.countPostsByTagIds(tagIds)
+    ).orElseGet(Map::of);
     List<TagDto> dtos = tags
       .stream()
       .map(t -> tagMapper.toDto(t, postCntByTagIds.getOrDefault(t.getId(), 0L)))
-      .sorted((a, b) -> Long.compare(b.getCount(), a.getCount()))
       .collect(Collectors.toList());
-    if (limit != null && limit > 0 && dtos.size() > limit) {
-      return dtos.subList(0, limit);
-    }
-    return dtos;
+
+    return new TagPageResponse(
+      dtos,
+      tagPage.getNumber(),
+      tagPage.getSize(),
+      tagPage.getTotalElements(),
+      tagPage.hasNext()
+    );
   }
 
   @GetMapping("/{id}")

--- a/backend/src/main/java/com/openisle/dto/TagPageResponse.java
+++ b/backend/src/main/java/com/openisle/dto/TagPageResponse.java
@@ -1,0 +1,18 @@
+package com.openisle.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TagPageResponse {
+
+  private List<TagDto> items;
+  private int page;
+  private int pageSize;
+  private long total;
+  private boolean hasNext;
+}

--- a/backend/src/main/java/com/openisle/repository/TagRepository.java
+++ b/backend/src/main/java/com/openisle/repository/TagRepository.java
@@ -4,6 +4,7 @@ import com.openisle.model.Tag;
 import com.openisle.model.User;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -12,6 +13,8 @@ public interface TagRepository extends JpaRepository<Tag, Long> {
   List<Tag> findByApproved(boolean approved);
   List<Tag> findByApprovedTrue();
   List<Tag> findByNameContainingIgnoreCaseAndApprovedTrue(String keyword);
+  Page<Tag> findByApprovedTrue(Pageable pageable);
+  Page<Tag> findByNameContainingIgnoreCaseAndApprovedTrue(String keyword, Pageable pageable);
 
   List<Tag> findByCreatorOrderByCreatedAtDesc(User creator, Pageable pageable);
   List<Tag> findByCreator(User creator);

--- a/frontend_nuxt/components/Dropdown.vue
+++ b/frontend_nuxt/components/Dropdown.vue
@@ -80,6 +80,7 @@
             <span>{{ o.name }}</span>
           </slot>
         </div>
+        <slot name="footer" :close="close"></slot>
       </template>
     </div>
     <Teleport to="body">
@@ -116,6 +117,7 @@
                 <span>{{ o.name }}</span>
               </slot>
             </div>
+            <slot name="footer" :close="close"></slot>
           </template>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add a paginated TagPageResponse DTO and expose page/pageSize parameters from GET /api/tags
- extend the tag service/repository plus controller test to exercise pageable queries
- add "view more" pagination affordances to the menu tag list and TagSelect dropdown using a new dropdown footer slot

## Testing
- mvn test *(fails: unable to download parent POM because the Maven Central host is unreachable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d365540c0c8327b3d8486cdfbbf295