### PR TITLE
Log post visibility scope changes

### DIFF
--- a/backend/src/main/java/com/openisle/dto/PostChangeLogDto.java
+++ b/backend/src/main/java/com/openisle/dto/PostChangeLogDto.java
@@ -1,6 +1,7 @@
 package com.openisle.dto;
 
 import com.openisle.model.PostChangeType;
+import com.openisle.model.PostVisibleScopeType;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Getter;
@@ -29,5 +30,7 @@ public class PostChangeLogDto {
   private LocalDateTime newPinnedAt;
   private Boolean oldFeatured;
   private Boolean newFeatured;
+  private PostVisibleScopeType oldVisibleScope;
+  private PostVisibleScopeType newVisibleScope;
   private Integer amount;
 }

--- a/backend/src/main/java/com/openisle/mapper/PostChangeLogMapper.java
+++ b/backend/src/main/java/com/openisle/mapper/PostChangeLogMapper.java
@@ -52,6 +52,9 @@ public class PostChangeLogMapper {
     } else if (log instanceof PostFeaturedChangeLog f) {
       dto.setOldFeatured(f.isOldFeatured());
       dto.setNewFeatured(f.isNewFeatured());
+    } else if (log instanceof PostVisibleScopeChangeLog v) {
+      dto.setOldVisibleScope(v.getOldVisibleScope());
+      dto.setNewVisibleScope(v.getNewVisibleScope());
     } else if (log instanceof PostDonateChangeLog d) {
       dto.setAmount(d.getAmount());
     }

