### PR TITLE
fix: keep dropdown at bottom after loading more

### DIFF
--- a/frontend_nuxt/components/Dropdown.vue
+++ b/frontend_nuxt/components/Dropdown.vue
@@ -52,6 +52,7 @@
       v-if="open && !isMobile && (loading || filteredOptions.length > 0 || showSearch)"
       :class="['dropdown-menu', menuClass]"
       v-click-outside="close"
+      ref="menuRef"
     >
       <div v-if="showSearch" class="dropdown-search">
         <search-icon class="search-icon" />
@@ -89,7 +90,7 @@
           <next class="back-icon" @click="close" />
           <span class="mobile-title">{{ placeholder }}</span>
         </div>
-        <div class="dropdown-mobile-menu">
+        <div class="dropdown-mobile-menu" ref="mobileMenuRef">
           <div v-if="showSearch" class="dropdown-search">
             <search-icon class="search-icon" />
             <input type="text" v-model="search" placeholder="搜索" />
@@ -153,6 +154,8 @@ export default {
     const loaded = ref(false)
     const loading = ref(false)
     const wrapper = ref(null)
+    const menuRef = ref(null)
+    const mobileMenuRef = ref(null)
     const isMobile = useIsMobile()
 
     const toggle = () => {
@@ -199,6 +202,13 @@ export default {
         options.value = []
       } finally {
         loading.value = false
+      }
+    }
+
+    const scrollToBottom = () => {
+      const el = isMobile.value ? mobileMenuRef.value : menuRef.value
+      if (el) {
+        el.scrollTop = el.scrollHeight
       }
     }
 
@@ -255,7 +265,7 @@ export default {
       return /^https?:\/\//.test(icon) || icon.startsWith('/')
     }
 
-    expose({ toggle, close, reload })
+    expose({ toggle, close, reload, scrollToBottom })
 
     return {
       open,
@@ -265,6 +275,8 @@ export default {
       search,
       filteredOptions,
       wrapper,
+      menuRef,
+      mobileMenuRef,
       selectedLabels,
       isSelected,
       loading,

--- a/frontend_nuxt/components/TagSelect.vue
+++ b/frontend_nuxt/components/TagSelect.vue
@@ -42,7 +42,7 @@
 </template>
 
 <script setup>
-import { computed, reactive, ref, watch } from 'vue'
+import { computed, reactive, ref, watch, nextTick } from 'vue'
 import { toast } from '~/main'
 import Dropdown from '~/components/Dropdown.vue'
 const config = useRuntimeConfig()
@@ -164,6 +164,8 @@ const loadMoreRemoteTags = async () => {
   loadMoreRequested.value = true
   try {
     await dropdownRef.value?.reload()
+    await nextTick()
+    dropdownRef.value?.scrollToBottom?.()
   } catch (e) {
     console.error('Failed to load more tags', e)
     loadMoreRequested.value = false


### PR DESCRIPTION
## Summary
- ensure the dropdown menu and mobile panel keep their scroll position at the bottom after loading more data
- expose a scrollToBottom helper from the dropdown and use it from TagSelect when loading more items

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3a6f80d608327912b1d97449753d9