### PR TITLE
修复文章变动图标问题

### DIFF
--- a/frontend_nuxt/pages/posts/[id]/index.vue
+++ b/frontend_nuxt/pages/posts/[id]/index.vue
@@ -366,7 +366,11 @@ const changeLogIcon = (l) => {
       return 'unlock'
     }
   } else if (l.type === 'PINNED') {
-    return 'pin-icon'
+    if(l.newPinnedAt){
+      return 'pin'
+    }else{
+      return 'clear-icon'
+    }
   } else if (l.type === 'FEATURED') {
     if (l.newFeatured) {
       return 'star'


### PR DESCRIPTION
1.修复置顶图标不显示
2.修复取消置顶图标不显示

<img width="1364" height="735" alt="image" src="https://github.com/user-attachments/assets/e802eb35-f5d0-4365-8080-d270ef5cd369" />
