### PR TITLE
Ensure pinned comments stay at top of post timeline

### DIFF
--- a/backend/src/main/java/com/openisle/dto/TimelineItemDto.java
+++ b/backend/src/main/java/com/openisle/dto/TimelineItemDto.java
@@ -15,5 +15,6 @@ public class TimelineItemDto<T> {
   private Long id;
   private String kind; // "comment" | "log"
   private LocalDateTime createdAt;
+  private LocalDateTime pinnedAt;
   private T payload; // 泛型，具体类型由外部决定
 }


### PR DESCRIPTION
## Summary
- include the comment pin timestamp on timeline items
- sort timeline results so pinned comments stay ahead of other entries while respecting the selected chronological order

## Testing
- mvn -f backend/pom.xml -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68e236ee7040832cbc3e3a91da178981