### PR TITLE
Fix hosted MCP authorization configuration

### DIFF
--- a/bots/bot_father.ts
+++ b/bots/bot_father.ts
@@ -69,7 +69,6 @@ export abstract class BotFather {
     const token = this.openisleToken;
     const authConfig = token
       ? {
-          authorization: `Bearer ${token}`,
           headers: {
             Authorization: `Bearer ${token}`,
           },


### PR DESCRIPTION
## Summary
- remove the duplicated authorization parameter when configuring the hosted MCP tool to avoid conflicts when the token is present

## Testing
- npx tsx bots/instance/coffee_bot.ts *(fails: missing @openai/agents dependency in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_6900779fae4c832c92403ca73855d26a