### PR TITLE
Allow bots to choose agent model

### DIFF
--- a/bots/bot_father.ts
+++ b/bots/bot_father.ts
@@ -29,11 +29,11 @@ export abstract class BotFather {
       name: this.name,
       instructions: this.buildInstructions(),
       tools: [
-        this.openisleMcp, 
-        this.weatherMcp, 
+        this.openisleMcp,
+        this.weatherMcp,
         this.webSearchPreview
       ],
-      model: "gpt-4o-mini",
+      model: this.getModel(),
       modelSettings: {
         temperature: 0.7,
         topP: 1,
@@ -118,6 +118,10 @@ export abstract class BotFather {
 
   protected getAdditionalInstructions(): string[] {
     return [];
+  }
+
+  protected getModel(): string {
+    return "gpt-4o-mini";
   }
 
   protected createRunner(): Runner {

--- a/bots/instance/daily_news_bot.ts
+++ b/bots/instance/daily_news_bot.ts
@@ -7,6 +7,10 @@ class DailyNewsBot extends BotFather {
     super("Daily News Bot");
   }
 
+  protected override getModel(): string {
+    return "gpt-4o";
+  }
+
   protected override getAdditionalInstructions(): string[] {
     return [
       "You are DailyNewsBot，专职在 OpenIsle 发布每日新闻速递。",


### PR DESCRIPTION
## Summary
- allow BotFather subclasses to override the model used when creating the agent
- update the Daily News Bot to run on the gpt-4o model

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6904223fc068832c8d3fb118f8647be3