### PR TITLE
feat: paginate tags across backend and ui

### DIFF
--- a/backend/src/main/java/com/openisle/controller/TagController.java
+++ b/backend/src/main/java/com/openisle/controller/TagController.java
@@ -100,18 +100,31 @@ public class TagController {
   )
   public List<TagDto> list(
     @RequestParam(value = "keyword", required = false) String keyword,
+    @RequestParam(value = "page", required = false) Integer page,
+    @RequestParam(value = "pageSize", required = false) Integer pageSize,
     @RequestParam(value = "limit", required = false) Integer limit
   ) {
     List<Tag> tags = tagService.searchTags(keyword);
     List<Long> tagIds = tags.stream().map(Tag::getId).toList();
     Map<Long, Long> postCntByTagIds = postService.countPostsByTagIds(tagIds);
+    if (postCntByTagIds == null) {
+      postCntByTagIds = java.util.Collections.emptyMap();
+    }
     List<TagDto> dtos = tags
       .stream()
       .map(t -> tagMapper.toDto(t, postCntByTagIds.getOrDefault(t.getId(), 0L)))
       .sorted((a, b) -> Long.compare(b.getCount(), a.getCount()))
       .collect(Collectors.toList());
+    if (page != null && pageSize != null && page >= 0 && pageSize > 0) {
+      int fromIndex = page * pageSize;
+      if (fromIndex >= dtos.size()) {
+        return java.util.Collections.emptyList();
+      }
+      int toIndex = Math.min(fromIndex + pageSize, dtos.size());
+      return new java.util.ArrayList<>(dtos.subList(fromIndex, toIndex));
+    }
     if (limit != null && limit > 0 && dtos.size() > limit) {
-      return dtos.subList(0, limit);
+      return new java.util.ArrayList<>(dtos.subList(0, limit));
     }
     return dtos;
   }

--- a/backend/src/test/java/com/openisle/controller/TagControllerTest.java
+++ b/backend/src/test/java/com/openisle/controller/TagControllerTest.java
@@ -82,6 +82,7 @@ class TagControllerTest {
     t.setIcon("i2");
     t.setSmallIcon("s2");
     Mockito.when(tagService.searchTags(null)).thenReturn(List.of(t));
+    Mockito.when(postService.countPostsByTagIds(List.of(2L))).thenReturn(java.util.Map.of());
 
     mockMvc
       .perform(get("/api/tags"))
@@ -91,6 +92,31 @@ class TagControllerTest {
       .andExpect(jsonPath("$[0].description").value("d2"))
       .andExpect(jsonPath("$[0].icon").value("i2"))
       .andExpect(jsonPath("$[0].smallIcon").value("s2"));
+  }
+
+  @Test
+  void listTagsWithPagination() throws Exception {
+    Tag t1 = new Tag();
+    t1.setId(1L);
+    t1.setName("java");
+    Tag t2 = new Tag();
+    t2.setId(2L);
+    t2.setName("spring");
+    Mockito.when(tagService.searchTags(null)).thenReturn(List.of(t1, t2));
+    Mockito.when(postService.countPostsByTagIds(List.of(1L, 2L))).thenReturn(
+      java.util.Map.of(1L, 1L, 2L, 5L)
+    );
+
+    mockMvc
+      .perform(get("/api/tags").param("page", "1").param("pageSize", "1"))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$", org.hamcrest.Matchers.hasSize(1)))
+      .andExpect(jsonPath("$[0].id").value(1));
+
+    mockMvc
+      .perform(get("/api/tags").param("page", "2").param("pageSize", "1"))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$", org.hamcrest.Matchers.hasSize(0)));
   }
 
   @Test

--- a/frontend_nuxt/components/Dropdown.vue
+++ b/frontend_nuxt/components/Dropdown.vue
@@ -80,6 +80,7 @@
             <span>{{ o.name }}</span>
           </slot>
         </div>
+        <slot name="footer" :close="close" :loading="loading" />
       </template>
     </div>
     <Teleport to="body">
@@ -116,6 +117,7 @@
                 <span>{{ o.name }}</span>
               </slot>
             </div>
+            <slot name="footer" :close="close" :loading="loading" />
           </template>
         </div>
       </div>
@@ -200,6 +202,10 @@ export default {
       }
     }
 
