### PR TITLE
Fix reply methods argument order in MCP search client

### DIFF
--- a/mcp/src/openisle_mcp/search_client.py
+++ b/mcp/src/openisle_mcp/search_client.py
@@ -111,8 +111,9 @@ class SearchClient:
     async def reply_to_comment(
         self,
         comment_id: int,
-        token: str | None = None,
         content: str,
+        *,
+        token: str | None = None,
         captcha: str | None = None,
     ) -> dict[str, Any]:
         """Reply to an existing comment and return the created reply."""
@@ -144,8 +145,9 @@ class SearchClient:
     async def reply_to_post(
         self,
         post_id: int,
-        token: str | None = None,
         content: str,
+        *,
+        token: str | None = None,
         captcha: str | None = None,
     ) -> dict[str, Any]:
         """Create a comment on a post and return the backend payload."""


### PR DESCRIPTION
## Summary
- reorder the positional and keyword-only parameters for the reply helper methods so required arguments come before optional defaults
- mark the optional arguments as keyword-only to avoid syntax errors when loading the module

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69007ed0fe84832ca83f687f45774095