### PR TITLE
Allow iframe embeds in markdown sanitizer

### DIFF
--- a/frontend_nuxt/utils/markdown.js
+++ b/frontend_nuxt/utils/markdown.js
@@ -157,6 +157,7 @@ const SANITIZE_CFG = {
     'th',
     'video',
     'source',
+    'iframe',
   ],
   // 允许的属性
   allowedAttributes: {
@@ -180,6 +181,16 @@ const SANITIZE_CFG = {
       'crossorigin',
     ],
     source: ['src', 'type'],
+    iframe: [
+      'src',
+      'title',
+      'width',
+      'height',
+      'allow',
+      'allowfullscreen',
+      'frameborder',
+      'referrerpolicy',
+    ],
   },
   // 允许的类名（保留你的样式钩子）
   allowedClasses: {


### PR DESCRIPTION
## Summary
- allow iframe elements through the markdown sanitizer so embedded media can render
- whitelist the iframe attributes needed for YouTube-style embeds while keeping other sanitization in place

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de7c341214832c96f0b5c7bf5020d3