+    const reload = async () => {
+      await loadOptions(props.remote ? search.value : undefined)
+    }
+
     watch(
       () => props.initialOptions,
       (val) => {
@@ -249,7 +255,7 @@ export default {
       return /^https?:\/\//.test(icon) || icon.startsWith('/')
     }
 
-    expose({ toggle, close })
+    expose({ toggle, close, reload })
 
     return {
       open,

--- a/frontend_nuxt/components/TagSelect.vue
+++ b/frontend_nuxt/components/TagSelect.vue
@@ -1,5 +1,6 @@
 <template>
   <Dropdown
+    ref="dropdownRef"
     v-model="selected"
     :fetch-options="fetchTags"
     multiple
@@ -25,11 +26,23 @@
         <div v-if="option.description" class="option-desc">{{ option.description }}</div>
       </div>
     </template>
+    <template #footer>
+      <div v-if="hasMoreRemoteTags" class="dropdown-footer">
+        <a
+          href="#"
+          class="dropdown-more"
+          :class="{ disabled: loadMoreRequested }"
+          @click.prevent="loadMoreRemoteTags"
+        >
+          {{ loadMoreRequested ? '加载中...' : '查看更多' }}
+        </a>
+      </div>
+    </template>
   </Dropdown>
 </template>
 
 <script setup>
-import { computed, ref, watch } from 'vue'
+import { computed, reactive, ref, watch } from 'vue'
 import { toast } from '~/main'
 import Dropdown from '~/components/Dropdown.vue'
 const config = useRuntimeConfig()
@@ -42,8 +55,18 @@ const props = defineProps({
   options: { type: Array, default: () => [] },
 })
 
+const dropdownRef = ref(null)
 const localTags = ref([])
 const providedTags = ref(Array.isArray(props.options) ? [...props.options] : [])
+
+const TAG_PAGE_SIZE = 10
+const remoteState = reactive({
+  keyword: '',
+  nextPage: 0,
+  hasMore: true,
+  options: [],
+})
+const loadMoreRequested = ref(false)
 
 watch(
   () => props.options,
@@ -53,7 +76,7 @@ watch(
 )
 
 const mergedOptions = computed(() => {
-  const arr = [...providedTags.value, ...localTags.value]
+  const arr = [...providedTags.value, ...localTags.value, ...remoteState.options]
   return arr.filter((v, i, a) => a.findIndex((t) => t.id === v.id) === i)
 })
 
@@ -62,42 +85,89 @@ const isImageIcon = (icon) => {
   return /^https?:\/\//.test(icon) || icon.startsWith('/')
 }
 
-const buildTagsUrl = (kw = '') => {
+const buildTagsUrl = (kw = '', page = 0) => {
   const base = API_BASE_URL || (import.meta.client ? window.location.origin : '')
   const url = new URL('/api/tags', base)
 
   if (kw) url.searchParams.set('keyword', kw)
-  url.searchParams.set('limit', '10')
+  url.searchParams.set('page', String(page))
+  url.searchParams.set('pageSize', String(TAG_PAGE_SIZE))
 
   return url.toString()
+}
+
+const fetchRemoteTags = async (kw = '', page = 0) => {
+  const url = buildTagsUrl(kw, page)
+  try {
+    const res = await fetch(url)
+    if (res.ok) {
+      const data = await res.json()
+      return Array.isArray(data) ? data : []
+    }
+    throw new Error('failed to fetch tags')
+  } catch (e) {
+    console.error('Failed to fetch tags', e)
+    toast.error('获取标签失败')
+    throw e
+  }
+}
+
+const combineOptions = (remoteOptions = []) => {
+  const options = [...providedTags.value, ...localTags.value, ...remoteOptions]
+  return Array.from(new Map(options.map((t) => [t.id, t])).values())
 }
 
 const fetchTags = async (kw = '') => {
   const defaultOption = { id: 0, name: '无标签' }
 
-  // 1) 先拼 URL（自动兜底到 window.location.origin）
-  const url = buildTagsUrl(kw)
-
-  // 2) 拉数据
-  let data = []
-  try {
-    const res = await fetch(url)
-    if (res.ok) data = await res.json()
-  } catch {
-    toast.error('获取标签失败')
+  if (kw !== remoteState.keyword) {
+    remoteState.keyword = kw
+    remoteState.nextPage = 0
+    remoteState.options = []
+    remoteState.hasMore = true
   }
 
-  // 3) 合并、去重、可创建
-  let options = [...data, ...localTags.value]
+  const shouldFetch = remoteState.options.length === 0 || loadMoreRequested.value
+  if (shouldFetch) {
+    const pageToFetch = loadMoreRequested.value ? remoteState.nextPage : 0
+    try {
+      const data = await fetchRemoteTags(remoteState.keyword, pageToFetch)
+      if (pageToFetch === 0) {
+        remoteState.options = data
+      } else {
+        const existing = Array.isArray(remoteState.options) ? remoteState.options : []
+        const merged = [...existing, ...data]
+        remoteState.options = Array.from(new Map(merged.map((t) => [t.id, t])).values())
+      }
+      remoteState.hasMore = data.length === TAG_PAGE_SIZE
+      remoteState.nextPage = pageToFetch + 1
+    } catch (e) {
+      return [defaultOption, ...combineOptions(remoteState.options)]
+    } finally {
+      loadMoreRequested.value = false
+    }
+  }
+
+  let options = combineOptions(remoteState.options)
 
   if (props.creatable && kw && !options.some((t) => t.name.toLowerCase() === kw.toLowerCase())) {
     options.push({ id: `__create__:${kw}`, name: `创建"${kw}"` })
   }
 
-  options = Array.from(new Map(options.map((t) => [t.id, t])).values())
-
-  // 4) 最终结果
   return [defaultOption, ...options]
+}
+
+const hasMoreRemoteTags = computed(() => remoteState.hasMore)
+
+const loadMoreRemoteTags = async () => {
+  if (!remoteState.hasMore || loadMoreRequested.value) return
+  loadMoreRequested.value = true
+  try {
+    await dropdownRef.value?.reload()
+  } catch (e) {
+    console.error('Failed to load more tags', e)
+    loadMoreRequested.value = false
+  }
 }
 
 const selected = computed({
@@ -150,5 +220,22 @@ const selected = computed({
 .option-count {
   font-weight: bold;
   opacity: 0.4;
+}
+
+.dropdown-footer {
+  padding: 8px 20px;
+  text-align: center;
+  border-top: 1px solid var(--normal-border-color);
+}
+
+.dropdown-more {
+  color: var(--primary-color);
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.dropdown-more.disabled {
+  pointer-events: none;
+  opacity: 0.6;
 }
 </style>


### PR DESCRIPTION
## Summary
- add page/pageSize support to the tag listing endpoint with safe pagination handling
- extend controller tests to cover paginated responses
- add load-more pagination to the menu tag list and TagSelect dropdown, including Dropdown support for a footer slot

## Testing
- mvn -q test *(fails: Maven Central unreachable in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d365540c0c8327b3d8486cdfbbf295