### PR TITLE
Add MCP tool for retrieving post details

### DIFF
--- a/mcp/src/openisle_mcp/schemas.py
+++ b/mcp/src/openisle_mcp/schemas.py
@@ -260,3 +260,14 @@ class RecentPostsResponse(BaseModel):
 
 
 CommentData.model_rebuild()
+
+
+class PostDetail(PostSummary):
+    """Detailed information for a single post, including comments."""
+
+    comments: list[CommentData] = Field(
+        default_factory=list,
+        description="Comments that belong to the post.",
+    )
+
+    model_config = ConfigDict(populate_by_name=True, extra="allow")

--- a/mcp/src/openisle_mcp/search_client.py
+++ b/mcp/src/openisle_mcp/search_client.py
@@ -84,6 +84,18 @@ class SearchClient:
             )
         return [self._ensure_dict(entry) for entry in payload]
 
+    async def get_post(self, post_id: int, token: str | None = None) -> dict[str, Any]:
+        """Retrieve the detailed payload for a single post."""
+
+        client = self._get_client()
+        headers = {"Accept": "application/json"}
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+
+        response = await client.get(f"/api/posts/{post_id}", headers=headers)
+        response.raise_for_status()
+        return self._ensure_dict(response.json())
+
     async def aclose(self) -> None:
         """Dispose of the underlying HTTP client."""
 


### PR DESCRIPTION
## Summary
- add a PostDetail schema that includes the full comment list for a post
- extend the MCP search client with a helper to fetch individual post details
- expose a new `get_post` MCP tool and update the server instructions accordingly

## Testing
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ff2a3b101c832ca59971b9df403ff8