### PR TITLE
fix: theme-toggle-flicker

### DIFF
--- a/frontend_nuxt/utils/theme.js
+++ b/frontend_nuxt/utils/theme.js
@@ -93,9 +93,8 @@ function getCircle(event) {
 
 function withViewTransition(event, applyFn, direction = true) {
   if (typeof document !== 'undefined' && document.startViewTransition) {
-    const transition = document.startViewTransition(async () => {
+    const transition = document.startViewTransition(() => {
       applyFn()
-      await nextTick()
     })
 
     transition.ready
@@ -111,6 +110,7 @@ function withViewTransition(event, applyFn, direction = true) {
           {
             duration: 400,
             easing: 'ease-in-out',
+            fill: 'both',
             pseudoElement: direction
               ? '::view-transition-new(root)'
               : '::view-transition-old(root)',


### PR DESCRIPTION
- Fixed #587 
- remove unnecessary await nextTick in view transition
- Simplify transition callback
- Add fill: 'both' to transition style