--- a/backend/src/main/java/com/openisle/model/PostChangeType.java
+++ b/backend/src/main/java/com/openisle/model/PostChangeType.java
@@ -8,6 +8,7 @@ public enum PostChangeType {
   CLOSED,
   PINNED,
   FEATURED,
+  VISIBLE_SCOPE,
   VOTE_RESULT,
   LOTTERY_RESULT,
   DONATE,

--- a/backend/src/main/java/com/openisle/model/PostVisibleScopeChangeLog.java
+++ b/backend/src/main/java/com/openisle/model/PostVisibleScopeChangeLog.java
@@ -1,0 +1,23 @@
+package com.openisle.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+@Table(name = "post_visible_scope_change_logs")
+public class PostVisibleScopeChangeLog extends PostChangeLog {
+
+  @Enumerated(EnumType.STRING)
+  private PostVisibleScopeType oldVisibleScope;
+
+  @Enumerated(EnumType.STRING)
+  private PostVisibleScopeType newVisibleScope;
+}

--- a/backend/src/main/java/com/openisle/service/PostChangeLogService.java
+++ b/backend/src/main/java/com/openisle/service/PostChangeLogService.java
@@ -99,6 +99,21 @@ public class PostChangeLogService {
     logRepository.save(log);
   }
 
+  public void recordVisibleScopeChange(
+    Post post,
+    User user,
+    PostVisibleScopeType oldVisibleScope,
+    PostVisibleScopeType newVisibleScope
+  ) {
+    PostVisibleScopeChangeLog log = new PostVisibleScopeChangeLog();
+    log.setPost(post);
+    log.setUser(user);
+    log.setType(PostChangeType.VISIBLE_SCOPE);
+    log.setOldVisibleScope(oldVisibleScope);
+    log.setNewVisibleScope(newVisibleScope);
+    logRepository.save(log);
+  }
+
   public void recordVoteResult(Post post) {
     PostVoteResultChangeLog log = new PostVoteResultChangeLog();
     log.setPost(post);

--- a/backend/src/main/java/com/openisle/service/PostService.java
+++ b/backend/src/main/java/com/openisle/service/PostService.java
@@ -340,10 +340,10 @@ public class PostService {
     post.setStatus(publishMode == PublishMode.REVIEW ? PostStatus.PENDING : PostStatus.PUBLISHED);
 
     // 什么都没设置的情况下，默认为ALL
-    if(Objects.isNull(postVisibleScopeType)){
-        post.setVisibleScope(PostVisibleScopeType.ALL);
-    }else{
-        post.setVisibleScope(postVisibleScopeType);
+    if (Objects.isNull(postVisibleScopeType)) {
+      post.setVisibleScope(PostVisibleScopeType.ALL);
+    } else {
+      post.setVisibleScope(postVisibleScopeType);
     }
 
     if (post instanceof LotteryPost) {
@@ -1190,6 +1190,7 @@ public class PostService {
     post.setContent(content);
     post.setCategory(category);
     post.setTags(new java.util.HashSet<>(tags));
+    PostVisibleScopeType oldVisibleScope = post.getVisibleScope();
     post.setVisibleScope(postVisibleScopeType);
     Post updated = postRepository.save(post);
     imageUploader.adjustReferences(oldContent, content);
@@ -1211,6 +1212,14 @@ public class PostService {
     java.util.Set<com.openisle.model.Tag> newTags = new java.util.HashSet<>(tags);
     if (!oldTags.equals(newTags)) {
       postChangeLogService.recordTagChange(updated, user, oldTags, newTags);
+    }
+    if (!java.util.Objects.equals(oldVisibleScope, postVisibleScopeType)) {
+      postChangeLogService.recordVisibleScopeChange(
+        updated,
+        user,
+        oldVisibleScope,
+        postVisibleScopeType
+      );
     }
     if (updated.getStatus() == PostStatus.PUBLISHED) {
       searchIndexEventPublisher.publishPostSaved(updated);

--- a/frontend_nuxt/components/PostChangeLogItem.vue
+++ b/frontend_nuxt/components/PostChangeLogItem.vue
@@ -36,6 +36,10 @@
         <template v-if="log.newFeatured">将文章设为精选</template>
         <template v-else>取消精选文章</template>
       </span>
+      <span v-else-if="log.type === 'VISIBLE_SCOPE'" class="change-log-content">
+        变更了文章可见范围, 从 {{ formatVisibleScope(log.oldVisibleScope) }} 修改为
+        {{ formatVisibleScope(log.newVisibleScope) }}
+      </span>
       <span v-else-if="log.type === 'VOTE_RESULT'" class="change-log-content"
         >系统已计算投票结果</span
       >
@@ -68,6 +72,17 @@ const props = defineProps({
   log: Object,
   title: String,
 })
+
+const VISIBLE_SCOPE_LABELS = {
+  ALL: '全部可见',
+  ONLY_ME: '仅自己可见',
+  ONLY_REGISTER: '仅注册用户可见',
+}
+
+const formatVisibleScope = (scope) => {
+  if (!scope) return VISIBLE_SCOPE_LABELS.ALL
+  return VISIBLE_SCOPE_LABELS[scope] ?? scope
+}
 
 const diffHtml = computed(() => {
   // Track theme changes

--- a/frontend_nuxt/pages/posts/[id]/index.vue
+++ b/frontend_nuxt/pages/posts/[id]/index.vue
@@ -416,6 +416,14 @@ const changeLogIcon = (l) => {
     } else {
       return 'dislike'
     }
+  } else if (l.type === 'VISIBLE_SCOPE') {
+    if (l.newVisibleScope === 'ONLY_ME') {
+      return 'lock-one'
+    } else if (l.newVisibleScope === 'ONLY_REGISTER') {
+      return 'peoples-two'
+    } else {
+      return 'communication'
+    }
   } else if (l.type === 'VOTE_RESULT') {
     return 'check-one'
   } else if (l.type === 'LOTTERY_RESULT') {
@@ -446,6 +454,8 @@ const mapChangeLog = (l) => ({
   newCategory: l.newCategory,
   oldTags: l.oldTags,
   newTags: l.newTags,
+  oldVisibleScope: l.oldVisibleScope,
+  newVisibleScope: l.newVisibleScope,
   amount: l.amount,
   icon: changeLogIcon(l),
 })


### PR DESCRIPTION
## Summary
- add a dedicated change log entry for post visibility scope updates on the backend
- expose the new visibility scope fields via the post change log DTO and surface them in the post timeline
- render icons and descriptive text for visibility changes in the post change log component

## Testing
- mvn -f backend/pom.xml test *(fails: PostServiceTest references outdated PostService signatures)*

------
https://chatgpt.com/codex/tasks/task_e_68fae521b460832ca79cf09de87188f5