### PR TITLE
Add MCP support for clearing read notifications

### DIFF
--- a/mcp/src/openisle_mcp/schemas.py
+++ b/mcp/src/openisle_mcp/schemas.py
@@ -358,3 +358,15 @@ class UnreadNotificationsResponse(BaseModel):
         default_factory=list,
         description="Unread notifications returned by the backend.",
     )
+
+
+class NotificationCleanupResult(BaseModel):
+    """Structured response returned after marking notifications as read."""
+
+    processed_ids: list[int] = Field(
+        default_factory=list,
+        description="Identifiers that were marked as read in the backend.",
+    )
+    total_marked: int = Field(
+        description="Total number of notifications successfully marked as read.",
+    )


### PR DESCRIPTION
## Summary
- add a NotificationCleanupResult schema and expose a mark_notifications_read MCP tool for cleaning read notifications
- extend the SearchClient with a mark_notifications_read helper that calls the backend endpoint
- update the reply bot to allow the new tool, append a cleanup step to its workflow, and emit additional operational logging

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69004e409a78832cac519b30192c46cc