### PR TITLE
Adjust coffee bot draw schedule

### DIFF
--- a/.github/workflows/coffee-bot.yml
+++ b/.github/workflows/coffee-bot.yml
@@ -2,7 +2,7 @@ name: Coffee Bot
 
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "0 1 * * 1-5"
   workflow_dispatch:
 
 jobs:

--- a/bots/instance/coffee_bot.ts
+++ b/bots/instance/coffee_bot.ts
@@ -22,7 +22,7 @@ class CoffeeBot extends BotFather {
     const now = new Date(Date.now() + 8 * 60 * 60 * 1000);
     const weekday = WEEKDAY_NAMES[now.getDay()];
     const drawTime = new Date(now);
-    drawTime.setHours(23, 0, 0, 0);
+    drawTime.setHours(15, 0, 0, 0);
 
     return `
 请立即在 https://www.open-isle.com 使用 create_post 发表一篇帖子，遵循以下要求：


### PR DESCRIPTION
## Summary
- move the coffee bot's GitHub Action to run only on weekdays at 09:00 Beijing time
- update the draw time generated by the coffee bot workflow to 15:00

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6900a10d6a98832ca521acefc1eab385