### PR TITLE
Include MCP service in deployment scripts

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -40,12 +40,12 @@ echo "👉 Build images ..."
 docker compose -f "$compose_file" --env-file "$env_file" \
   build --pull \
   --build-arg NUXT_ENV=production \
-  frontend_service
+  frontend_service mcp
 
 echo "👉 Recreate & start all target services (no dev profile)..."
 docker compose -f "$compose_file" --env-file "$env_file" \
   up -d --force-recreate --remove-orphans --no-deps \
-  mysql redis rabbitmq websocket-service springboot frontend_service
+  mysql redis rabbitmq websocket-service springboot frontend_service mcp
 
 echo "👉 Current status:"
 docker compose -f "$compose_file" --env-file "$env_file" ps

--- a/deploy/deploy_staging.sh
+++ b/deploy/deploy_staging.sh
@@ -39,12 +39,12 @@ echo "👉 Build images (staging)..."
 docker compose -f "$compose_file" --env-file "$env_file" \
   build --pull \
   --build-arg NUXT_ENV=staging \
-  frontend_service
+  frontend_service mcp
 
 echo "👉 Recreate & start all target services (no dev profile)..."
 docker compose -f "$compose_file" --env-file "$env_file" \
   up -d --force-recreate --remove-orphans --no-deps \
-  mysql redis rabbitmq websocket-service springboot frontend_service
+  mysql redis rabbitmq websocket-service springboot frontend_service mcp
 
 echo "👉 Current status:"
 docker compose -f "$compose_file" --env-file "$env_file" ps


### PR DESCRIPTION
## Summary
- ensure the MCP service is built alongside the frontend during deploys
- start the MCP container with the rest of the production stack

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fdb9919060832c8bfb181090e611e1