### PR TITLE
Add MCP tool for initializing session JWT tokens

### DIFF
--- a/mcp/src/openisle_mcp/server.py
+++ b/mcp/src/openisle_mcp/server.py
@@ -140,6 +140,25 @@ app = FastMCP(
 
 
 @app.tool(
+    name="set_token",
+    description=(
+        "Set JWT token for the current session to be reused by other tools."
+    ),
+)
+async def set_token(
+    token: Annotated[
+        str,
+        PydanticField(description="JWT token string."),
+    ],
+    ctx: Context | None = None,
+) -> str:
+    """Persist a JWT token for the active MCP session."""
+
+    session_token_manager.resolve(ctx, token)
+    return "Token stored successfully."
+
+
+@app.tool(
     name="search",
     description="Perform a global search across OpenIsle resources.",
     structured_output=True,


### PR DESCRIPTION
## Summary
- add a `set_token` MCP tool that stores a JWT token on the current session
- keep the stored token available for subsequent authenticated tool invocations

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ffafbd3640832ca3bb072fb6c806c6