### PR TITLE
修复手机网页iframe的视频标签超出容器的问题

### DIFF
--- a/frontend_nuxt/assets/global.css
+++ b/frontend_nuxt/assets/global.css
@@ -341,6 +341,16 @@ body {
   .info-content-text pre {
     line-height: 1.5;
   }
+  
+  /*处理iframe视频标签*/
+  .info-content-text iframe {
+    width: 100%;
+    max-width: 100%;
+    height: auto;
+    aspect-ratio: 16 / 9; /* 保持 16:9 比例 */
+    border: none;
+    display: block;
+  }
 
   .d2h-file-name {
     font-size: 14px !important;


### PR DESCRIPTION
<img width="717" height="894" alt="image" src="https://github.com/user-attachments/assets/6ade3c7d-0d99-4da6-9ebf-19719424a495" />
