### PR TITLE
Add MCP support for replying to posts

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -31,9 +31,11 @@ By default the server listens on port `8085` and serves MCP over Streamable HTTP
 | Tool | Description |
 | --- | --- |
 | `search` | Perform a global search against the OpenIsle backend. |
+| `reply_to_post` | Create a new comment on a post using a JWT token. |
 | `reply_to_comment` | Reply to an existing comment using a JWT token. |
 | `recent_posts` | Retrieve posts created within the last *N* minutes. |
 
 The tools return structured data mirroring the backend DTOs, including highlighted snippets for
-search results, the full comment payload for replies, and detailed metadata for recent posts.
+search results, the full comment payload for post replies and comment replies, and detailed
+metadata for recent posts.
 

--- a/mcp/src/openisle_mcp/schemas.py
+++ b/mcp/src/openisle_mcp/schemas.py
@@ -177,6 +177,12 @@ class CommentReplyResult(BaseModel):
     comment: CommentData = Field(description="Reply comment returned by the backend.")
 
 
+class CommentCreateResult(BaseModel):
+    """Structured response returned when creating a comment on a post."""
+
+    comment: CommentData = Field(description="Comment returned by the backend.")
+
+
 class PostSummary(BaseModel):
     """Summary information for a post."""
 

--- a/mcp/src/openisle_mcp/search_client.py
+++ b/mcp/src/openisle_mcp/search_client.py
@@ -66,6 +66,35 @@ class SearchClient:
         response.raise_for_status()
         return self._ensure_dict(response.json())
 
+    async def reply_to_post(
+        self,
+        post_id: int,
+        token: str,
+        content: str,
+        captcha: str | None = None,
+    ) -> dict[str, Any]:
+        """Create a comment on a post and return the backend payload."""
+
+        client = self._get_client()
+        headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {token}",
+        }
+        payload: dict[str, Any] = {"content": content}
+        if captcha is not None:
+            stripped_captcha = captcha.strip()
+            if stripped_captcha:
+                payload["captcha"] = stripped_captcha
+
+        response = await client.post(
+            f"/api/posts/{post_id}/comments",
+            json=payload,
+            headers=headers,
+        )
+        response.raise_for_status()
+        return self._ensure_dict(response.json())
+
     async def recent_posts(self, minutes: int) -> list[dict[str, Any]]:
         """Return posts created within the given timeframe."""
 


### PR DESCRIPTION
## Summary
- add a FastMCP tool for replying to posts using authenticated requests
- extend the search client and schemas used by the new tool and update documentation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ff6369ef6c832cbabcc56994275258