### PR TITLE
Add scheduled workflow to run reply bots

### DIFF
--- a/.github/workflows/reply-bots.yml
+++ b/.github/workflows/reply-bots.yml
@@ -1,0 +1,28 @@
+name: Reply Bots
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+
+jobs:
+  run-reply-bot:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm install --no-save @openai/agents ts-node typescript
+
+      - name: Run reply bot
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENISLE_TOKEN: ${{ secrets.OPENISLE_TOKEN }}
+        run: npx ts-node --esm bots/reply_bots.ts


### PR DESCRIPTION
## Summary
- add a scheduled GitHub Actions workflow that runs `bots/reply_bots.ts` every 30 minutes
- install the `@openai/agents` dependency and provide required secrets to the workflow environment

## Testing
- not run (workflow only)


------
https://chatgpt.com/codex/tasks/task_e_69005a5030d8832c8673cac32ff30b46