### PR TITLE
Add MCP tool for creating posts

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -31,6 +31,7 @@ By default the server listens on port `8085` and serves MCP over Streamable HTTP
 | Tool | Description |
 | --- | --- |
 | `search` | Perform a global search against the OpenIsle backend. |
+| `create_post` | Publish a new post using a JWT token. |
 | `reply_to_post` | Create a new comment on a post using a JWT token. |
 | `reply_to_comment` | Reply to an existing comment using a JWT token. |
 | `recent_posts` | Retrieve posts created within the last *N* minutes. |

--- a/mcp/src/openisle_mcp/schemas.py
+++ b/mcp/src/openisle_mcp/schemas.py
@@ -192,6 +192,12 @@ class CommentCreateResult(BaseModel):
     comment: CommentData = Field(description="Comment returned by the backend.")
 
 
+class PostCreateResult(BaseModel):
+    """Structured response returned when creating a new post."""
+
+    post: PostDetail = Field(description="Detailed post payload returned by the backend.")
+
+
 class PostSummary(BaseModel):
     """Summary information for a post."""
 

--- a/mcp/src/openisle_mcp/search_client.py
+++ b/mcp/src/openisle_mcp/search_client.py
@@ -173,6 +173,33 @@ class SearchClient:
         logger.info("Reply to post_id=%s succeeded with id=%s", post_id, body.get("id"))
         return body
 
+    async def create_post(
+        self,
+        payload: dict[str, Any],
+        *,
+        token: str | None = None,
+    ) -> dict[str, Any]:
+        """Create a new post and return the detailed backend payload."""
+
+        client = self._get_client()
+        resolved_token = self._require_token(token)
+        headers = self._build_headers(token=resolved_token, include_json=True)
+
+        logger.debug(
+            "Creating post with category_id=%s and %d tag(s)",
+            payload.get("categoryId"),
+            len(payload.get("tagIds", []) if isinstance(payload.get("tagIds"), list) else []),
+        )
+        response = await client.post(
+            "/api/posts",
+            json=payload,
+            headers=headers,
+        )
+        response.raise_for_status()
+        body = self._ensure_dict(response.json())
+        logger.info("Post creation succeeded with id=%s", body.get("id"))
+        return body
+
     async def recent_posts(self, minutes: int) -> list[dict[str, Any]]:
         """Return posts created within the given timeframe."""
 


### PR DESCRIPTION
## Summary
- add a structured response model and HTTP client helper for post creation
- expose a create_post MCP tool with extensive validation and payload sanitisation
- document the new tool in the server instructions and README table

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_69006a28479c832ca91dc5fb69d0123c